### PR TITLE
lfs rough draft - DO NOT MERGE

### DIFF
--- a/src/riak_moss_lfs.erl
+++ b/src/riak_moss_lfs.erl
@@ -1,0 +1,80 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Large file storage interface
+
+-module(riak_moss_lfs).
+
+-compile(export_all).
+
+-define(DEFAULT_BLOCK_SIZE, 1000).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec create(string(), string(), pos_integer(), binary(), list()) ->
+                    {ok, binary()} | {error, term()}.
+create(Bucket, FileName, FileSize, Data, MetaData) ->
+    create(Bucket, FileName, FileSize, Data, ?DEFAULT_BLOCK_SIZE, MetaData).
+
+-spec create(string(), string(), pos_integer(), pos_integer(), binary(), list()) ->
+                    {ok, binary()} | {error, term()}.
+create(Bucket, FileName, FileSize, BlockSize, Data, MetaData) ->
+    %% @TODO Use actual UUID
+    UUID = riak_moss:unique_hex_id(),
+    %% Calculate the number of blocks
+    case FileSize rem BlockSize of
+        0 ->
+            BlockCount = FileSize div BlockSize;
+        _ ->
+            BlockCount = (FileSize div BlockSize) + 1
+    end,
+    %% Punting on optimization where no extra blocks are created if
+    %% file size <= block size.
+    Blocks = [list_to_binary(FileName ++ UUID ++ integer_to_list(X)) ||
+                 X <- lists:seq(1,BlockCount+1)],
+    %% Assemble the metadata
+    MDDict = dict:from_list(MetaData ++
+                                [{file_size, FileSize},
+                                 {block_size, BlockSize},
+                                 {blocks_missing, Blocks},
+                                 {alive, false},
+                                 {uuid, UUID}]),
+
+    %% Punting on proper connection handling for now
+    case riakc_pb_socket:start_link("127.0.0.1", 8087) of
+        {ok, Pid} ->
+            Obj = riakc_obj:new(Bucket,
+                                list_to_binary(FileName),
+                                UUID),
+            NewObj = riakc_obj:update_metadata(Obj, dict:to_list(MDDict)),
+            case riakc_pb_socket:put(Pid, NewObj, [return_body]) of
+                {ok, NewObj} ->
+                    %% Get the vector clock
+                    VClock = ok,
+                    put(Pid, FileName, VClock, BlockSize, Blocks, Data);
+                {ok, _} ->
+                    %% Handle conflict
+                    ok;
+                {error, _Reason1} ->
+                    ok
+            end;
+        {error, Reason} ->
+            lager:error("Couldn't connect to Riak: ~p", [Reason])
+    end.
+
+put(_Pid, _FileName, _VClock, _BlockSize, [], _) ->
+    %% Mark file as available
+    ok;
+put(Pid, FileName, VClock, BlockSize, [_Block | RestBlocks], Data) ->
+    <<_BlockData:BlockSize/binary, RestData/binary>> = Data,
+    %% Write block
+    %% Update root metadata
+    put(Pid, FileName, VClock, BlockSize, RestBlocks, RestData).
+
+%% get(FileName) ->
+


### PR DESCRIPTION
**Note**: This pull request is intended for discussion purposes only and is not intended to be merged.
## Usage

<pre>
<code>
%% Store file
Data = list_to_binary(string:chars($a, 1000) ++ string:chars($b, 1000) ++ string:chars($c, 1000)).
riak_moss_lfs:create("lfs_test_bucket", "testfile1", 3000, Data, []).
</code>
<code>
%% Get file
riak_moss_lfs:get("lfs_test_bucket", "testfile1").
</code>
</pre>

## Notes
- This code is very rough, but it is just to illustrate some of the ideas we want to refine
- I ignored the optimization of storing only chunking if the file is _large_
- Proper handling of many error or failure conditions is lacking.
- It makes sense to try to keep the large file code separate from the web proxy code. Puts could make a distinction ahead of time, but gets and delete won't have _a priori_ knowledge of whether the file is _large_ or not. Better to keep the web proxy code as clean as possible.  
- I think using a separate `gen_fsm` module for get, put, and delete makes sense. We can create supervisor to manage them similar to how it's done in `riak_kv`. 
- Connections to Riak via the pb interface are created as needed. If we wanted to use a fixed connection pool that reuses connections, there is opportunity to refactor `riak_moss_riakc` to not be a `gen_server` and instead use a separate `gen_server` module to manage connections that can be used by the `riakc` module or the `lfs` module(s). This would let us spend less time in synchronous code in `riakc` but still get the benefit of reusing connections. Or maybe it's better to just create connections as needed at this point. 
