### PR TITLE
Changes so that s3cmd subcommands sync, du, and rb work.

### DIFF
--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -178,16 +178,13 @@ canonicalize_resource(RD) ->
 -else.
 canonicalize_resource(RD) ->
     case {bucket_from_host(wrq:get_req_header("host", RD), RD),
-          wrq:path_info(key, RD)} of
-        {undefined, undefined} -> ["/"];
-        {Bucket, undefined} -> ["/", Bucket, "/"];
-        {Bucket, Key} -> ["/", Bucket, "/", Key]
+          wrq:path_tokens(RD)} of
+        {undefined, []} -> ["/"];
+        {Bucket, []} -> ["/", Bucket, "/"];
+        {Bucket, KeyTokens} ->
+            ["/", Bucket, "/", string:join(KeyTokens, "/")]
     end.
 -endif.
-
-
-
-
 
 %% ===================================================================
 %% Eunit tests

--- a/src/riak_moss_web.erl
+++ b/src/riak_moss_web.erl
@@ -21,5 +21,5 @@ dispatch_table() ->
      {[], riak_moss_wm_service, [{auth_bypass, AuthBypass}]},
      {["user"], riak_moss_wm_user, []},
      {[bucket], riak_moss_wm_bucket, [{auth_bypass, AuthBypass}]},
-     {[bucket, key], riak_moss_wm_key, [{auth_bypass, AuthBypass}]}
+     {[bucket, '*'], riak_moss_wm_key, [{auth_bypass, AuthBypass}]}
     ].

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -29,7 +29,12 @@ init(Config) ->
 -spec extract_paths(term(), term()) -> term().
 extract_paths(RD, Ctx) ->
     Bucket = wrq:path_info(bucket, RD),
-    Key = wrq:path_info(key, RD),
+    case wrq:path_tokens(RD) of
+        [] ->
+            Key = undefined;
+        KeyTokens ->
+            Key = string:join(KeyTokens, "/")
+    end,
     Ctx#key_context{bucket=Bucket, key=Key}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.


### PR DESCRIPTION
Some of these changes are pragmatic and we will want to evaluate the possibility of improving efficiency in the future. Getting the metadata for object size and checksum is particularly expensive, but should suffice for the near-term. Also changes will be required when we begin enforcing globally-unique bucket names. I have tried to notate places that could be affected with `TODO` statements. 
