### PR TITLE
Set the content type on puts.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R14B0[234]"}.
+{require_otp_vsn, "R14B0[234]|R15"}.
 
 {cover_enabled, true}.
 

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -184,8 +184,9 @@ content_types_accepted(RD, Ctx) ->
 -spec accept_body(term(), term()) ->
     {true, term(), term()}.
 accept_body(RD, Ctx=#key_context{bucket=Bucket,key=Key,
-                                 putctype=_CType,size=Size}) ->
-    {ok, Pid} = riak_moss_put_fsm:start_link(list_to_binary(Bucket), Key, Size, <<>>, 60000),
+                                 putctype=ContentType,size=Size}) ->
+    Args = [list_to_binary(Bucket), Key, Size, ContentType, <<>>, 60000],
+    {ok, Pid} = riak_moss_put_fsm_sup:start_put_fsm(node(), Args),
     accept_streambody(RD, Ctx, Pid, wrq:stream_req_body(RD, riak_moss_lfs_utils:block_size())).
 
 accept_streambody(RD, Ctx=#key_context{}, Pid, {Data, Next}) ->

--- a/test/riak_moss_put_fsm_eqc.erl
+++ b/test/riak_moss_put_fsm_eqc.erl
@@ -82,6 +82,7 @@ prop_put_fsm() ->
                                              Bucket,
                                              FileName,
                                              ContentLength,
+                                             "text/plain",
                                              Data,
                                              10000),
 

--- a/test/riak_moss_writer_test.erl
+++ b/test/riak_moss_writer_test.erl
@@ -38,7 +38,8 @@ initialize_case({WriterPid, ReceiverPid}) ->
                                          ReceiverPid,
                                          <<"testbucket">>,
                                          <<"testfile">>,
-                                         1024),
+                                         1024,
+                                        "text/plain"),
     {"initialize response test",
      fun() ->
              [


### PR DESCRIPTION
- Use `riakc_obj:new/4` to set the content type when the manifest is
  initially written.
- Update all related functions so the content type is passed from
  webmachine to the put fsm and onto the writer process.
- Update appropriate tests to use a content type parameter.
