### PR TITLE
Fix bucket creation when a content-type header with parameters is used.

### DIFF
--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -80,9 +80,9 @@ content_types_accepted(RD, Ctx) ->
         undefined ->
             {[{"application/octet-stream", accept_body}], RD, Ctx};
         CType ->
-            {[{CType, accept_body}], RD, Ctx}
+            {Media, _Params} = mochiweb_util:parse_header(CType),
+            {[{Media, accept_body}], RD, Ctx}
     end.
-
 
 -spec to_xml(term(), term()) ->
     {iolist(), term(), term()}.

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -173,7 +173,7 @@ content_types_accepted(RD, Ctx) ->
         %% This was shamelessly ripped out of
         %% https://github.com/basho/riak_kv/blob/0d91ca641a309f2962a216daa0cee869c82ffe26/src/riak_kv_wm_object.erl#L492
         CType ->
-            Media = hd(string:tokens(CType, ";")),
+            {Media, _Params} = mochiweb_util:parse_header(CType),
             case string:tokens(Media, "/") of
                 [_Type, _Subtype] ->
                     %% accept whatever the user says


### PR DESCRIPTION
The webmachine resource for handling bucket creation requests was not separating the media type from the parameters that were included in the _content-type_ header. This was causing the media type to be unrecognized and resulting in `415 Unsupported Media Type` errors being returned.
