### PR TITLE
Support multiple simultaneous auth schemes 

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -10,8 +10,6 @@
           creation_date :: term()}).
 
 -record(context, {auth_bypass :: atom(),
-                  auth_mod=riak_kv_passthru_auth :: atom(),
                   user :: #rs3_user{}}).
 
 -define(USER_BUCKET, <<"moss.users">>).
-

--- a/src/riak_moss_auth.erl
+++ b/src/riak_moss_auth.erl
@@ -12,7 +12,7 @@
 
 -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
 behaviour_info(callbacks) ->
-    [{authenticate, 1}];
+    [{authenticate, 2}];
 behaviour_info(_Other) ->
     undefined.
 

--- a/src/riak_moss_blockall_auth.erl
+++ b/src/riak_moss_blockall_auth.erl
@@ -10,14 +10,11 @@
 
 -include("riak_moss.hrl").
 
--export([authenticate/1]).
+-export([authenticate/2]).
 
--spec authenticate(term()) -> {ok, #rs3_user{}}
-                        | {ok, unknown}
-                        | {error, atom()}.
-authenticate(_RD) ->
-    %% TODO:
-    %% is there a better
-    %% atom we could return?
-    {error, invalid_authentication}.
+-spec authenticate(term(), [string()]) -> {ok, #rs3_user{}}
+                                              | {ok, unknown}
+                                              | {error, atom()}.
+authenticate(_RD, [Reason]) ->
+    {error, Reason}.
 

--- a/src/riak_moss_passthru_auth.erl
+++ b/src/riak_moss_passthru_auth.erl
@@ -10,14 +10,14 @@
 
 -include("riak_moss.hrl").
 
--export([authenticate/1]).
+-export([authenticate/2]).
 
--spec authenticate(term()) -> {ok, #rs3_user{}}
-                        | {ok, unknown}
-                        | {error, atom()}.
-authenticate(_RD) ->
+-spec authenticate(term(), [string()]) -> {ok, #rs3_user{}}
+                                              | {ok, unknown}
+                                              | {error, atom()}.
+authenticate(_RD, _AuthArgs) ->
     %% TODO:
-    %% Even though we're 
+    %% Even though we're
     %% going to authorize
     %% no matter what,
     %% maybe it still makes sense

--- a/src/riak_moss_riakc.erl
+++ b/src/riak_moss_riakc.erl
@@ -181,7 +181,7 @@ do_get_object(BucketName, Key, RiakcPid) ->
     BinKey = list_to_binary(Key),
     riakc_pb_socket:get(RiakcPid, BucketName, BinKey).
 
-do_put_object(KeyID, BucketName, Key, Value, Metadata, RiakcPid) ->
+do_put_object(_KeyID, BucketName, Key, Value, Metadata, RiakcPid) ->
     %% TODO: KeyID is currently
     %% not used
 

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -35,15 +35,11 @@ malformed_request(RD, Ctx) ->
 %%      authenticated. Normally with HTTP
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
-forbidden(RD, Ctx=#context{auth_bypass=AuthBypass,
-                           auth_mod=AuthMod}) ->
-    case AuthBypass of
-        true ->
-            %% Authentication is disabled, allow access
-            {false, RD, Ctx};
-        false ->
-            %% Attempt to authenticate the request
-            case AuthMod:authenticate(RD) of
+forbidden(RD, Ctx=#context{auth_bypass=AuthBypass}) ->
+    AuthHeader = wrq:get_req_header("authorization", RD),
+    case riak_moss_wm_utils:parse_auth_header(AuthHeader, AuthBypass) of
+        {ok, AuthMod, Args} ->
+            case AuthMod:authenticate(RD, Args) of
                 {ok, User} ->
                     %% Authentication succeeded
                     {false, RD, Ctx#context{user=User}};
@@ -60,7 +56,7 @@ allowed_methods(RD, Ctx) ->
     {['HEAD', 'GET'], RD, Ctx}.
 
 -spec content_types_provided(term(), term()) ->
-    {[{atom(), module()}], term(), term()}.
+                                    {[{atom(), module()}], term(), term()}.
 content_types_provided(RD, Ctx) ->
     %% TODO:
     %% As I understand S3, the content types provided
@@ -72,7 +68,7 @@ content_types_provided(RD, Ctx) ->
     {[{"text/plain", produce_body}], RD, Ctx}.
 
 -spec produce_body(term(), term()) ->
-    {iolist(), term(), term()}.
+                          {iolist(), term(), term()}.
 produce_body(RD, Ctx) ->
     %% TODO:
     %% This is really just a placeholder

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -6,7 +6,8 @@
 
 -module(riak_moss_wm_utils).
 
--export([service_available/2]).
+-export([service_available/2,
+         parse_auth_header/2]).
 
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
@@ -23,3 +24,20 @@ service_available(RD, Ctx) ->
     %% For now we just always
     %% return true
     {true, RD, Ctx}.
+
+%% @doc Parse an authentication header string and determine
+%% the appropriate module to use to authenticate the request.
+-spec parse_auth_header(string(), boolean()) -> {ok, atom(), [string()]} | {error, term()}.
+parse_auth_header(_, true) ->
+    {ok, riak_moss_passthru_auth, []};
+parse_auth_header(undefined, false) ->
+    {ok, riak_moss_blockall_auth, [unkown_auth_scheme]};
+parse_auth_header("AWS " ++ Key, _) ->
+    case string:tokens(Key, ":") of
+        [KeyId, KeyData] ->
+            {ok, riak_moss_s3_auth, [KeyId, KeyData]};
+        Other -> Other
+    end;
+parse_auth_header(_, _) ->
+    {ok, riak_moss_blockall_auth, [unkown_auth_scheme]}.
+


### PR DESCRIPTION
Reorganize how authentication is handled to allow multiple authentication schemes to be used at one time. The `parse_header` function is now what determines which authentication scheme is being used and it now lives in the `riak_moss_wm_util` module. The `authenticate` function in the auth modules now has arity 2. The first parameter being the request data and the second a list of scheme-specific terms that are created by `riak_moss_wm_util:parse_header`. Also the `auth_mod` field in the `context` record has been replaced with an `auth_bypass` boolean field to indicate if authentication bypass is enabled.
