### PR TITLE
Rework setup for webmachine dispatch and authentication.

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -9,7 +9,8 @@
           name :: binary(),
           creation_date :: term()}).
 
--record(context, {auth_mod :: atom()}).
+-record(context, {auth_bypass :: atom(),
+                  auth_mod=riak_kv_passthru_auth :: atom()}).
 
 -define(USER_BUCKET, <<"moss.users">>).
 

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -5,12 +5,15 @@
  {riak_moss, [
               {moss_ip, "{{moss_ip}}"},
               {moss_port, {{moss_port}} } ,
+
+              %%{ssl, [
+              %%       {certfile, "./etc/cert.pem"},
+              %%       {keyfile, "./etc/key.pem"}
+              %%      ]},
+
               {riak_ip, "{{riak_ip}}"},
-              {riak_http_port, {{riak_http_port}} } ,
               {riak_pb_port, {{riak_pb_port}} } ,
-              {dispatch, [{[], riak_moss_wm_service, [{auth_module, {{auth_module}} }]},
-                          {[bucket], riak_moss_wm_bucket, [{auth_module, {{auth_module}} }]},
-                          {[bucket, key], riak_moss_wm_key, [{auth_module, {{auth_module}} }]}]}
+              {auth_bypass, {{auth_bypass}} }
              ]},
 
  {lager, [

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -14,9 +14,8 @@
 {moss_ip,           "127.0.0.1"}.
 {moss_port,         8080}.
 {riak_ip,           "127.0.0.1"}.
-{riak_http_port,    8098}.
 {riak_pb_port,      8087}.
-{auth_module,       riak_moss_passthru_auth}.
+{auth_bypass,       true}.
 
 %%
 %% etc/vm.args

--- a/src/riak_moss_web.erl
+++ b/src/riak_moss_web.erl
@@ -1,0 +1,24 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Convenience functions for setting up the riak_moss HTTP interface.
+
+-module(riak_moss_web).
+
+-export([dispatch_table/0]).
+
+dispatch_table() ->
+    case application:get_env(riak_moss, auth_bypass) of
+        {ok, AuthBypass} ->
+            ok;
+        undefined ->
+            AuthBypass = false
+    end,
+    [
+     {[], riak_moss_wm_service, [{auth_bypass, AuthBypass}]},
+     {[bucket], riak_moss_wm_bucket, [{auth_bypass, AuthBypass}]},
+     {[bucket, key], riak_moss_wm_key, [{auth_bypass, AuthBypass}]}
+    ].

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -18,9 +18,10 @@
 -include_lib("webmachine/include/webmachine.hrl").
 
 init(Config) ->
-    %% Get the authentication module
-    AuthMod = proplists:get_value(auth_module, Config),
-    {ok, #context{auth_mod=AuthMod}}.
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
@@ -34,12 +35,13 @@ malformed_request(RD, Ctx) ->
 %%      authenticated. Normally with HTTP
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
-forbidden(RD, Ctx=#context{auth_mod=AuthMod}) ->
-    case AuthMod of
-        undefined ->
-            %% Authentication module not specified, deny access
-            {true, RD, Ctx};
-        _ ->
+forbidden(RD, Ctx=#context{auth_bypass=AuthBypass,
+                           auth_mod=AuthMod}) ->
+    case AuthBypass of
+        true ->
+            %% Authentication is disabled, allow access
+            {false, RD, Ctx};
+        false ->
             %% Attempt to authenticate the request
             case AuthMod:authenticate(RD) of
                 true ->

--- a/src/riak_moss_wm_service.erl
+++ b/src/riak_moss_wm_service.erl
@@ -18,9 +18,10 @@
 -include_lib("webmachine/include/webmachine.hrl").
 
 init(Config) ->
-    %% Get the authentication module
-    AuthMod = proplists:get_value(auth_module, Config),
-    {ok, #context{auth_mod=AuthMod}}.
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
@@ -34,12 +35,13 @@ malformed_request(RD, Ctx) ->
 %%      authenticated. Normally with HTTP
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
-forbidden(RD, Ctx=#context{auth_mod=AuthMod}) ->
-    case AuthMod of
-        undefined ->
-            %% Authentication module not specified, deny access
-            {true, RD, Ctx};
-        _ ->
+forbidden(RD, Ctx=#context{auth_bypass=AuthBypass,
+                           auth_mod=AuthMod}) ->
+    case AuthBypass of
+        true ->
+            %% Authentication is disabled, allow access
+            {false, RD, Ctx};
+        false ->
             %% Attempt to authenticate the request
             case AuthMod:authenticate(RD) of
                 true ->


### PR DESCRIPTION
Added a `riak_moss_web` module to handle the setup of the webmachine dispatch table. Also use an `auth_bypass` configuration option to enable authentication to be disabled.
