### PR TITLE
Add naive(ish) implementation of sorted list keys

### DIFF
--- a/src/riak_moss_riakc.erl
+++ b/src/riak_moss_riakc.erl
@@ -188,6 +188,11 @@ do_delete_bucket(KeyID, BucketName, RiakcPid) ->
 
 do_list_keys(BucketName, RiakcPid) ->
     {ok, Keys} = riakc_pb_socket:list_keys(RiakcPid, BucketName),
+    %% TODO:
+    %% This is a naive implementation,
+    %% the longer-term solution is likely
+    %% going to involve 2i and merging the
+    %% results from each of the vnodes.
     {ok, lists:sort(Keys)}.
 
 do_get_object(BucketName, Key, RiakcPid) ->

--- a/src/riak_moss_riakc.erl
+++ b/src/riak_moss_riakc.erl
@@ -187,7 +187,8 @@ do_delete_bucket(KeyID, BucketName, RiakcPid) ->
     do_save_user(UpdatedUser, RiakcPid).
 
 do_list_keys(BucketName, RiakcPid) ->
-    riakc_pb_socket:list_keys(RiakcPid, BucketName).
+    {ok, Keys} = riakc_pb_socket:list_keys(RiakcPid, BucketName),
+    {ok, lists:sort(Keys)}.
 
 do_get_object(BucketName, Key, RiakcPid) ->
     %% TODO:

--- a/test/riak_moss_riakc_test.erl
+++ b/test/riak_moss_riakc_test.erl
@@ -38,7 +38,8 @@ riakc_test_() ->
       fun name_matches/0,
       fun bucket_appears/0,
       fun key_appears/0,
-      fun object_returns/0
+      fun object_returns/0,
+      fun keys_are_sorted/0
      ]}.
 
 %% @doc Make sure that the name
@@ -86,6 +87,22 @@ key_appears() ->
 
     {ok, ListKeys} = riak_moss_riakc:list_keys(BucketName),
     ?assert(lists:member(list_to_binary(KeyName), ListKeys)).
+
+keys_are_sorted() ->
+    Name = "fooser",
+    BucketName = "keys_are_sorted",
+    Keys = [<<"dog">>, <<"zebra">>, <<"aardvark">>, <<01>>, <<"panda">>],
+
+    {ok, User} = riak_moss_riakc:create_user(Name),
+    KeyID = User#moss_user.key_id,
+    ok = riak_moss_riakc:create_bucket(KeyID, BucketName),
+
+    [riak_moss_riakc:put_object(KeyID, BucketName, binary_to_list(KeyName),
+                                      "value", dict:new()) ||
+                                       KeyName <- Keys],
+
+    {ok, ListKeys} = riak_moss_riakc:list_keys(BucketName),
+    ?assertEqual(lists:sort(Keys), ListKeys).
 
 %% @doc Make sure that when we save an object,
 %%      we can later retrieve it and get the same

--- a/test/riak_moss_riakc_test.erl
+++ b/test/riak_moss_riakc_test.erl
@@ -88,6 +88,9 @@ key_appears() ->
     {ok, ListKeys} = riak_moss_riakc:list_keys(BucketName),
     ?assert(lists:member(list_to_binary(KeyName), ListKeys)).
 
+%% TODO:
+%% This would make a great
+%% EQC test
 keys_are_sorted() ->
     Name = "fooser",
     BucketName = "keys_are_sorted",


### PR DESCRIPTION
AZ883
- Sort the keys returned by pb client list keys
- Add a test to make sure the keys are sorted
