### PR TITLE
Change user record structure and lay ground work for ACLs

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -1,6 +1,8 @@
 
 -record(moss_user, {
           name :: string(),
+          display_name :: string(),
+          email :: string(),
           key_id :: string(),
           key_secret :: string(),
           canonical_id :: string(),

--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -1,17 +1,23 @@
-
 -record(moss_user, {
+          name :: string(),
+          key_id :: string(),
+          key_secret :: string(),
+          buckets = []}).
+
+-record(moss_user_v1, {
           name :: string(),
           display_name :: string(),
           email :: string(),
           key_id :: string(),
           key_secret :: string(),
-          canonical_id :: string(),
-          buckets = []}).
--type moss_user() :: #moss_user{}.
+          canonical_id :: string()}).
+-type moss_user() :: #moss_user_v1{}.
 
+-type bucket_acl() :: string().
 -record(moss_bucket, {
           name :: string(),
-          creation_date :: term()}).
+          creation_date :: term(),
+          acl :: bucket_acl()}).
 -type moss_bucket() :: #moss_bucket{}.
 
 -record(context, {auth_bypass :: atom(),
@@ -25,6 +31,16 @@
                       key :: list(),
                       size :: non_neg_integer()}).
 
+-type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
+-type acl_perms() :: [acl_perm()].
+-type acl_grant() :: {{string(), string()}, acl_perms()}.
+-record(acl_v1, {owner={"", ""} :: {string(), string()},
+                 grants=[] :: [acl_grant()]}).
+-type acl_v1() :: #acl_v1{}.
+
+-define(ACL, #acl_v1).
+-define(MOSS_USER, #moss_user_v1).
 -define(USER_BUCKET, <<"moss.users">>).
 -define(MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
 -define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
+-define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").

--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -3,6 +3,7 @@
           name :: string(),
           key_id :: string(),
           key_secret :: string(),
+          canonical_id :: string(),
           buckets = []}).
 -type moss_user() :: #moss_user{}.
 

--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -10,7 +10,8 @@
           email :: string(),
           key_id :: string(),
           key_secret :: string(),
-          canonical_id :: string()}).
+          canonical_id :: string(),
+          buckets=[] :: [moss_bucket()]}).
 -type moss_user() :: #moss_user_v1{}.
 
 -type bucket_acl() :: string().

--- a/src/riak_moss_acl_utils.erl
+++ b/src/riak_moss_acl_utils.erl
@@ -1,0 +1,254 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc ACL utility functions
+
+-module(riak_moss_acl_utils).
+
+-include("riak_moss.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-endif.
+
+%% Public API
+-export([acl/3,
+         acl_from_xml/1,
+         acl_to_xml/1,
+         default_acl/2
+        ]).
+
+-type xmlElement() :: #xmlElement{}.
+-type xmlText() :: #xmlText{}.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Construct an acl. The structure is the same for buckets
+%% and objects.
+-spec acl(string(), string(), [acl_grant()]) -> acl_v1().
+acl(DisplayName, CanonicalId, Grants) ->
+    OwnerData = {DisplayName, CanonicalId},
+    ?ACL{owner=OwnerData,
+         grants=Grants}.
+
+%% @doc Construct a default acl. The structure is the same for buckets
+%% and objects.
+-spec default_acl(string(), string()) -> acl_v1().
+default_acl(DisplayName, CanonicalId) ->
+    acl(DisplayName,
+        CanonicalId,
+        [{{DisplayName, CanonicalId}, ['FULL_CONTROL']}]).
+
+%% @doc Convert an XML document representing an ACL into
+%% an internal representation.
+-spec acl_from_xml(string()) -> acl_v1().
+acl_from_xml(Xml) ->
+    {ParsedData, _Rest} = xmerl_scan:string(Xml, []),
+    process_acl_contents(ParsedData#xmlElement.content, ?ACL{}).
+
+%% @doc Convert an internal representation of an ACL
+%% into XML.
+-spec acl_to_xml(acl_v1()) -> string().
+acl_to_xml(Acl) ->
+    {OwnerName, OwnerId} = Acl?ACL.owner,
+    XmlDoc =
+        [{'AccessControlPolicy',
+          [
+           {'Owner',
+            [
+             {'ID', [OwnerId]},
+             {'DisplayName', [OwnerName]}
+            ]},
+           {'AccessControlList', grants_xml(Acl?ACL.grants)}
+          ]}],
+    unicode:characters_to_list(
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @doc Assemble the xml for the set of grantees for an acl.
+-spec grants_xml([acl_grant()]) -> term().
+grants_xml(Grantees) ->
+    grants_xml(Grantees, []).
+
+%% @doc Assemble the xml for the set of grantees for an acl.
+-spec grants_xml([acl_grant()], []) -> term().
+grants_xml([], Acc) ->
+    lists:flatten(Acc);
+grants_xml([HeadGrantee | RestGrantees], Acc) ->
+    {{GranteeName, GranteeId}, Perms} = HeadGrantee,
+    GranteeXml = [grant_xml(GranteeName, GranteeId, Perm) || Perm <- Perms],
+    grants_xml(RestGrantees, [GranteeXml | Acc]).
+
+%% @doc Assemble the xml for a single grantee for an acl.
+-spec grant_xml(string(), string(), acl_perm()) -> term().
+grant_xml(DisplayName, CanonicalId, Permission) ->
+    {'Grant',
+     [
+      {'Grantee',
+       [
+        {'ID', [CanonicalId]},
+        {'DisplayName', [DisplayName]}
+       ]},
+      {'Permission', [atom_to_list(Permission)]}
+     ]}.
+
+%% @doc Process the top-level elements of the
+-spec process_acl_contents([xmlElement()], acl_v1()) -> acl_v1().
+process_acl_contents([], Acl) ->
+    Acl;
+process_acl_contents([HeadElement | RestElements], Acl) ->
+    Content = HeadElement#xmlElement.content,
+    lager:debug("Element name: ~p", [HeadElement#xmlElement.name]),
+    ElementName = HeadElement#xmlElement.name,
+    case ElementName of
+        'Owner' ->
+            UpdAcl = process_owner(Content, Acl);
+        'AccessControlList' ->
+            UpdAcl = process_grants(Content, Acl);
+        _ ->
+            lager:debug("Encountered unexpected element: ~p", [ElementName]),
+            UpdAcl = Acl
+    end,
+    process_acl_contents(RestElements, UpdAcl).
+
+%% @doc Process an XML element containing acl owner information.
+-spec process_owner([xmlElement()], acl_v1()) -> acl_v1().
+process_owner([], Acl) ->
+    Acl;
+process_owner([HeadElement | RestElements], Acl) ->
+    Owner = Acl?ACL.owner,
+    [Content] = HeadElement#xmlElement.content,
+    Value = Content#xmlText.value,
+    ElementName = HeadElement#xmlElement.name,
+    case ElementName of
+        'ID' ->
+            lager:debug("Owner ID value: ~p", [Value]),
+            {OwnerName, _} = Owner,
+            UpdOwner = {OwnerName, Value};
+        'DisplayName' ->
+            lager:debug("Owner Name content: ~p", [Value]),
+            {_, OwnerId} = Owner,
+            UpdOwner = {Value, OwnerId};
+        _ ->
+            lager:debug("Encountered unexpected element: ~p", [ElementName]),
+            UpdOwner = Owner
+    end,
+    process_owner(RestElements, Acl?ACL{owner=UpdOwner}).
+
+%% @doc Process an XML element containing the grants for the acl.
+-spec process_grants([xmlElement()], acl_v1()) -> acl_v1().
+process_grants([], Acl) ->
+    Acl;
+process_grants([HeadElement | RestElements], Acl) ->
+    Content = HeadElement#xmlElement.content,
+    ElementName = HeadElement#xmlElement.name,
+    case ElementName of
+        'Grant' ->
+            Grant = process_grant(Content, {{"", ""}, []}),
+            UpdAcl = Acl?ACL{grants=[Grant | Acl?ACL.grants]};
+        _ ->
+            lager:debug("Encountered unexpected grants element: ~p", [ElementName]),
+            UpdAcl = Acl
+    end,
+    process_grants(RestElements, UpdAcl).
+
+%% @doc Process an XML element containing the grants for the acl.
+-spec process_grant([xmlElement()], acl_grant()) -> acl_grant().
+process_grant([], Grant) ->
+    Grant;
+process_grant([HeadElement | RestElements], Grant) ->
+    Content = HeadElement#xmlElement.content,
+    ElementName = HeadElement#xmlElement.name,
+    lager:debug("ElementName: ~p", [ElementName]),
+    lager:debug("Content: ~p", [Content]),
+    case ElementName of
+        'Grantee' ->
+            UpdGrant = process_grantee(Content, Grant);
+        'Permission' ->
+            UpdGrant = process_permission(Content, Grant);
+        _ ->
+            lager:debug("Encountered unexpected grant element: ~p", [ElementName]),
+            UpdGrant = Grant
+    end,
+    process_grant(RestElements, UpdGrant).
+
+%% @doc Process an XML element containing information about
+%% an ACL permission grantee.
+-spec process_grantee([xmlElement()], acl_grant()) -> acl_grant().
+process_grantee([], Grant) ->
+    Grant;
+process_grantee([HeadElement | RestElements], Grant) ->
+    [Content] = HeadElement#xmlElement.content,
+    Value = Content#xmlText.value,
+    ElementName = HeadElement#xmlElement.name,
+    case ElementName of
+        'ID' ->
+            lager:debug("ID value: ~p", [Value]),
+            {{Name, _}, Perms} = Grant,
+            UpdGrant = {{Name, Value}, Perms};
+        'DisplayName' ->
+            lager:debug("Name value: ~p", [Value]),
+            {{_, Id}, Perms} = Grant,
+            UpdGrant = {{Value, Id}, Perms};
+        _ ->
+            UpdGrant = Grant
+    end,
+    process_grantee(RestElements, UpdGrant).
+
+%% @doc Process an XML element containing information about
+%% an ACL permission.
+-spec process_permission(xmlText(), acl_grant()) -> acl_grant().
+process_permission([Content], Grant) ->
+    Value = list_to_existing_atom(Content#xmlText.value),
+    {Grantee, Perms} = Grant,
+    case lists:member(Value, Perms) of
+        true ->
+            UpdPerms = Perms;
+        false ->
+            UpdPerms = [Value | Perms]
+    end,
+    {Grantee, UpdPerms}.
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+%% @TODO Use eqc to do some more interesting case explorations.
+
+default_acl_test() ->
+    ExpectedXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><AccessControlPolicy><Owner><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Owner><AccessControlList><Grant><Grantee><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>",
+    DefaultAcl = default_acl("tester1", "TESTID1"),
+    ?assertEqual({acl_v1,{"tester1","TESTID1"},
+                  [{{"tester1","TESTID1"},['FULL_CONTROL']}]}, DefaultAcl),
+    ?assertEqual(ExpectedXml, acl_to_xml(DefaultAcl)).
+
+acl_from_xml_test() ->
+    application:start(lager),
+    Xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><AccessControlPolicy><Owner><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Owner><AccessControlList><Grant><Grantee><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>",
+    DefaultAcl = default_acl("tester1", "TESTID1"),
+    ?assertEqual(DefaultAcl, acl_from_xml(Xml)).
+
+acl_to_xml_test() ->
+    Xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><AccessControlPolicy><Owner><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Owner><AccessControlList><Grant><Grantee><ID>TESTID2</ID><DisplayName>tester2</DisplayName></Grantee><Permission>WRITE</Permission></Grant><Grant><Grantee><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>",
+    Acl = acl("tester1", "TESTID1", [{{"tester1", "TESTID1"}, ['READ']},
+                                     {{"tester2", "TESTID2"}, ['WRITE']}]),
+    ?assertEqual(Xml, acl_to_xml(Acl)).
+
+roundtrip_test() ->
+    Xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><AccessControlPolicy><Owner><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Owner><AccessControlList><Grant><Grantee><ID>TESTID1</ID><DisplayName>tester1</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>",
+    ?assertEqual(Xml, acl_to_xml(acl_from_xml(Xml))).
+
+-endif.

--- a/src/riak_moss_blockall_auth.erl
+++ b/src/riak_moss_blockall_auth.erl
@@ -12,9 +12,6 @@
 
 -export([authenticate/2]).
 
--spec authenticate(term(), [string()]) -> {ok, #moss_user{}}
-                                              | {ok, unknown}
-                                              | {error, atom()}.
+-spec authenticate(term(), [string()]) -> {error, atom()}.
 authenticate(_RD, [Reason]) ->
     {error, Reason}.
-

--- a/src/riak_moss_passthru_auth.erl
+++ b/src/riak_moss_passthru_auth.erl
@@ -12,7 +12,7 @@
 
 -export([authenticate/2]).
 
--spec authenticate(term(), [string()]) -> {ok, #moss_user{}}
+-spec authenticate(term(), [string()]) -> {ok, ?MOSS_USER{}}
                                               | {ok, unknown}
                                               | {error, atom()}.
 authenticate(_RD, []) ->

--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -20,7 +20,7 @@
 %% Public API
 %% ===================================================================
 
--spec authenticate(term(), [string()]) -> {ok, #moss_user{}}
+-spec authenticate(term(), [string()]) -> {ok, ?MOSS_USER{}}
                                               | {ok, unknown}
                                               | {error, atom()}.
 authenticate(RD, [KeyID, Signature]) ->
@@ -28,18 +28,19 @@ authenticate(RD, [KeyID, Signature]) ->
     case riak_moss_utils:get_user(KeyID) of
         {ok, User} ->
             CalculatedSignature =
-                calculate_signature(User#moss_user.key_secret, RD),
+                calculate_signature(User?MOSS_USER.key_secret, RD),
             case check_auth(Signature, CalculatedSignature) of
                 true ->
-                    case bucket_auth(User,
-                                     wrq:method(RD),
-                                     wrq:path_info(bucket, RD),
-                                     wrq:path_tokens(RD)) of
-                        true ->
-                            {ok, User};
-                        false ->
-                            {error, invalid_authentication}
-                    end;
+                    {ok, User};
+                    %% case bucket_auth(User,
+                    %%                  wrq:method(RD),
+                    %%                  wrq:path_info(bucket, RD),
+                    %%                  wrq:path_tokens(RD)) of
+                    %%     true ->
+                            %% {ok, User};
+                    %%     false ->
+                    %%         {error, invalid_authentication}
+                    %% end;
                 _ ->
                     {error, invalid_authentication}
             end;
@@ -192,17 +193,17 @@ canonicalize_resource(RD) ->
     end.
 -endif.
 
-bucket_auth(_User=#moss_user{}, _, undefined, []) ->
-    true;
-bucket_auth(_User=#moss_user{}, 'PUT', _BucketName, []) ->
-    true;
-bucket_auth(User=#moss_user{}, _, BucketName, _KeyName) ->
-    bucket_owner(User, BucketName).
+%% bucket_auth(_User=#moss_user{}, _, undefined, []) ->
+%%     true;
+%% bucket_auth(_User=#moss_user{}, 'PUT', _BucketName, []) ->
+%%     true;
+%% bucket_auth(User=#moss_user{}, _, BucketName, _KeyName) ->
+%%     bucket_owner(User, BucketName).
 
-bucket_owner(User=#moss_user{}, BucketName) ->
-    lists:member(BucketName,
-                 [B#moss_bucket.name
-                  || B <- riak_moss_utils:get_buckets(User)]).
+%% bucket_owner(User=#moss_user{}, BucketName) ->
+%%     lists:member(BucketName,
+%%                  [B#moss_bucket.name
+%%                   || B <- riak_moss_utils:get_buckets(User)]).
 
 
 

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -14,6 +14,8 @@
 
 error_message(invalid_access_key_id) ->
     "The AWS Access Key Id you provided does not exist in our records.";
+error_message(invalid_email_address) ->
+    "The email address you provided is not a valid.";
 error_message(access_denied) ->
     "Access Denied";
 error_message(bucket_not_empty) ->
@@ -29,6 +31,7 @@ error_message({riak_connect_failed, Reason}) ->
 
 
 error_code(invalid_access_key_id) -> 'InvalidAccessKeyId';
+error_code(invalid_email_address) -> 'InvalidEmailAddress';
 error_code(access_denied) -> 'AccessDenied';
 error_code(bucket_not_empty) -> 'BucketNotEmpty';
 error_code(bucket_already_exists) -> 'BucketAlreadyExists';
@@ -37,6 +40,8 @@ error_code(no_such_bucket) -> 'NoSuchBucket';
 error_code({riak_connect_failed, _}) -> 'RiakConnectFailed'.
 
 
+status_code(invalid_access_key_id) -> 403;
+status_code(invalid_email_address) -> 400;
 status_code(access_denied) ->  403;
 status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -9,7 +9,7 @@
          error_response/5,
          list_bucket_response/5,
          list_all_my_buckets_response/3]).
--define(xml_prolog, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").
+
 -include("riak_moss.hrl").
 
 error_message(invalid_access_key_id) ->
@@ -46,7 +46,6 @@ status_code(access_denied) ->  403;
 status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;
 status_code(entity_too_large) -> 400;
-status_code(invalid_access_key_id) -> 403;
 status_code(no_such_bucket) -> 404;
 status_code({riak_connect_failed, _}) -> 503.
 
@@ -60,9 +59,9 @@ api_error(Error, ReqData, Ctx) when is_atom(Error) ->
 
 error_response(StatusCode, Code, Message, RD, Ctx) ->
     XmlDoc = [{'Error', [{'Code', [Code]},
-                        {'Message', [Message]},
-                        {'Resource', [wrq:path(RD)]},
-                        {'RequestId', [""]}]}],
+                         {'Message', [Message]},
+                         {'Resource', [wrq:path(RD)]},
+                         {'RequestId', [""]}]}],
     respond(StatusCode, export_xml(XmlDoc), RD, Ctx).
 
 
@@ -111,20 +110,20 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
                 end
                 || {Key, ObjResp} <- KeyObjPairs],
     BucketProps = [{'Name', [Bucket#moss_bucket.name]},
-                    {'Prefix', []},
-                    {'Marker', []},
-                    {'MaxKeys', ["1000"]},
-                    {'Delimiter', ["/"]},
-                    {'IsTruncated', ["false"]}],
+                   {'Prefix', []},
+                   {'Marker', []},
+                   {'MaxKeys', ["1000"]},
+                   {'Delimiter', ["/"]},
+                   {'IsTruncated', ["false"]}],
     XmlDoc = [{'ListBucketResult', BucketProps++
                    lists:filter(fun(E) -> E /= undefined end,
                                 Contents)}],
     respond(200, export_xml(XmlDoc), RD, Ctx).
 
-user_to_xml_owner(#moss_user{key_id=KeyId, name=Name}) ->
-    {'Owner', [{'ID', [KeyId]},
+user_to_xml_owner(?MOSS_USER{canonical_id=CanonicalId, display_name=Name}) ->
+    {'Owner', [{'ID', [CanonicalId]},
                {'DisplayName', [Name]}]}.
 
 export_xml(XmlDoc) ->
     unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?xml_prolog}])).
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -12,7 +12,7 @@
 -export([binary_to_hexlist/1,
          close_riak_connection/1,
          create_bucket/2,
-         create_user/1,
+         create_user/2,
          delete_bucket/2,
          delete_object/2,
          from_bucket_name/1,
@@ -95,21 +95,30 @@ create_bucket(KeyID, BucketName) ->
     end.
 
 %% @doc Create a new MOSS user
--spec create_user(string()) -> {ok, moss_user()}.
-create_user(UserName) ->
-    case riak_connection() of
-        {ok, RiakPid} ->
-            {KeyID, Secret} = generate_access_creds(UserName),
-            CanonicalID = generate_canonical_id(KeyID, Secret),
-            User = #moss_user{name=UserName,
-                              key_id=KeyID,
-                              key_secret=Secret,
-                              canonical_id=CanonicalID},
-            save_user(User, RiakPid),
-            close_riak_connection(RiakPid),
-            {ok, User};
-        {error, Reason} ->
-            {error, {riak_connect_failed, Reason}}
+-spec create_user(string(), string()) -> {ok, moss_user()}.
+create_user(UserName, Email) ->
+    %% Validate the email address
+    case validate_email(Email) of
+        ok ->
+            case riak_connection() of
+                {ok, RiakPid} ->
+                    {KeyID, Secret} = generate_access_creds(UserName),
+                    CanonicalID = generate_canonical_id(KeyID, Secret),
+                    DisplayName = display_name(Email),
+                    User = #moss_user{name=UserName,
+                                      display_name=DisplayName,
+                                      email=Email,
+                                      key_id=KeyID,
+                                      key_secret=Secret,
+                                      canonical_id=CanonicalID},
+                    save_user(User, RiakPid),
+                    close_riak_connection(RiakPid),
+                    {ok, User};
+                {error, Reason} ->
+                    {error, {riak_connect_failed, Reason}}
+            end;
+        {error, Reason1} ->
+            {error, Reason1}
     end.
 
 %% @doc Delete a bucket
@@ -355,6 +364,12 @@ bucket_exists(Buckets, CheckBucket) ->
             true
     end.
 
+%% @doc Strip off the user name portion of an email address
+-spec display_name(string()) -> string().
+display_name(Email) ->
+    Index = string:chr(Email, $@),
+    string:sub_string(Email, 1, Index-1).
+
 %% @doc Generate a new set of access credentials for user.
 -spec generate_access_creds(string()) -> {binary(), binary()}.
 generate_access_creds(UserName) ->
@@ -423,3 +438,14 @@ save_user(User, RiakPid) ->
     %% @TODO Error handling
     ok = riakc_pb_socket:put(RiakPid, UserObj),
     ok.
+
+%% @doc Validate an email address.
+-spec validate_email(string()) -> ok | {error, term()}.
+validate_email(EmailAddr) ->
+    %% @TODO More robust email address validation
+    case string:chr(EmailAddr, $@) of
+        0 ->
+            {error, invalid_email_address};
+        _ ->
+            ok
+    end.

--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -33,13 +33,9 @@ allowed_methods(RD, Ctx) ->
 process_post(RD, Ctx) ->
     Body = wrq:req_body(RD),
     ParsedBody = mochiweb_util:parse_qs(binary_to_list(Body)),
-    %% TODO:
-    %% we should halt the request
-    %% if this pattern doesn't match
-    %% and return 400
-    UserName = proplists:get_value("name", ParsedBody),
-
-    case riak_moss_utils:create_user(UserName) of
+    UserName = proplists:get_value("name", ParsedBody, ""),
+    Email= proplists:get_value("email", ParsedBody, ""),
+    case riak_moss_utils:create_user(UserName, Email) of
         {ok, UserRecord} ->
             PropListUser = riak_moss_wm_utils:user_record_to_proplist(UserRecord),
             CTypeWritten = wrq:set_resp_header("Content-Type", "application/json", RD),
@@ -50,4 +46,3 @@ process_post(RD, Ctx) ->
         {error, Reason} ->
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
     end.
-

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -84,10 +84,12 @@ streaming_get(FsmPid) ->
 user_record_to_proplist(#moss_user{name=Name,
                                    key_id=KeyID,
                                    key_secret=KeySecret,
+                                   canonical_id=CanonicalID,
                                    buckets = Buckets}) ->
     [{<<"name">>, list_to_binary(Name)},
      {<<"key_id">>, list_to_binary(KeyID)},
      {<<"key_secret">>, list_to_binary(KeySecret)},
+     {<<"id">>, list_to_binary(CanonicalID)},
      {<<"buckets">>, Buckets}].
 
 %% @doc Get an ISO 8601 formatted timestamp representing

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -81,15 +81,25 @@ streaming_get(FsmPid) ->
 %%      into a property list, likely
 %%      for json encoding
 -spec user_record_to_proplist(term()) -> list().
+user_record_to_proplist(?MOSS_USER{email=Email,
+                                   display_name=DisplayName,
+                                   name=Name,
+                                   key_id=KeyID,
+                                   key_secret=KeySecret,
+                                   canonical_id=CanonicalID}) ->
+    [{<<"email">>, list_to_binary(Email)},
+     {<<"display_name">>, list_to_binary(DisplayName)},
+     {<<"name">>, list_to_binary(Name)},
+     {<<"key_id">>, list_to_binary(KeyID)},
+     {<<"key_secret">>, list_to_binary(KeySecret)},
+     {<<"id">>, list_to_binary(CanonicalID)}];
 user_record_to_proplist(#moss_user{name=Name,
                                    key_id=KeyID,
                                    key_secret=KeySecret,
-                                   canonical_id=CanonicalID,
                                    buckets = Buckets}) ->
     [{<<"name">>, list_to_binary(Name)},
      {<<"key_id">>, list_to_binary(KeyID)},
      {<<"key_secret">>, list_to_binary(KeySecret)},
-     {<<"id">>, list_to_binary(CanonicalID)},
      {<<"buckets">>, Buckets}].
 
 %% @doc Get an ISO 8601 formatted timestamp representing

--- a/test/riak_moss_utils_test.erl
+++ b/test/riak_moss_utils_test.erl
@@ -62,7 +62,8 @@ riak_moss_utils_test_() ->
 %%      the moss_user record
 name_matches() ->
     Name = "fooser",
-    {ok, User} = riak_moss_utils:create_user(Name),
+    Email = "fooser@fooser.com",
+    {ok, User} = riak_moss_utils:create_user(Name, Email),
     {"name matches test",
      fun() ->
              [
@@ -77,8 +78,9 @@ name_matches() ->
 %%      one owned by that user
 bucket_appears() ->
     Name = "fooser",
+    Email = "fooser@fooser.com",
     BucketName = "fooser-bucket",
-    {ok, User} = riak_moss_utils:create_user(Name),
+    {ok, User} = riak_moss_utils:create_user(Name, Email),
     KeyID = User#moss_user.key_id,
     riak_moss_utils:create_bucket(KeyID, BucketName),
     {ok, UserAfter} = riak_moss_utils:get_user(KeyID),
@@ -102,9 +104,10 @@ key_appears() ->
     %% key in as a list instead
     %% of a binary?
     Name = "fooser",
+    Email = "fooser@fooser.com",
     BucketName = "key_appears",
     KeyName = "testkey",
-    {ok, User} = riak_moss_utils:create_user(Name),
+    {ok, User} = riak_moss_utils:create_user(Name, Email),
     KeyID = User#moss_user.key_id,
     ok = riak_moss_utils:create_bucket(KeyID, BucketName),
     riak_moss_utils:put_object(BucketName, KeyName,
@@ -124,11 +127,12 @@ key_appears() ->
 %%      keeps the content-type on GET
 content_type_sticks() ->
     Name = "fooser",
+    Email = "fooser@fooser.com",
     BucketName = "content_type_sticks",
     KeyName = "testkey",
     CType = "x-foo/bar",
     Metadata = dict:from_list([{<<"content-type">>, CType}]),
-    {ok, User} = riak_moss_utils:create_user(Name),
+    {ok, User} = riak_moss_utils:create_user(Name, Email),
     KeyID = User#moss_user.key_id,
     ok = riak_moss_utils:create_bucket(KeyID, BucketName),
     riak_moss_utils:put_object(BucketName, KeyName,
@@ -147,10 +151,11 @@ content_type_sticks() ->
 %% EQC test
 keys_are_sorted() ->
     Name = "fooser",
+    Email = "fooser@fooser.com",
     BucketName = "keys_are_sorted",
     Keys = [<<"dog">>, <<"zebra">>, <<"aardvark">>, <<01>>, <<"panda">>],
 
-    {ok, User} = riak_moss_utils:create_user(Name),
+    {ok, User} = riak_moss_utils:create_user(Name, Email),
     KeyID = User#moss_user.key_id,
     ok = riak_moss_utils:create_bucket(KeyID, BucketName),
 

--- a/test/riak_moss_wm_service_test.erl
+++ b/test/riak_moss_wm_service_test.erl
@@ -22,7 +22,8 @@ get_bucket_to_json() ->
     %% XXX TODO: MAKE THESE ACTUALLY TEST SOMETHING
     BucketNames = ["foo", "bar", "baz"],
     UserName = "fooser",
-    {ok, User} = riak_moss_utils:create_user(UserName),
+    Email = "fooser@fooser.com",
+    {ok, User} = riak_moss_utils:create_user(UserName, Email),
     KeyID = User#moss_user.key_id,
     [riak_moss_utils:create_bucket(KeyID, Name) || Name <- BucketNames],
     {ok, UpdatedUser} = riak_moss_utils:get_user(User#moss_user.key_id),


### PR DESCRIPTION
This set of changes updates the user record structure to include _email_, _display_name_, and _canonical_id_ fields. These fields are necessary to mirror the information used by amazon for S3 and to implement ACLs. The _buckets_ field is removed as all bucket information will be stored in the `<<moss.buckets>>` bucket instead of with each users's data. The changes are also a prerequisite for the serialization of user creation requests which is required to enforce the uniqueness of email addresses in the system. 

Also included is `riak_moss_acl_utils`, a utility module for ACL handling. A default ACL is created when a bucket is created in `riak_moss_wm_bucket`, but it's currently just a placeholder. The `create_bucket` function in `riak_moss_utils` does not currently do anything with it. This is just more groundwork for more ACL work that will be done in the near future.

Creating a user is still accomplished via a POST to the `/user` resource, but in addition to specifying a name, a properly formatted email address is also required. 

A curl request to create a user would look like this:

<pre><code>
curl http://localhost:8080/user --data "email=joe@bob.com&name=joe%20bob"
</code></pre>


The response JSON would look similar to the following:

<pre><code>
{
    "email": "joe@bob.com",
    "display_name": "joe",
    "key_id": "324ABC0713CD0B420EFC086821BFAE7ED81442C", 
    "key_secret": "5BE84D7EEA1AEEAACF070A1982DDA74DA0AA5DA7", 
    "name": "joe bob",
    "id":"8d6f05190095117120d4449484f5d87691aa03801cc4914411ab432e6ee0fd6b"
}
</code></pre>


We may need a script to assist existing users in migrating to this new user representation, but that has been left as a separate piece of work. 
