### PR TITLE
S71 get fsm eqc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dev
 log/
 *~
 /log
+current_counterexample.eqc

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,7 @@
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "wrd-content-length-with-streaming"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},
         {sext, ".*", {git, "git://github.com/esl/sext", "master"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {branch, "master"}}}
        ]}.

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -109,7 +109,7 @@ prepare(timeout, #state{bucket=Bucket, key=Key, reader_pid=ReaderPid}=State) ->
     %% start the process that will
     %% fetch the value, be it manifest
     %% or regular object
-    {ok, ReaderPid} = riak_moss_reader_sup:start_reader(node(), []),
+    {ok, ReaderPid} = riak_moss_reader_sup:start_reader(node(), [self()]),
     %% TODO:
     %% we need to tell the reader gen_server
     %% about our pid() another way

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -100,7 +100,9 @@ init([test, Bucket, Key]) ->
     %% purposely have the timeout happen
     %% so that we get called in the prepare
     %% state
-    {ok, prepare, State1, 0}.
+    {ok, ReaderPid} = riak_moss_reader:start_link([self()]),
+    riak_moss_reader:get_manifest(ReaderPid, Bucket, Key),
+    {ok, waiting_value, State1#state{reader_pid=ReaderPid}}.
 
 %% TODO:
 %% could this func use
@@ -109,7 +111,7 @@ prepare(timeout, #state{bucket=Bucket, key=Key, reader_pid=ReaderPid}=State) ->
     %% start the process that will
     %% fetch the value, be it manifest
     %% or regular object
-    {ok, ReaderPid} = riak_moss_reader_sup:start_reader(node(), [self()]),
+    {ok, ReaderPid} = riak_moss_reader_sup:start_reader(node(), self()),
     %% TODO:
     %% we need to tell the reader gen_server
     %% about our pid() another way

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -107,7 +107,7 @@ init([test, Bucket, Key, ContentLength, BlockSize]) ->
 %% TODO:
 %% could this func use
 %% use a better name?
-prepare(timeout, #state{bucket=Bucket, key=Key, reader_pid=ReaderPid}=State) ->
+prepare(timeout, #state{bucket=Bucket, key=Key}=State) ->
     %% start the process that will
     %% fetch the value, be it manifest
     %% or regular object

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -95,12 +95,12 @@ init([Bucket, Key]) ->
     %% so that we get called in the prepare
     %% state
     {ok, prepare, State, 0};
-init([test, Bucket, Key]) ->
+init([test, Bucket, Key, ContentLength]) ->
     {ok, prepare, State1, 0} = init([Bucket, Key]),
     %% purposely have the timeout happen
     %% so that we get called in the prepare
     %% state
-    {ok, ReaderPid} = riak_moss_reader:start_link([self()]),
+    {ok, ReaderPid} = riak_moss_dummy_reader:start_link([self(), ContentLength]),
     riak_moss_reader:get_manifest(ReaderPid, Bucket, Key),
     {ok, waiting_value, State1#state{reader_pid=ReaderPid}}.
 
@@ -132,6 +132,7 @@ waiting_value({object, _Pid, Reply}, #state{from=From}=State) ->
             notfound;
         {ok, Value} ->
             RawValue = riakc_obj:get_value(Value),
+            lager:error("the value is ~p", [RawValue]),
             case riak_moss_lfs_utils:is_manifest(RawValue) of
                 false ->
                     %% TODO:

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -100,7 +100,7 @@ init([test, Bucket, Key, ContentLength]) ->
     %% purposely have the timeout happen
     %% so that we get called in the prepare
     %% state
-    {ok, ReaderPid} = riak_moss_dummy_reader:start_link([self(), ContentLength]),
+    {ok, ReaderPid} = riak_moss_dummy_reader:start_link([self(), ContentLength, riak_moss_lfs_utils:block_size()]),
     riak_moss_reader:get_manifest(ReaderPid, Bucket, Key),
     {ok, waiting_value, State1#state{reader_pid=ReaderPid}}.
 

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -26,10 +26,12 @@
          block_name/3,
          block_name_to_term/1,
          block_size/0,
+         safe_block_size_from_manifest/1,
          file_uuid/1,
          finalize_manifest/2,
          initial_blocks/1,
          initial_blocks/2,
+         block_sequences_for_manifest/1,
          is_manifest/1,
          metadata_from_manifest/1,
          new_manifest/6,
@@ -86,7 +88,7 @@ block_count(ContentLength, BlockSize) ->
 initial_block_keynames(#lfs_manifest{bkey={_, KeyName},
                              uuid=UUID,
                              content_length=ContentLength}) ->
-    BlockList = lists:sort(sets:to_list(initial_blocks(ContentLength))),
+    BlockList = initial_blocks(ContentLength),
     block_keynames(KeyName, UUID, BlockList).
 
 remaining_block_keynames(#lfs_manifest{bkey={_, KeyName},
@@ -121,6 +123,13 @@ block_size() ->
             end
     end.
 
+safe_block_size_from_manifest(#lfs_manifest{block_size=BlockSize}) ->
+    case BlockSize of
+        undefined ->
+            block_size();
+        _ -> BlockSize
+    end.
+
 %% @doc Get the file UUID from the manifest.
 -spec file_uuid(lfs_manifest()) -> binary().
 file_uuid(#lfs_manifest{uuid=UUID}) ->
@@ -140,17 +149,18 @@ finalize_manifest(Manifest, MD5) ->
 %%      make up the file.
 -spec initial_blocks(pos_integer()) -> set().
 initial_blocks(ContentLength) ->
-    UpperBound = block_count(ContentLength),
-    Seq = lists:seq(0, (UpperBound - 1)),
-    sets:from_list(Seq).
+    initial_blocks(ContentLength, block_size()).
 
 %% @doc A set of all of the blocks that
 %%      make up the file.
 -spec initial_blocks(pos_integer(), pos_integer()) -> set().
 initial_blocks(ContentLength, BlockSize) ->
     UpperBound = block_count(ContentLength, BlockSize),
-    Seq = lists:seq(0, (UpperBound - 1)),
-    sets:from_list(Seq).
+    lists:seq(0, (UpperBound - 1)).
+
+block_sequences_for_manifest(#lfs_manifest{content_length=ContentLength}=Manifest) ->
+    SafeBlockSize = safe_block_size_from_manifest(Manifest),
+    initial_blocks(ContentLength, SafeBlockSize).
 
 %% @doc Returns true if Value is
 %%      a manifest record
@@ -177,7 +187,7 @@ metadata_from_manifest(#lfs_manifest{metadata=Metadata}) ->
                    dict()) -> lfs_manifest().
 new_manifest(Bucket, FileName, UUID, ContentLength, ContentMd5, MetaData) ->
     BlockSize = block_size(),
-    Blocks = initial_blocks(ContentLength, BlockSize),
+    Blocks = sets:from_list(initial_blocks(ContentLength, BlockSize)),
     #lfs_manifest{bkey={Bucket, FileName},
                   uuid=UUID,
                   content_length=ContentLength,

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -1,0 +1,131 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Module to write data to Riak.
+
+-module(riak_moss_reader).
+
+-behaviour(gen_server).
+
+-include("riak_moss.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Test API
+-export([test_link/0]).
+
+-endif.
+
+%% API
+-export([start_link/0,
+         get_manifest/3,
+         get_chunk/5]).
+
+%% gen_server callbacks
+-export([init/1,
+         init/2,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {riakc_pid :: pid(),
+                caller_pid :: pid()}).
+
+-type state() :: #state{}.
+
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Start a `riak_moss_reader'.
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link(?MODULE, [], []).
+
+get_manifest(Pid, Bucket, Key) ->
+    gen_server:call(?MODULE, Pid, {get_manifest, Bucket, Key}).
+
+get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
+    gen_server:call(?MODULE, Pid, {get_chunk, Bucket, Key, UUID, ChunkSeq}).
+
+%% TODO:
+%% Add shutdown public function
+
+%% ===================================================================
+%% gen_server callbacks
+%% ===================================================================
+
+%% @doc Initialize the server.
+-spec init([] | {test, [atom()]}) -> {ok, state()} | {stop, term()}.
+init([CallerPid]) ->
+    %% Get a connection to riak
+    case riak_moss_utils:riak_connection() of
+        {ok, RiakPid} ->
+            {ok, #state{riakc_pid=RiakPid,
+                        caller_pid=CallerPid}};
+        {error, Reason} ->
+            lager:error("Failed to establish connection to Riak. Reason: ~p",
+                        [Reason]),
+            {stop, riak_connect_failed}
+    end.
+init(test, CallerPid) ->
+    init([CallerPid]).
+
+%% @doc Unused
+-spec handle_call(term(), {pid(), term()}, state()) ->
+                         {reply, ok, state()}.
+handle_call(_Msg, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({get_manifest, Bucket, Key}, #state{riakc_pid=RiakcPid, caller_pid=CallerPid}=State) ->
+    ManifestValue = riakc_pb_socket:get(RiakcPid, Bucket, Key),
+    riak_moss_get_fsm:manifest(CallerPid, ManifestValue),
+    {noreply, State};
+handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{riakc_pid=RiakcPid, caller_pid=CallerPid}=State) ->
+    Key = riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq),
+    ChunkValue = riakc_pb_socket:get(RiakcPid, Bucket, Key),
+    riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, ChunkValue),
+    {noreply, State};
+handle_cast(Event, State) ->
+    lager:warning("Received unknown cast event: ~p", [Event]),
+    {noreply, State}.
+
+%% @doc @TODO
+-spec handle_info(term(), state()) ->
+                         {noreply, state()}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @doc Unused.
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%% @doc Unused.
+-spec code_change(term(), state(), term()) ->
+                         {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% ====================================================================
+%% Internal functions
+%% ====================================================================
+%% ===================================================================
+%% Test API
+%% ===================================================================
+
+-ifdef(TEST).
+
+%% @doc Start a `riak_moss_reader' for testing.
+-spec test_link() -> {ok, pid()} | {error, term()}.
+test_link() ->
+    gen_server:start_link(?MODULE, test, []).
+
+-endif.

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -47,7 +47,7 @@
 %% @doc Start a `riak_moss_reader'.
 -spec start_link(list()) -> {ok, pid()} | {error, term()}.
 start_link(Args) ->
-    gen_server:start_link(?MODULE, [], Args).
+    gen_server:start_link(?MODULE, Args, []).
 
 get_manifest(Pid, Bucket, Key) ->
     gen_server:call(?MODULE, Pid, {get_manifest, Bucket, Key}).
@@ -63,7 +63,7 @@ get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
 %% ===================================================================
 
 %% @doc Initialize the server.
--spec init([] | {test, [atom()]}) -> {ok, state()} | {stop, term()}.
+-spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
 init([CallerPid]) ->
     %% Get a connection to riak
     case riak_moss_utils:riak_connection() of

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -50,10 +50,10 @@ start_link(Args) ->
     gen_server:start_link(?MODULE, Args, []).
 
 get_manifest(Pid, Bucket, Key) ->
-    gen_server:call(?MODULE, Pid, {get_manifest, Bucket, Key}).
+    gen_server:cast(Pid, {get_manifest, Bucket, Key}).
 
 get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
-    gen_server:call(?MODULE, Pid, {get_chunk, Bucket, Key, UUID, ChunkSeq}).
+    gen_server:cast(Pid, {get_chunk, Bucket, Key, UUID, ChunkSeq}).
 
 %% TODO:
 %% Add shutdown public function

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -35,8 +35,7 @@
          code_change/3]).
 
 -record(state, {riakc_pid :: pid(),
-                caller_pid :: pid(),
-                monitor_ref :: reference()}).
+                caller_pid :: pid()}).
 
 -type state() :: #state{}.
 
@@ -63,16 +62,11 @@ get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
 %% @doc Initialize the server.
 -spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
 init([CallerPid]) ->
-    %% start a monitor with our calling
-    %% proc so that if it goes away, so
-    %% do we
-    MonitorRef = erlang:monitor(process, CallerPid),
     %% Get a connection to riak
     case riak_moss_utils:riak_connection() of
         {ok, RiakPid} ->
             {ok, #state{riakc_pid=RiakPid,
-                        caller_pid=CallerPid,
-                        monitor_ref=MonitorRef}};
+                        caller_pid=CallerPid}};
         {error, Reason} ->
             lager:error("Failed to establish connection to Riak. Reason: ~p",
                         [Reason]),
@@ -105,8 +99,6 @@ handle_cast(Event, State) ->
 %% @doc @TODO
 -spec handle_info(term(), state()) ->
                          {noreply, state()}.
-handle_info({'DOWN', Ref, process, _Pid, _Reason}, State=#state{monitor_ref=Ref}) ->
-    {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -36,7 +36,7 @@
 
 -record(state, {riakc_pid :: pid(),
                 caller_pid :: pid(),
-                monitor_ref :: reference()}). %% TODO: is ref() the right type here?
+                monitor_ref :: reference()}).
 
 -type state() :: #state{}.
 

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -21,7 +21,7 @@
 -endif.
 
 %% API
--export([start_link/0,
+-export([start_link/1,
          get_manifest/3,
          get_chunk/5]).
 
@@ -45,9 +45,9 @@
 %% ===================================================================
 
 %% @doc Start a `riak_moss_reader'.
--spec start_link() -> {ok, pid()} | {error, term()}.
-start_link() ->
-    gen_server:start_link(?MODULE, [], []).
+-spec start_link(list()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+    gen_server:start_link(?MODULE, [], Args).
 
 get_manifest(Pid, Bucket, Key) ->
     gen_server:call(?MODULE, Pid, {get_manifest, Bucket, Key}).

--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -85,12 +85,14 @@ handle_call(_Msg, _From, State) ->
     {reply, ok, State}.
 
 handle_cast({get_manifest, Bucket, Key}, #state{riakc_pid=RiakcPid, caller_pid=CallerPid}=State) ->
-    ManifestValue = riakc_pb_socket:get(RiakcPid, Bucket, Key),
+    PrefixedBucket = riak_moss_utils:to_bucket_name(objects, Bucket),
+    ManifestValue = riakc_pb_socket:get(RiakcPid, PrefixedBucket, Key),
     riak_moss_get_fsm:manifest(CallerPid, ManifestValue),
     {noreply, State};
 handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{riakc_pid=RiakcPid, caller_pid=CallerPid}=State) ->
-    Key = riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq),
-    ChunkValue = riakc_pb_socket:get(RiakcPid, Bucket, Key),
+    PrefixedBucket = riak_moss_utils:to_bucket_name(blocks, Bucket),
+    BlockKey = riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq),
+    ChunkValue = riakc_pb_socket:get(RiakcPid, PrefixedBucket, BlockKey),
     riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, ChunkValue),
     {noreply, State};
 handle_cast(Event, State) ->

--- a/src/riak_moss_reader_sup.erl
+++ b/src/riak_moss_reader_sup.erl
@@ -30,8 +30,8 @@ start_link() ->
 %% @doc Start a `riak_moss_reader' child process.
 -spec start_reader(node(), supervisor:child_spec()) ->
                           supervisor:startchild_ret().
-start_reader(Node, Args) ->
-    supervisor:start_child({?MODULE, Node}, [Args]).
+start_reader(Node, CallerPid) ->
+    supervisor:start_child({?MODULE, Node}, [[CallerPid]]).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/riak_moss_reader_sup.erl
+++ b/src/riak_moss_reader_sup.erl
@@ -43,7 +43,7 @@ start_reader(Node, Args) ->
                          pos_integer(),
                          pos_integer()},
                         [supervisor:child_spec()]}}.
-init([CallerPid]) ->
+init([]) ->
     RestartStrategy = simple_one_for_one,
     MaxRestarts = 1000,
     MaxSecondsBetweenRestarts = 3600,
@@ -55,8 +55,7 @@ init([CallerPid]) ->
     Type = worker,
 
     ReaderSpec = {undefined,
-                  {riak_moss_reader, start_link, [CallerPid]},
+                  {riak_moss_reader, start_link, []},
                   Restart, Shutdown, Type, [riak_moss_reader]},
 
     {ok, {SupFlags, [ReaderSpec]}}.
-

--- a/src/riak_moss_reader_sup.erl
+++ b/src/riak_moss_reader_sup.erl
@@ -1,0 +1,62 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Supervisor for `riak_moss_reader'
+
+-module(riak_moss_reader_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_reader/2]).
+-export([start_link/0]).
+
+%% Supervisor callbacks
+-export([init/1]).
+
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+%% @doc API for starting the supervisor.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a `riak_moss_reader' child process.
+-spec start_reader(node(), supervisor:child_spec()) ->
+                          supervisor:startchild_ret().
+start_reader(Node, Args) ->
+    supervisor:start_child({?MODULE, Node}, Args).
+
+%% ===================================================================
+%% Supervisor callbacks
+%% ===================================================================
+
+%% @doc Initialize this supervisor. This is a `simple_one_for_one',
+%%      whose child spec is for starting `riak_moss_reader' processes.
+-spec init([]) -> {ok, {{supervisor:strategy(),
+                         pos_integer(),
+                         pos_integer()},
+                        [supervisor:child_spec()]}}.
+init([CallerPid]) ->
+    RestartStrategy = simple_one_for_one,
+    MaxRestarts = 1000,
+    MaxSecondsBetweenRestarts = 3600,
+
+    SupFlags = {RestartStrategy, MaxRestarts, MaxSecondsBetweenRestarts},
+
+    Restart = temporary,
+    Shutdown = 2000,
+    Type = worker,
+
+    ReaderSpec = {undefined,
+                  {riak_moss_reader, start_link, [CallerPid]},
+                  Restart, Shutdown, Type, [riak_moss_reader]},
+
+    {ok, {SupFlags, [ReaderSpec]}}.
+

--- a/src/riak_moss_reader_sup.erl
+++ b/src/riak_moss_reader_sup.erl
@@ -31,7 +31,7 @@ start_link() ->
 -spec start_reader(node(), supervisor:child_spec()) ->
                           supervisor:startchild_ret().
 start_reader(Node, Args) ->
-    supervisor:start_child({?MODULE, Node}, Args).
+    supervisor:start_child({?MODULE, Node}, [Args]).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/riak_moss_reader_sup.erl
+++ b/src/riak_moss_reader_sup.erl
@@ -11,12 +11,12 @@
 -behaviour(supervisor).
 
 %% API
--export([start_reader/2]).
--export([start_link/0]).
+-export([start_link/0,
+         start_reader/2,
+         terminate_reader/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
-
 
 %% ===================================================================
 %% API functions
@@ -32,6 +32,11 @@ start_link() ->
                           supervisor:startchild_ret().
 start_reader(Node, CallerPid) ->
     supervisor:start_child({?MODULE, Node}, [[CallerPid]]).
+
+%% @doc Stop a reader process immediately
+-spec terminate_reader(node(), supervisor:child_spec()) -> {ok | {error, term()}}.
+terminate_reader(Node, ReaderPid) ->
+    supervisor:terminate_child({?MODULE, Node}, ReaderPid).
 
 %% ===================================================================
 %% Supervisor callbacks

--- a/src/riak_moss_sup.erl
+++ b/src/riak_moss_sup.erl
@@ -73,6 +73,9 @@ init([]) ->
     WriterSup = {riak_moss_writer_sup,
                  {riak_moss_writer_sup, start_link, []},
                  permanent, 5000, worker, dynamic},
+    ReaderSup = {riak_moss_reader_sup,
+                 {riak_moss_reader_sup, start_link, []},
+                 permanent, 5000, worker, dynamic},
     GetFsmSup = {riak_moss_get_fsm_sup,
              {riak_moss_get_fsm_sup, start_link, []},
              permanent, 5000, worker, dynamic},
@@ -86,6 +89,7 @@ init([]) ->
                  DeleteFsmSup,
                  GetFsmSup,
                  WriterSup,
+                 ReaderSup,
                  PutFsmSup,
                  Web],
     {ok, { {one_for_one, 10, 10}, Processes} }.

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -6,7 +6,7 @@
 
 %% @doc Module to write data to Riak.
 
--module(riak_moss_reader).
+-module(riak_moss_dummy_reader).
 
 -behaviour(gen_server).
 
@@ -31,6 +31,7 @@
          code_change/3]).
 
 -record(state, {content_length :: integer(),
+                block_size :: integer(),
                 caller_pid :: pid()}).
 
 -type state() :: #state{}.
@@ -60,9 +61,10 @@ get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
 
 %% @doc Initialize the server.
 -spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
-init([CallerPid, ContentLength]) ->
+init([CallerPid, ContentLength, BlockSize]) ->
     %% Get a connection to riak
     {ok, #state{content_length=ContentLength,
+                block_size=BlockSize,
                 caller_pid=CallerPid}}.
 
 %% @doc Unused

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -81,12 +81,12 @@ handle_cast({get_manifest, Bucket, Key}, #state{content_length=ContentLength,
                                                 <<"md5">>,
                                                 dict:new()),
     RiakObject = riakc_obj:new_obj(Bucket,Key, [], [{dict:new(), term_to_binary(Manifest)}]),
-    riak_moss_get_fsm:manifest(CallerPid, RiakObject),
+    riak_moss_get_fsm:manifest(CallerPid, {ok, RiakObject}),
     {noreply, State};
 handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{caller_pid=CallerPid, block_size=BlockSize}=State) ->
-    FakeData = list_to_binary(lists:seq(1, BlockSize)),
-    RiakObject = riakc_obj:new_obj(Bucket,riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq, [], [{dict:new(),FakeData}])),
-    riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, RiakObject),
+    FakeData = list_to_binary(["a" || _ <- lists:seq(1, BlockSize)]),
+    RiakObject = riakc_obj:new_obj(Bucket,riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq), [], [{dict:new(),FakeData}]),
+    riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, {ok, RiakObject}),
     {noreply, State};
 handle_cast(Event, State) ->
     lager:warning("Received unknown cast event: ~p", [Event]),

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -84,7 +84,8 @@ handle_cast({get_manifest, Bucket, Key}, #state{content_length=ContentLength,
     riak_moss_get_fsm:manifest(CallerPid, {ok, RiakObject}),
     {noreply, State};
 handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{caller_pid=CallerPid, block_size=BlockSize}=State) ->
-    FakeData = list_to_binary(["a" || _ <- lists:seq(1, BlockSize)]),
+    BigFakeData = list_to_binary(["a" || _ <- lists:seq(1, BlockSize - 4)]),
+    FakeData = <<ChunkSeq:4/integer, BigFakeData/binary>>,
     RiakObject = riakc_obj:new_obj(Bucket,riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq), [], [{dict:new(),FakeData}]),
     riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, {ok, RiakObject}),
     {noreply, State};

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -1,0 +1,108 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Module to write data to Riak.
+
+-module(riak_moss_reader).
+
+-behaviour(gen_server).
+
+-include("riak_moss.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-endif.
+
+%% API
+-export([start_link/1,
+         get_manifest/3,
+         get_chunk/5]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {content_length :: integer(),
+                caller_pid :: pid()}).
+
+-type state() :: #state{}.
+
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Start a `riak_moss_reader'.
+-spec start_link(list()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+    gen_server:start_link(?MODULE, Args, []).
+
+get_manifest(Pid, Bucket, Key) ->
+    gen_server:cast(Pid, {get_manifest, Bucket, Key}).
+
+get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
+    gen_server:cast(Pid, {get_chunk, Bucket, Key, UUID, ChunkSeq}).
+
+%% TODO:
+%% Add shutdown public function
+
+%% ===================================================================
+%% gen_server callbacks
+%% ===================================================================
+
+%% @doc Initialize the server.
+-spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
+init([CallerPid, ContentLength]) ->
+    %% Get a connection to riak
+    {ok, #state{content_length=ContentLength,
+                caller_pid=CallerPid}}.
+
+%% @doc Unused
+-spec handle_call(term(), {pid(), term()}, state()) ->
+                         {reply, ok, state()}.
+handle_call(_Msg, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({get_manifest, Bucket, Key}, #state{content_length=ContentLength,
+                                                caller_pid=CallerPid}=State) ->
+    Manifest = riak_moss_lfs_utils:new_manifest(Bucket, Key,
+                                                <<"uuid">>,
+                                                ContentLength,
+                                                <<"md5">>,
+                                                dict:new()),
+    RiakObject = riakc_obj:new_obj(Bucket,Key, [], [{dict:new(), term_to_binary(Manifest)}]),
+    riak_moss_get_fsm:manifest(CallerPid, RiakObject),
+    {noreply, State};
+handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{caller_pid=CallerPid, block_size=BlockSize}=State) ->
+    FakeData = list_to_binary(lists:seq(1, BlockSize)),
+    RiakObject = riakc_obj:new_obj(Bucket,riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq, [], [{dict:new(),FakeData}])),
+    riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, RiakObject),
+    {noreply, State};
+handle_cast(Event, State) ->
+    lager:warning("Received unknown cast event: ~p", [Event]),
+    {noreply, State}.
+
+%% @doc @TODO
+-spec handle_info(term(), state()) ->
+                         {noreply, state()}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @doc Unused.
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%% @doc Unused.
+-spec code_change(term(), state(), term()) ->
+                         {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -83,9 +83,8 @@ handle_cast({get_manifest, Bucket, Key}, #state{content_length=ContentLength,
     RiakObject = riakc_obj:new_obj(Bucket,Key, [], [{dict:new(), term_to_binary(Manifest)}]),
     riak_moss_get_fsm:manifest(CallerPid, {ok, RiakObject}),
     {noreply, State};
-handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{caller_pid=CallerPid, block_size=BlockSize}=State) ->
-    BigFakeData = list_to_binary(["a" || _ <- lists:seq(1, BlockSize - 4)]),
-    FakeData = <<ChunkSeq:4/integer, BigFakeData/binary>>,
+handle_cast({get_chunk, Bucket, Key, UUID, ChunkSeq}, #state{caller_pid=CallerPid, block_size=_BlockSize}=State) ->
+    FakeData = <<ChunkSeq:32/integer>>,
     RiakObject = riakc_obj:new_obj(Bucket,riak_moss_lfs_utils:block_name(Key, UUID, ChunkSeq), [], [{dict:new(),FakeData}]),
     riak_moss_get_fsm:chunk(CallerPid, ChunkSeq, {ok, RiakObject}),
     {noreply, State};

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -60,8 +60,8 @@ test(Iterations) ->
 %% ====================================================================
 
 prop_get_fsm() ->
-    ?FORALL(State, #state{content_length=moss_gen:bounded_content_length()},
-        ?FORALL(Cmds, commands(?MODULE, {start, State}),
+    ?FORALL(State, #state{content_length=?LET(X, moss_gen:bounded_content_length(), X * 10)},
+        ?FORALL(Cmds, eqc_statem:more_commands(10, commands(?MODULE, {start, State})),
                 begin
                     {H,{_F,_S},Res} = run_commands(?MODULE, Cmds),
                     ?WHENFAIL(io:format("history is ~p ~n", [[StateRecord#state{last_chunk=last_chunk_substitute} || {{_StateName, StateRecord}, _Results}<- H]]), equals(ok, Res))

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -1,0 +1,93 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Quickcheck test module for `riak_moss_get_fsm'.
+
+-module(riak_moss_get_fsm_eqc).
+
+-ifdef(EQC).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_fsm.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% Public API
+-compile(export_all).
+-export([test/0, test/1]).
+
+%% eqc_fsm callbacks
+-export([initial_state/0,
+         initial_state_data/0,
+         next_state_data/5,
+         precondition/4,
+         postcondition/5]).
+
+%% eqc property
+-export([prop_get_fsm/0]).
+
+%% States
+-export([state_name/1]).
+
+%% Helpers
+-export([]).
+
+-define(TEST_ITERATIONS, 500).
+
+-record(state, {}).
+
+%% ====================================================================
+%% Public API
+%% ====================================================================
+
+test() ->
+    test(?TEST_ITERATIONS).
+
+test(Iterations) ->
+    eqc:quickcheck(eqc:numtests(Iterations, prop_get_fsm())).
+
+%% ====================================================================
+%% eqc property
+%% ====================================================================
+
+prop_get_fsm() ->
+    ?FORALL(Cmds, commands(?MODULE),
+            begin
+                {H,{_F,S},Res} = run_commands(?MODULE, Cmds),
+                equals(ok, Res)
+            end).
+
+%%====================================================================
+%% Generators
+%%====================================================================
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%%====================================================================
+%% eqc_fsm callbacks
+%%====================================================================
+
+initial_state() ->
+    {stopped, true}.
+
+initial_state_data() ->
+    ok.
+
+next_state_data(_From, _To, S, _R, _C) ->
+    S.
+
+state_name(_S) ->
+    [].
+
+precondition(_From,_To,_S,_C) ->
+    true.
+
+postcondition(_From, _To, _S, _C, _R) ->
+    true.
+
+-endif.
+

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -29,7 +29,7 @@
 -export([prop_get_fsm/0]).
 
 %% States
--export([state_name/1]).
+-export([stopped/2]).
 
 %% Helpers
 -export([]).
@@ -80,7 +80,7 @@ initial_state_data() ->
 next_state_data(_From, _To, S, _R, _C) ->
     S.
 
-state_name(_S) ->
+stopped(_Args, _S) ->
     [].
 
 precondition(_From,_To,_S,_C) ->

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -20,7 +20,6 @@
 
 %% eqc_fsm callbacks
 -export([initial_state/0,
-         initial_state_data/0,
          next_state_data/5,
          precondition/4,
          postcondition/5]).
@@ -29,9 +28,12 @@
 -export([prop_get_fsm/0]).
 
 %% States
--export([start/1]).
+-export([start/1,
+         waiting_chunk/1,
+         stop/1]).
 
 %% Helpers
+%% TODO: export!
 -export([]).
 
 -define(TEST_ITERATIONS, 500).
@@ -52,28 +54,41 @@ test() ->
 test(Iterations) ->
     eqc:quickcheck(eqc:numtests(Iterations, prop_get_fsm())).
 
+
 %% ====================================================================
 %% eqc property
 %% ====================================================================
 
 prop_get_fsm() ->
-    ?FORALL(Cmds, commands(?MODULE),
-        #state{content_length=moss_gen:bounded_content_length()},
-            begin
-                {H,{_F,S},Res} = run_commands(?MODULE, Cmds),
-                equals(ok, Res)
-            end).
+    ?FORALL(State, #state{content_length=moss_gen:bounded_content_length()},
+        ?FORALL(Cmds, commands(?MODULE, {start, State}),
+                begin
+                    {H,{_F,_S},Res} = run_commands(?MODULE, Cmds),
+                    ?WHENFAIL(io:format("history is ~p ~n", [[StateRecord#state{last_chunk=last_chunk_substitute} || {{_StateName, StateRecord}, _Results}<- H]]), equals(ok, Res))
+                end)).
 
 %%====================================================================
 %% Generators
 %%====================================================================
+
+start_fsm(ContentLength, BlockSize) ->
+    {ok, FSMPid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
+    _Metadata = riak_moss_get_fsm:get_metadata(FSMPid),
+    riak_moss_get_fsm:continue(FSMPid),
+    FSMPid.
+
+get_chunk(FSMPid) ->
+    riak_moss_get_fsm:get_next_chunk(FSMPid).
+
+stop_fsm() -> ok.
 
 %%====================================================================
 %% Helpers
 %%====================================================================
 
 check_chunk(Counter, Chunk) ->
-    <<Counter:4/integer, _>> = Chunk.
+    <<NewCounter:32>> = Chunk,
+    Counter == NewCounter.
 
 %%====================================================================
 %% eqc_fsm callbacks
@@ -82,38 +97,36 @@ check_chunk(Counter, Chunk) ->
 initial_state() ->
     {start, true}.
 
-next_state_data(start, waiting_chunk, #state{content_length=ContentLength}=S, _R, _C) ->
+next_state_data(start, waiting_chunk, #state{content_length=ContentLength}=S, R, _C) ->
     BlockSize = riak_moss_lfs_utils:block_size(),
-    {ok, FSMPid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
     BlockCount = riak_moss_lfs_utils:block_count(ContentLength, BlockSize),
-    _Metadata = riak_moss_get_fsm:get_metadata(FSMPid),
-    riak_moss_get_fsm:continue(FSMPid),
-    S#state{fsm_pid=FSMPid, total_blocks=BlockCount};
-next_state_data(waiting_chunk, waiting_chunk, #state{fsm_pid=FSMPid}=S, _R, _C) ->
-    NextChunk = riak_moss_get_fsm:get_next_chunk(FSMPid),
-    S#state{last_chunk=NextChunk}.
+    S#state{total_blocks=(BlockCount-1), fsm_pid=R};
+next_state_data(waiting_chunk, waiting_chunk, #state{counter=Counter}=S, R, _C) ->
+    S#state{counter=Counter+1,last_chunk=R};
 next_state_data(_From, _To, S, _R, _C) ->
     S.
 
 start(#state{content_length=ContentLength}) ->
-    [{waiting_chunk, {call, ?MODULE, waiting_chunk, []}}].
+    [{waiting_chunk, {call, ?MODULE, start_fsm, [ContentLength, riak_moss_lfs_utils:block_size()]}}].
 
-waiting_chunk(S) ->
-    [{waiting_chunk, {call, ?MODULE, waiting_chunk, []}},
-     {stop, {call, ?MODULE, stop, []}}].
+waiting_chunk(#state{fsm_pid=Pid}) ->
+    [{waiting_chunk, {call, ?MODULE, get_chunk, [Pid]}},
+     {stop, {call, ?MODULE, stop_fsm, []}}].
 
-stop(S) ->
+stop(_S) ->
     [].
 
-precondition(waiting_chunk,stop,S#{counter=Counter, total_blocks=TotalBlocks,_C) ->
+precondition(waiting_chunk,stop,#state{counter=Counter, total_blocks=TotalBlocks},_C) ->
     Counter == TotalBlocks;
+precondition(waiting_chunk,waiting_chunk,#state{counter=Counter, total_blocks=TotalBlocks},_C) ->
+    Counter < TotalBlocks;
 precondition(_From,_To,_S,_C) ->
     true.
 
-postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={done, Chunk},total_blocks=Counter, _C, _R) ->
-    check_chunk(Counter, Chunk);
-postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={chunk, Chunk}, _C, _R) ->
-    check_chunk(Counter, Chunk);
+postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={done, Chunk},total_blocks=Counter}, _C, _R) ->
+    check_chunk((Counter-1), Chunk);
+postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={chunk, Chunk}}, _C, _R) ->
+    check_chunk((Counter-1), Chunk);
 postcondition(_From, _To, _S, _C, _R) ->
     true.
 

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -29,14 +29,18 @@
 -export([prop_get_fsm/0]).
 
 %% States
--export([stopped/2]).
+-export([start/1]).
 
 %% Helpers
 -export([]).
 
 -define(TEST_ITERATIONS, 500).
 
--record(state, {}).
+-record(state, {fsm_pid :: pid(), %% real pid}
+                content_length :: integer(), %% not symbolic
+                total_blocks :: integer(), %% not symbolic
+                last_chunk :: binary(), %% not symbolic
+                counter=0 :: integer()}). %% not symbolic
 
 %% ====================================================================
 %% Public API
@@ -54,6 +58,7 @@ test(Iterations) ->
 
 prop_get_fsm() ->
     ?FORALL(Cmds, commands(?MODULE),
+        #state{content_length=moss_gen:bounded_content_length()},
             begin
                 {H,{_F,S},Res} = run_commands(?MODULE, Cmds),
                 equals(ok, Res)
@@ -67,25 +72,48 @@ prop_get_fsm() ->
 %% Helpers
 %%====================================================================
 
+check_chunk(Counter, Chunk) ->
+    <<Counter:4/integer, _>> = Chunk.
+
 %%====================================================================
 %% eqc_fsm callbacks
 %%====================================================================
 
 initial_state() ->
-    {stopped, true}.
+    {start, true}.
 
-initial_state_data() ->
-    ok.
-
+next_state_data(start, waiting_chunk, #state{content_length=ContentLength}=S, _R, _C) ->
+    BlockSize = riak_moss_lfs_utils:block_size(),
+    {ok, FSMPid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
+    BlockCount = riak_moss_lfs_utils:block_count(ContentLength, BlockSize),
+    _Metadata = riak_moss_get_fsm:get_metadata(FSMPid),
+    riak_moss_get_fsm:continue(FSMPid),
+    S#state{fsm_pid=FSMPid, total_blocks=BlockCount};
+next_state_data(waiting_chunk, waiting_chunk, #state{fsm_pid=FSMPid}=S, _R, _C) ->
+    NextChunk = riak_moss_get_fsm:get_next_chunk(FSMPid),
+    S#state{last_chunk=NextChunk}.
 next_state_data(_From, _To, S, _R, _C) ->
     S.
 
-stopped(_Args, _S) ->
+start(#state{content_length=ContentLength}) ->
+    [{waiting_chunk, {call, ?MODULE, waiting_chunk, []}}].
+
+waiting_chunk(S) ->
+    [{waiting_chunk, {call, ?MODULE, waiting_chunk, []}},
+     {stop, {call, ?MODULE, stop, []}}].
+
+stop(S) ->
     [].
 
+precondition(waiting_chunk,stop,S#{counter=Counter, total_blocks=TotalBlocks,_C) ->
+    Counter == TotalBlocks;
 precondition(_From,_To,_S,_C) ->
     true.
 
+postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={done, Chunk},total_blocks=Counter, _C, _R) ->
+    check_chunk(Counter, Chunk);
+postcondition(waiting_chunk, waiting_chunk, #state{counter=Counter,last_chunk={chunk, Chunk}, _C, _R) ->
+    check_chunk(Counter, Chunk);
 postcondition(_From, _To, _S, _C, _R) ->
     true.
 

--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -9,7 +9,11 @@
 -include_lib("eunit/include/eunit.hrl").
 
 setup() ->
+%    TestNode = list_to_atom("testnode" ++ integer_to_list(element(3, now())) ++
+%                                "@localhost"),
+%    {ok, _} = net_kernel:start([TestNode, longnames]),
     application:load(sasl),
+    %application:start(riak_moss),
     application:load(riak_moss),
     application:set_env(sasl, sasl_error_logger, {file, "moss_get_fsm_sasl.log"}),
     error_logger:tty(false),
@@ -20,7 +24,8 @@ setup() ->
 %% Implement this
 teardown(_) ->
     application:stop(riak_moss),
-    application:stop(sasl).
+    application:stop(sasl),
+    net_kernel:stop().
 
 get_fsm_test_() ->
     {setup,

--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -46,16 +46,17 @@ calc_block_size(ContentLength, NumBlocks) ->
 
 test_n_chunks_builder(N) ->
     fun () ->
-        BlockSize = calc_block_size(10000, N),
+        ContentLength = 10000,
+        BlockSize = calc_block_size(ContentLength, N),
         application:set_env(riak_moss, lfs_block_size, BlockSize),
-        {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>),
+        {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
         ?assert(dict:is_key("content-length", riak_moss_get_fsm:get_metadata(Pid))),
         riak_moss_get_fsm:continue(Pid),
         expect_n_chunks(Pid, N)
     end.
 
 receives_metadata() ->
-    {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>),
+    {ok, Pid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, 100, 10),
     ?assert(dict:is_key("content-length", riak_moss_get_fsm:get_metadata(Pid))),
     riak_moss_get_fsm:stop(Pid).
 

--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -13,7 +13,6 @@ setup() ->
 %                                "@localhost"),
 %    {ok, _} = net_kernel:start([TestNode, longnames]),
     application:load(sasl),
-    %application:start(riak_moss),
     application:load(riak_moss),
     application:set_env(sasl, sasl_error_logger, {file, "moss_get_fsm_sasl.log"}),
     error_logger:tty(false),

--- a/test/riak_moss_lfs_utils_eqc.erl
+++ b/test/riak_moss_lfs_utils_eqc.erl
@@ -76,7 +76,7 @@ prop_manifest_manipulation() ->
                                                         Md5,
                                                         MD),
 
-            Blocks = sets:to_list(riak_moss_lfs_utils:initial_blocks(CLength)),
+            Blocks = riak_moss_lfs_utils:initial_blocks(CLength),
             %% TODO: maybe we should shuffle blocks?
             FoldFun = fun (Chunk, Mani) -> riak_moss_lfs_utils:remove_block(Mani, Chunk) end,
             EmptyMani = lists:foldl(FoldFun, Manifest, Blocks),


### PR DESCRIPTION
This branch has a few more changes than I would've liked, but I guess that's what a week of QuickCheck does. The biggest changes this branch has are:
- refactor the GET FSM to use a "reader" gen_server instead of spawning procs itself
- create a test reader that doesn't connect to Riak
- clean up process dependencies so that processes get shutdown nicely when they're deps or creator go away
- add an EQC test for the GET FSM. This test has some known limitations, namely that the number of commands generated doesn't always drive the GET FSM through all of its phases. ie, it doesn't ask for the maximum number of blocks. I intend to fix this in the future by changing the test to be a "regular" EQC test instead of an `eqc_fsm` test.
## Tests
- all of these tests with `make test` should pass
- `prototype_parity.py` tests should also pass
