### PR TITLE
Az1023 keyname performance

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,5 +13,6 @@
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "wrd-content-length-with-streaming"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
+        {sext, ".*", {git, "git://github.com/esl/sext", "master"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {branch, "master"}}}
        ]}.

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -95,10 +95,11 @@ block_keynames(KeyName, UUID, BlockList) ->
     lists:map(MapFun, BlockList).
 
 block_name(Key, UUID, Number) ->
-    term_to_binary({Key, UUID, Number}).
+    sext:encode({Key, Number, UUID}).
 
 block_name_to_term(Name) ->
-    binary_to_term(Name).
+    {Key, Number, UUID} = sext:decode(Name),
+    {Key, UUID, Number}.
 
 %% @doc Return the configured block size
 -spec block_size() -> pos_integer().


### PR DESCRIPTION
I've changed the block keynames to be encoded with sext, and to have a sequential ordering, {Filename, BlockNumber, UUID}. In my unscientific testing this was > 2x faster than random keys. Here are the results of uploading a 3.5GB file:

```
# with keys generated by term_to_binary
sleepimage -> s3://bucket/sleep  [1 of 1]
 3723493376 of 3723493376   100% in  732s     4.85 MB/s  done
s3cmd put sleepimage s3://bucket/sleep  59.25s user 17.50s system 10% cpu 12:12.21 total

# with keys generated by sext:encode/1
sleepimage -> s3://bucket/sleep  [1 of 1]
 3723493376 of 3723493376   100% in  353s    10.06 MB/s  done
s3cmd put sleepimage s3://bucket/sleep  60.81s user 17.87s system 22% cpu 5:53.20 total
```
