### PR TITLE
Create the beginnings of a pluggable authentication mechanism.

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -6,8 +6,10 @@
           buckets = []}).
 
 -record(rs3_bucket, {
-          name :: binary(), 
+          name :: binary(),
           creation_date :: term()}).
+
+-record(context, {auth_mod :: atom()}).
 
 -define(USER_BUCKET, <<"moss.users">>).
 

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -8,9 +8,9 @@
               {riak_ip, "{{riak_ip}}"},
               {riak_http_port, {{riak_http_port}} } ,
               {riak_pb_port, {{riak_pb_port}} } ,
-              {dispatch, [{[], riak_moss_wm_service, []},
-                          {[bucket], riak_moss_wm_bucket, []},
-                          {[bucket, key], riak_moss_wm_key, []}]}
+              {dispatch, [{[], riak_moss_wm_service, [{auth_module, {{auth_module}} }]},
+                          {[bucket], riak_moss_wm_bucket, [{auth_module, {{auth_module}} }]},
+                          {[bucket, key], riak_moss_wm_key, [{auth_module, {{auth_module}} }]}]}
              ]},
 
  {lager, [

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -16,6 +16,7 @@
 {riak_ip,           "127.0.0.1"}.
 {riak_http_port,    8098}.
 {riak_pb_port,      8087}.
+{auth_module,       riak_moss_passthru_auth}.
 
 %%
 %% etc/vm.args

--- a/src/riak_moss_auth.erl
+++ b/src/riak_moss_auth.erl
@@ -2,111 +2,17 @@
 %%
 %% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
 %%
-%% This file is provided to you under the Apache License,
-%% Version 2.0 (the "License"); you may not use this file
-%% except in compliance with the License.  You may obtain
-%% a copy of the License at
-%%
-%%   http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing,
-%% software distributed under the License is distributed on an
-%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-%% KIND, either express or implied.  See the License for the
-%% specific language governing permissions and limitations
-%% under the License.
-%%
 %% -------------------------------------------------------------------
 
 -module(riak_moss_auth).
 
+-export([behaviour_info/1]).
+
 -compile(export_all).
 
-extract_amz_meta(RD) ->
-    lists:filter(fun({K,_V}) ->
-                    lists:prefix(
-                        "x-amz-",
-                        string:to_lower(any_to_list(K)))
-                end,
-                mochiweb_headers:to_list(wrq:req_headers(RD))).
-
-any_to_list(V) when is_list(V) ->
-    V;
-any_to_list(V) when is_atom(V) ->
-    atom_to_list(V);
-any_to_list(V) when is_binary(V) ->
-    binary_to_list(V);
-any_to_list(V) when is_integer(V) ->
-    integer_to_list(V).
-
-
--define(ROOT_HOST, "s3.amazonaws.com").
--define(SUBRESOURCES, ["acl", "location", "logging", "notification", "partNumber",
-                       "policy", "requestPayment", "torrent", "uploadId", "uploads",
-                       "versionId", "versioning", "versions", "website"]).
-
-canonicalize_qs(QS) ->
-    canonicalize_qs(QS, []).
-
-canonicalize_qs([], []) ->
-    [];
-canonicalize_qs([], Acc) ->
-    lists:flatten(["?", Acc]);
-canonicalize_qs([{K, []}|T], Acc) ->
-    case lists:member(K, ?SUBRESOURCES) of
-        true ->
-            canonicalize_qs(T, [K|Acc]);
-        false ->
-            canonicalize_qs(T)
-    end;
-canonicalize_qs([{K, V}|T], Acc) ->
-    case lists:member(K, ?SUBRESOURCES) of
-        true ->
-            canonicalize_qs(T, [[K, "=", V]|Acc]);
-        false ->
-            canonicalize_qs(T)
-    end.
-
-
-parse_auth_header("AWS " ++ Key) ->
-    case string:tokens(Key, ":") of
-        [KeyId, KeyData] ->
-            {ok, KeyId, KeyData};
-        Other -> Other
-    end.
-
-
-bucket_from_host(HostHeader) ->
-    BaseTokens = string:tokens(?ROOT_HOST, "."),
-    case string:tokens(HostHeader, ".") of
-        [H|BaseTokens] ->
-            H;
-        _ ->
-            undefined
-    end.
-
-canonicalize_resource(RD) ->
-    case bucket_from_host(wrq:get_req_header("host", RD)) of
-        undefined ->
-            [wrq:path(RD)];
-        Bucket ->
-            ["/", Bucket, wrq:path(RD)]
-    end.
-
-
-check_auth(KeyID, KeyData, RD, Signature) ->
-    AmzHeaders = [[string:to_lower(K), ":", V, "\n"] ||
-                     {K, V} <- ordsets:to_list(ordsets:from_list(extract_amz_meta(RD)))],
-    Resource = [canonicalize_resource(RD),
-                canonicalize_qs(lists:sort(wrq:req_qs(RD)))],
-    CMD5 = wrq:get_req_header("content-md5", RD),
-    CType = wrq:get_req_header("content-type", RD),
-    STS = [atom_to_list(wrq:method(RD)), "\n",
-           case CMD5 of undefined -> ""; O -> O end, "\n",
-           case CType of undefined -> ""; O -> O end, "\n",
-           wrq:get_req_header("date", RD), "\n",
-           AmzHeaders,
-           Resource],
-    Sig = base64:encode_to_string(crypto:sha_mac(KeyData, STS)),
-    Sig == Signature.
+-spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
+behaviour_info(callbacks) ->
+    [{authenticate, 1}];
+behaviour_info(_Other) ->
+    undefined.
 

--- a/src/riak_moss_blockall_auth.erl
+++ b/src/riak_moss_blockall_auth.erl
@@ -1,0 +1,17 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_moss_blockall_auth).
+
+-behavior(riak_moss_auth).
+
+-include("riak_moss.hrl").
+
+-export([authenticate/1]).
+
+authenticate(_RD) ->
+    false.
+

--- a/src/riak_moss_passthru_auth.erl
+++ b/src/riak_moss_passthru_auth.erl
@@ -1,0 +1,17 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_moss_passthru_auth).
+
+-behavior(riak_moss_auth).
+
+-include("riak_moss.hrl").
+
+-export([authenticate/1]).
+
+authenticate(_RD) ->
+    true.
+

--- a/src/riak_moss_resource.erl
+++ b/src/riak_moss_resource.erl
@@ -68,9 +68,9 @@ make_request(RD, Ctx, User) ->
                      subresource=string:str(canonicalize_resource(RD), "?") /= 0,
                      user=User}).
 
-parse_resource(RD, Ctx=#ctx{host=undefined, mode=service}) ->
+parse_resource(_RD, Ctx=#ctx{host=undefined, mode=service}) ->
     Ctx;
-parse_resource(RD, Ctx=#ctx{host=Host, mode=service}) ->
+parse_resource(_RD, Ctx=#ctx{host=Host, mode=service}) ->
     Ctx#ctx{mode=bucket,bucket=Host};
 parse_resource(RD, Ctx=#ctx{host=undefined, mode=bucket}) ->
     Ctx#ctx{bucket=wrq:path_info(bucket, RD)};
@@ -86,7 +86,7 @@ make_context(RD, Ctx) ->
         {ok, KeyId, Signature} ->
             case riak_moss_riakc:get_user(KeyId) of
                 {ok, User} ->
-                    Authed = moss_auth:check_auth(User#rs3_user.key_id,
+                    Authed = riak_moss_auth:check_auth(User#rs3_user.key_id,
                                                   User#rs3_user.key_data,
                                                   RD,
                                                   Signature),
@@ -190,7 +190,7 @@ delete_resource(RD, Ctx=#ctx{user=User, bucket=Bucket, key=Key}) ->
     case C:delete_object(Bucket, Key) of
         ok ->
             {true, RD, Ctx};
-        O ->
+        _ ->
             {false, RD, Ctx}
     end.
 

--- a/src/riak_moss_riakc.erl
+++ b/src/riak_moss_riakc.erl
@@ -92,7 +92,7 @@ handle_call({get_user, KeyId}, _From, State) ->
     {reply, do_get_user(KeyId), State};
 handle_call({create_user, UserName}, _From, State) ->
     {reply, {ok, do_create_user(UserName)}, State};
-handle_call({get_buckets, KeyId}, _From, State) ->
+handle_call({get_buckets, _KeyId}, _From, State) ->
     {reply, ok, State};
 handle_call({create_bucket, KeyId, Name}, _From, State) ->
     Bucket = #rs3_bucket{name=Name, creation_date=httpd_util:rfc1123_date()},
@@ -106,7 +106,7 @@ handle_call({create_bucket, KeyId, Name}, _From, State) ->
             ignore
     end,
     {reply, ok, State};
-handle_call({delete_bucket, KeyId, Name}, _From, State) ->
+handle_call({delete_bucket, _KeyId, _Name}, _From, State) ->
     {reply, ok, State}.
 
 handle_cast(_Msg, State) ->

--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -1,0 +1,118 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_moss_s3_auth).
+
+-behavior(riak_moss_auth).
+
+-include("riak_moss.hrl").
+
+-export([authenticate/1]).
+
+authenticate(RD) ->
+    AuthHeader = wrq:get_req_header("authorization", RD),
+    case parse_auth_header(AuthHeader) of
+        {ok, KeyId, Signature} ->
+            case riak_moss_riakc:get_user(KeyId) of
+                {ok, User} ->
+                    check_auth(User#rs3_user.key_id,
+                               User#rs3_user.key_data,
+                               RD,
+                               Signature);
+                _ ->
+                    {api_error, invalid_access_key_id}
+            end;
+        Error -> Error
+    end.
+
+extract_amz_meta(RD) ->
+    lists:filter(fun({K,_V}) ->
+                    lists:prefix(
+                        "x-amz-",
+                        string:to_lower(any_to_list(K)))
+                end,
+                mochiweb_headers:to_list(wrq:req_headers(RD))).
+
+any_to_list(V) when is_list(V) ->
+    V;
+any_to_list(V) when is_atom(V) ->
+    atom_to_list(V);
+any_to_list(V) when is_binary(V) ->
+    binary_to_list(V);
+any_to_list(V) when is_integer(V) ->
+    integer_to_list(V).
+
+
+-define(ROOT_HOST, "s3.amazonaws.com").
+-define(SUBRESOURCES, ["acl", "location", "logging", "notification", "partNumber",
+                       "policy", "requestPayment", "torrent", "uploadId", "uploads",
+                       "versionId", "versioning", "versions", "website"]).
+
+canonicalize_qs(QS) ->
+    canonicalize_qs(QS, []).
+
+canonicalize_qs([], []) ->
+    [];
+canonicalize_qs([], Acc) ->
+    lists:flatten(["?", Acc]);
+canonicalize_qs([{K, []}|T], Acc) ->
+    case lists:member(K, ?SUBRESOURCES) of
+        true ->
+            canonicalize_qs(T, [K|Acc]);
+        false ->
+            canonicalize_qs(T)
+    end;
+canonicalize_qs([{K, V}|T], Acc) ->
+    case lists:member(K, ?SUBRESOURCES) of
+        true ->
+            canonicalize_qs(T, [[K, "=", V]|Acc]);
+        false ->
+            canonicalize_qs(T)
+    end.
+
+
+parse_auth_header("AWS " ++ Key) ->
+    case string:tokens(Key, ":") of
+        [KeyId, KeyData] ->
+            {ok, KeyId, KeyData};
+        Other -> Other
+    end.
+
+
+bucket_from_host(HostHeader) ->
+    BaseTokens = string:tokens(?ROOT_HOST, "."),
+    case string:tokens(HostHeader, ".") of
+        [H|BaseTokens] ->
+            H;
+        _ ->
+            undefined
+    end.
+
+canonicalize_resource(RD) ->
+    case bucket_from_host(wrq:get_req_header("host", RD)) of
+        undefined ->
+            [wrq:path(RD)];
+        Bucket ->
+            ["/", Bucket, wrq:path(RD)]
+    end.
+
+
+check_auth(_KeyID, KeyData, RD, Signature) ->
+    AmzHeaders = [[string:to_lower(K), ":", V, "\n"] ||
+                     {K, V} <- ordsets:to_list(ordsets:from_list(extract_amz_meta(RD)))],
+    Resource = [canonicalize_resource(RD),
+                canonicalize_qs(lists:sort(wrq:req_qs(RD)))],
+    CMD5 = wrq:get_req_header("content-md5", RD),
+    CType = wrq:get_req_header("content-type", RD),
+    STS = [atom_to_list(wrq:method(RD)), "\n",
+           case CMD5 of undefined -> ""; O -> O end, "\n",
+           case CType of undefined -> ""; O -> O end, "\n",
+           wrq:get_req_header("date", RD), "\n",
+           AmzHeaders,
+           Resource],
+    Sig = base64:encode_to_string(crypto:sha_mac(KeyData, STS)),
+    Sig == Signature.
+

--- a/src/riak_moss_wm_service.erl
+++ b/src/riak_moss_wm_service.erl
@@ -31,9 +31,10 @@
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
--spec init(term()) -> {ok, term()}.
-init(_Ctx) ->
-    {ok, _Ctx}.
+init(Config) ->
+    %% Get the authentication module
+    AuthMod = proplists:get_value(auth_module, Config),
+    {ok, #context{auth_mod=AuthMod}}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
@@ -43,17 +44,26 @@ service_available(RD, Ctx) ->
 malformed_request(RD, Ctx) ->
     {false, RD, Ctx}.
 
-
 %% @doc Check to see if the user is
 %%      authenticated. Normally with HTTP
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
--spec forbidden(term(), term()) -> {false, term(), term()}.
-forbidden(RD, Ctx) ->
-    %% TODO:
-    %% Actually check to see if this
-    %% is a real account.
-    {false, RD, Ctx}.
+forbidden(RD, Ctx=#context{auth_mod=AuthMod}) ->
+    case AuthMod of
+        undefined ->
+            %% Authentication module not specified, deny access
+            {true, RD, Ctx};
+        _ ->
+            %% Attempt to authenticate the request
+            case AuthMod:authenticate(RD) of
+                true ->
+                    %% Authentication succeeded
+                    {false, RD, Ctx};
+                false ->
+                    %% Authentication failed, deny access
+                    {true, RD, Ctx}
+            end
+    end.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.


### PR DESCRIPTION
- Add configuration entries to the app.config file to pass an
  authentication module name to the webmachine resources.
- Add an entry to the vars.config file so that the app.config for a
  release will specify the passthru auth module for all resources.
- Create an auth module behavior, riak_moss_auth.
- Create three auth modules: one to pass all requests, one to block
  all requests, and a stub for s3 authentication.
- Change the service, bucket, and key resources to get the
  authentication module from the config during init and add it to the
  context.
- Add a context record to the riak_moss.hrl file.

This actually ended up encapsulating the work described in [az829](https://agilezen.com/project/17206/story/829) and [az834](https://agilezen.com/project/17206/story/834) as well as [az822](https://agilezen.com/project/17206/story/822), but it actually would have been less efficient to separate them out into more individual pieces.
