### PR TITLE
Az999 get fsm backpressure

### DIFF
--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -56,7 +56,6 @@
                 value_cache :: binary(), 
                 metadata_cache :: term(), 
                 chunk_queue :: term(),
-                reply_pid :: pid(),
                 manifest :: term(),
                 blocks_left :: list(),
                 get_module :: module()}).

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -14,14 +14,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test API
--export([test_link/3]).
+-export([test_link/2]).
 
 -endif.
 
 -include("riak_moss.hrl").
 
 %% API
--export([start_link/3,
+-export([start_link/2,
          stop/1,
          continue/1,
          get_metadata/1,
@@ -65,8 +65,8 @@
 %% Public API
 %% ===================================================================
 
-start_link(From, Bucket, Key) ->
-    gen_fsm:start_link(?MODULE, [From, Bucket, Key], []).
+start_link(Bucket, Key) ->
+    gen_fsm:start_link(?MODULE, [Bucket, Key], []).
 
 stop(Pid) ->
     gen_fsm:send_event(Pid, stop).
@@ -84,7 +84,7 @@ get_next_chunk(Pid) ->
 %% gen_fsm callbacks
 %% ====================================================================
 
-init([_From, Bucket, Key]) ->
+init([Bucket, Key]) ->
     Queue = queue:new(),
     State = #state{bucket=Bucket, key=Key,
                    get_module=riak_moss_riakc,
@@ -93,8 +93,8 @@ init([_From, Bucket, Key]) ->
     %% so that we get called in the prepare
     %% state
     {ok, prepare, State, 0};
-init([test, From, Bucket, Key]) ->
-    {ok, prepare, State1, 0} = init([From, Bucket, Key]),
+init([test, Bucket, Key]) ->
+    {ok, prepare, State1, 0} = init([Bucket, Key]),
     State2 = State1#state{get_module=riak_moss_dummy_gets},
     %% purposely have the timeout happen
     %% so that we get called in the prepare
@@ -306,7 +306,7 @@ blocks_retriever(Pid, GetModule, BucketName, BlockKeys) ->
 
 -ifdef(TEST).
 
-test_link(From, Bucket, Key) ->
-    gen_fsm:start_link(?MODULE, [test, From, Bucket, Key], []).
+test_link(Bucket, Key) ->
+    gen_fsm:start_link(?MODULE, [test, Bucket, Key], []).
 
 -endif.

--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -44,14 +44,14 @@ test_n_chunks_builder(N) ->
     fun () ->
         BlockSize = calc_block_size(10000, N),
         application:set_env(riak_moss, lfs_block_size, BlockSize),
-        {ok, Pid} = riak_moss_get_fsm:test_link(self(), <<"bucket">>, <<"key">>),
+        {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>),
         ?assertEqual(dict:new(), riak_moss_get_fsm:get_metadata(Pid)),
         riak_moss_get_fsm:continue(Pid),
         expect_n_chunks(Pid, N)
     end.
 
 receives_metadata() ->
-    {ok, Pid} = riak_moss_get_fsm:test_link(self(), <<"bucket">>, <<"key">>),
+    {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>),
     ?assertEqual(dict:new(), riak_moss_get_fsm:get_metadata(Pid)),
     riak_moss_get_fsm:stop(Pid).
 

--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -45,33 +45,22 @@ test_n_chunks_builder(N) ->
         BlockSize = calc_block_size(10000, N),
         application:set_env(riak_moss, lfs_block_size, BlockSize),
         {ok, Pid} = riak_moss_get_fsm:test_link(self(), <<"bucket">>, <<"key">>),
-        ?assertMatch({metadata, _}, receive_with_timeout(1000)),
+        ?assertEqual(dict:new(), riak_moss_get_fsm:get_metadata(Pid)),
         riak_moss_get_fsm:continue(Pid),
-        expect_n_chunks(N),
-        riak_moss_get_fsm:stop(Pid)
+        expect_n_chunks(Pid, N)
     end.
 
 receives_metadata() ->
     {ok, Pid} = riak_moss_get_fsm:test_link(self(), <<"bucket">>, <<"key">>),
-    ?assertMatch({metadata, _}, receive_with_timeout(1000)),
+    ?assertEqual(dict:new(), riak_moss_get_fsm:get_metadata(Pid)),
     riak_moss_get_fsm:stop(Pid).
 
 %% ===================================================================
 %% Helper Funcs
 %% ===================================================================
 
-%% @doc Just returns whatever it receives, or
-%%      `timeout` after `Timeout`
-receive_with_timeout(Timeout) ->
-    receive
-        Anything ->
-            Anything
-    after
-        Timeout -> timeout
-    end.
-
-expect_n_chunks(N) ->
+expect_n_chunks(FsmPid, N) ->
     %% subtract 1 from N because the last
     %% chunk will have a different pattern
-    [?assertMatch({chunk, _}, receive_with_timeout(100)) || _ <- lists:seq(1, N-1)],
-    ?assertMatch({done, _}, receive_with_timeout(1000)).
+    [?assertMatch({chunk, _}, riak_moss_get_fsm:get_next_chunk(FsmPid)) || _ <- lists:seq(1, N-1)],
+    ?assertMatch({done, _}, riak_moss_get_fsm:get_next_chunk(FsmPid)).


### PR DESCRIPTION
I've refactored the GET fsm to have the caller _ask_ for chunks instead of receiving them in the process mailbox. This adds implicit backpressure and makes writing the WM code easier because we don't have to deal with the potential variability in the WM proc pid. The tests have been updated to reflect this. Take a look at the tests to see the new usage.
