### PR TITLE
Changes so that s3cmd object listing works.

### DIFF
--- a/src/riak_moss_riakc.erl
+++ b/src/riak_moss_riakc.erl
@@ -153,7 +153,8 @@ do_save_user(User, RiakcPid) ->
 %% exist anywhere, since everyone
 %% shares a global bucket namespace
 do_create_bucket(KeyID, BucketName, RiakcPid) ->
-    Bucket = #moss_bucket{name=BucketName, creation_date=creation_date()},
+    Bucket = #moss_bucket{name=BucketName,
+                          creation_date=riak_moss_wm_utils:iso_8601_datetime()},
     %% TODO:
     %% We don't do anything about
     %% {error, Reason} here
@@ -221,11 +222,3 @@ do_put_object(_KeyID, BucketName, Key, Value, Metadata, RiakcPid) ->
 do_delete_object(BucketName, Key, RiakcPid) ->
     BinKey = list_to_binary(Key),
     riakc_pb_socket:delete(RiakcPid, BucketName, BinKey).
-
-creation_date() ->
-    iso_8601(erlang:universaltime()).
-
-iso_8601(DateTime) ->
-    {{Year,Month,Day},{Hour,Min,Sec}} = DateTime,
-    io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000Z",
-                  [Year, Month, Day, Hour, Min, Sec]).

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -9,7 +9,8 @@
 -export([service_available/2,
          parse_auth_header/2,
          ensure_doc/1,
-         user_record_to_proplist/1]).
+         user_record_to_proplist/1,
+         iso_8601_datetime/0]).
 
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
@@ -79,3 +80,11 @@ user_record_to_proplist(#moss_user{name=Name,
      {<<"key_id">>, list_to_binary(KeyID)},
      {<<"key_secret">>, list_to_binary(KeySecret)},
      {<<"buckets">>, Buckets}].
+
+%% @doc Get an ISO 8601 formatted timestamp representing
+%% current time.
+-spec iso_8601_datetime() -> [non_neg_integer()].
+iso_8601_datetime() ->
+    {{Year, Month, Day}, {Hour, Min, Sec}} = erlang:universaltime(),
+    io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000Z",
+                  [Year, Month, Day, Hour, Min, Sec]).


### PR DESCRIPTION
- Use ISO 8601 timestamp for value of last-modified element in response document.
- Add Etag element to response document.
