### PR TITLE
Fix handling of HEAD requests when the object does not exist.

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -76,6 +76,11 @@ forbidden('GET', RD, Ctx=#key_context{doc_metadata=undefined}) ->
     forbidden('GET', RD, NewCtx);
 forbidden('GET', RD, Ctx=#key_context{doc_metadata=notfound}) ->
     {{halt, 404}, RD, Ctx};
+forbidden('HEAD', RD, Ctx=#key_context{doc_metadata=undefined}) ->
+    NewCtx = riak_moss_wm_utils:ensure_doc(Ctx),
+    forbidden('HEAD', RD, NewCtx);
+forbidden('HEAD', RD, Ctx=#key_context{doc_metadata=notfound}) ->
+    {{halt, 404}, RD, Ctx};
 forbidden(_, RD, Ctx) ->
     {false, RD, Ctx}.
 


### PR DESCRIPTION
`HEAD` requests for non-existent objects caused a 500 error. This change fixes that so that a proper 404 error is returned instead. This change affects the usage the `s3cmd` subcommand `info`.
