### PR TITLE
Change the rs3_user and rs3_bucket records to moss_user and moss_bucket

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -1,17 +1,17 @@
 
--record(rs3_user, {
+-record(moss_user, {
           name :: binary(),
           key_id :: binary(),
           key_secret :: binary(),
           buckets = []}).
 
--record(rs3_bucket, {
+-record(moss_bucket, {
           name :: binary(),
           creation_date :: term()}).
 
 -record(context, {auth_bypass :: atom(),
                   auth_mod=riak_kv_passthru_auth :: atom(),
-                  user :: #rs3_user{}}).
+                  user :: #moss_user{}}).
 
 -define(USER_BUCKET, <<"moss.users">>).
 

--- a/src/riak_moss_blockall_auth.erl
+++ b/src/riak_moss_blockall_auth.erl
@@ -12,7 +12,7 @@
 
 -export([authenticate/1]).
 
--spec authenticate(term()) -> {ok, #rs3_user{}}
+-spec authenticate(term()) -> {ok, #moss_user{}}
                         | {ok, unknown}
                         | {error, atom()}.
 authenticate(_RD) ->

--- a/src/riak_moss_passthru_auth.erl
+++ b/src/riak_moss_passthru_auth.erl
@@ -12,12 +12,12 @@
 
 -export([authenticate/1]).
 
--spec authenticate(term()) -> {ok, #rs3_user{}}
+-spec authenticate(term()) -> {ok, #moss_user{}}
                         | {ok, unknown}
                         | {error, atom()}.
 authenticate(_RD) ->
     %% TODO:
-    %% Even though we're 
+    %% Even though we're
     %% going to authorize
     %% no matter what,
     %% maybe it still makes sense

--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -10,7 +10,7 @@
 
 -include("riak_moss.hrl").
 
--spec authenticate(term()) -> {ok, #rs3_user{}}
+-spec authenticate(term()) -> {ok, #moss_user{}}
                         | {ok, unknown}
                         | {error, atom()}.
 -export([authenticate/1]).
@@ -21,8 +21,8 @@ authenticate(RD) ->
         {ok, KeyID, Signature} ->
             case riak_moss_riakc:get_user(KeyID) of
                 {ok, User} ->
-                    case check_auth(User#rs3_user.key_id,
-                               User#rs3_user.key_secret,
+                    case check_auth(User#moss_user.key_id,
+                               User#moss_user.key_secret,
                                RD,
                                Signature) of
                         true ->


### PR DESCRIPTION
Change the name of the `rs3_user` record to `moss_user` and update all references in applicable modules. Likewise, do the same for the `rs3_bucket` record, renaming it to `moss_bucket`.
