### PR TITLE
Use file creation time instead of `now` for last-modified time when listing files.

### DIFF
--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -41,6 +41,7 @@
          still_waiting/1,
          content_md5/1,
          content_length/1,
+         created/1,
          is_active/1]).
 
 -export_type([lfs_manifest/0]).
@@ -54,7 +55,7 @@
     content_length :: integer(),
     content_md5 :: term(),
     metadata :: dict(),
-    created=httpd_util:rfc1123_date() :: term(), % @TODO Maybe change to iso8601
+    created=riak_moss_wm_utils:iso_8601_datetime(),
     finished :: term(),
     active=false :: boolean(),
     blocks_remaining = sets:new()}).
@@ -227,6 +228,10 @@ content_md5(#lfs_manifest{content_md5=ContentMD5}) ->
 -spec content_length(lfs_manifest()) -> integer().
 content_length(#lfs_manifest{content_length=CL}) ->
     CL.
+
+-spec created(lfs_manifest()) -> string().
+created(#lfs_manifest{created=Created}) ->
+    Created.
 
 -spec is_active(lfs_manifest()) -> boolean().
 is_active(#lfs_manifest{active=A}) ->

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -77,7 +77,6 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
     %% associated with each key is an `lfs_manifest' or not.
     Contents = [begin
                     KeyString = binary_to_list(Key),
-                    LastModified = riak_moss_wm_utils:iso_8601_datetime(),
                     case ObjResp of
                         {ok, Obj} ->
                             Manifest = binary_to_term(riakc_obj:get_value(Obj)),
@@ -85,6 +84,9 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
                                 true ->
                                     Size = integer_to_list(
                                              riak_moss_lfs_utils:content_length(Manifest)),
+                                    LastModified =
+                                        riak_moss_wm_utils:to_iso_8601(
+                                          riak_moss_lfs_utils:created(Manifest)),
                                     ETag = "\"" ++ riak_moss_utils:binary_to_hexlist(
                                                      riak_moss_lfs_utils:content_md5(Manifest))
                                         ++ "\"",


### PR DESCRIPTION
- Use file creation time as value for last-modified element in object
  listing responses.
- Use ISO 8601 time format in creation field of file manifest records.
