### PR TITLE
support the prefix query parameter

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -17,7 +17,7 @@
          delete_object/2,
          from_bucket_name/1,
          get_buckets/1,
-         get_keys_and_objects/1,
+         get_keys_and_objects/2,
          get_object/2,
          get_object/3,
          get_user/1,
@@ -175,15 +175,15 @@ get_buckets(#moss_user{buckets=Buckets}) ->
 
 %% @doc Return a list of keys for a bucket along
 %% with their associated objects.
--spec get_keys_and_objects(binary()) -> {ok, [binary()]}.
-get_keys_and_objects(BucketName) ->
+-spec get_keys_and_objects(binary(), binary()) -> {ok, [binary()]}.
+get_keys_and_objects(BucketName, Prefix) ->
     case riak_connection() of
         {ok, RiakPid} ->
             case list_keys(BucketName, RiakPid) of
                 {ok, Keys} ->
                     KeyObjPairs =
                         [{Key, get_object(BucketName, Key, RiakPid)}
-                         || Key <- Keys],
+                         || Key <- prefix_filter(Keys, Prefix)],
                     Res = {ok, KeyObjPairs};
                 {error, Reason1} ->
                     Res = {error, Reason1}
@@ -193,6 +193,14 @@ get_keys_and_objects(BucketName) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+-spec prefix_filter(list(), binary()) -> list().
+prefix_filter(Keys, Prefix) ->
+    PL = size(Prefix),
+    lists:filter(
+      fun(<<P:PL/binary,_/binary>>) when P =:= Prefix -> true;
+         (_) -> false
+      end, Keys).
 
 %% @doc Get an object from Riak
 -spec get_object(binary(), binary()) ->

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -195,6 +195,8 @@ get_keys_and_objects(BucketName, Prefix) ->
     end.
 
 -spec prefix_filter(list(), binary()) -> list().
+prefix_filter(Keys, <<>>) ->
+    Keys;
 prefix_filter(Keys, Prefix) ->
     PL = size(Prefix),
     lists:filter(

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -90,7 +90,8 @@ to_xml(RD, Ctx=#context{user=User}) ->
     BucketName = wrq:path_info(bucket, RD),
     Bucket = hd([B || B <- riak_moss_utils:get_buckets(User), B#moss_bucket.name =:= BucketName]),
     MOSSBucket = riak_moss_utils:to_bucket_name(objects, list_to_binary(Bucket#moss_bucket.name)),
-    case riak_moss_utils:get_keys_and_objects(MOSSBucket) of
+    Prefix = list_to_binary(wrq:get_qs_value("prefix", "", RD)),
+    case riak_moss_utils:get_keys_and_objects(MOSSBucket, Prefix) of
         {ok, KeyObjPairs} ->
             riak_moss_s3_response:list_bucket_response(User,
                                                        Bucket,


### PR DESCRIPTION
this is needed by the blackflag loader script.  from the python repl using boto:

```>>> b.get_all_keys()
[<Key: baz,acbd18db4cc2f85cedef654fccc4a4d8>, <Key: baz,p1>, <Key: baz,p2>, <Key: baz,p3>]

> > > b.get_all_keys(prefix="p")
> > > [<Key: baz,p1>, <Key: baz,p2>, <Key: baz,p3>]
> > > b.get_all_keys(prefix="")
> > > [<Key: baz,acbd18db4cc2f85cedef654fccc4a4d8>, <Key: baz,p1>, <Key: baz,p2>, <Key: baz,p3>]```
