### PR TITLE
Integrate user serialization

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -50,6 +50,8 @@
 -define(MOSS_BUCKET, #moss_bucket_v1).
 -define(MOSS_USER, #moss_user_v1).
 -define(USER_BUCKET, <<"moss.users">>).
+-define(BUCKETS_BUCKET, <<"moss.buckets">>).
+-define(FREE_BUCKET_MARKER, <<"0">>).
 -define(MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
 -define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
 -define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").

--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -32,15 +32,6 @@ authenticate(RD, [KeyID, Signature]) ->
             case check_auth(Signature, CalculatedSignature) of
                 true ->
                     {ok, User};
-                    %% case bucket_auth(User,
-                    %%                  wrq:method(RD),
-                    %%                  wrq:path_info(bucket, RD),
-                    %%                  wrq:path_tokens(RD)) of
-                    %%     true ->
-                            %% {ok, User};
-                    %%     false ->
-                    %%         {error, invalid_authentication}
-                    %% end;
                 _ ->
                     {error, invalid_authentication}
             end;
@@ -192,20 +183,6 @@ canonicalize_resource(RD) ->
             ["/", Bucket, "/", string:join(KeyTokens, "/")]
     end.
 -endif.
-
-%% bucket_auth(_User=#moss_user{}, _, undefined, []) ->
-%%     true;
-%% bucket_auth(_User=#moss_user{}, 'PUT', _BucketName, []) ->
-%%     true;
-%% bucket_auth(User=#moss_user{}, _, BucketName, _KeyName) ->
-%%     bucket_owner(User, BucketName).
-
-%% bucket_owner(User=#moss_user{}, BucketName) ->
-%%     lists:member(BucketName,
-%%                  [B?MOSS_BUCKET.name
-%%                   || B <- riak_moss_utils:get_buckets(User)]).
-
-
 
 %% ===================================================================
 %% Eunit tests

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -33,7 +33,6 @@ error_message(admin_key_undefined) -> "Please reduce your request rate.";
 error_message(admin_secret_undefined) -> "Please reduce your request rate.";
 error_message(econnrefused) -> "Please reduce your request rate.".
 
-
 error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
 error_code(access_denied) -> "AccessDenied";
 error_code(bucket_not_empty) -> "BucketNotEmpty";
@@ -44,7 +43,6 @@ error_code({riak_connect_failed, _}) -> "RiakConnectFailed";
 error_code(admin_key_undefined) -> "ServiceUnavailable";
 error_code(admin_secret_undefined) -> "ServiceUnavailable";
 error_code(econnrefused) -> "ServiceUnavailable".
-
 
 status_code(invalid_access_key_id) -> 403;
 status_code(invalid_email_address) -> 400;

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -23,6 +23,8 @@ error_message(bucket_not_empty) ->
     "The bucket you tried to delete is not empty.";
 error_message(bucket_already_exists) ->
     "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.";
+error_message(user_already_exists) ->
+    "The specified email address has already been registered. Email addresses must be unique among all users of the system. Please try again with a different email address.";
 error_message(entity_too_large) ->
     "Your proposed upload exceeds the maximum allowed object size.";
 error_message(no_such_bucket) ->
@@ -37,6 +39,7 @@ error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
 error_code(access_denied) -> "AccessDenied";
 error_code(bucket_not_empty) -> "BucketNotEmpty";
 error_code(bucket_already_exists) -> "BucketAlreadyExists";
+error_code(user_already_exists) -> "UserAlreadyExists";
 error_code(entity_too_large) -> "EntityTooLarge";
 error_code(no_such_bucket) -> "NoSuchBucket";
 error_code({riak_connect_failed, _}) -> "RiakConnectFailed";
@@ -49,6 +52,7 @@ status_code(invalid_email_address) -> 400;
 status_code(access_denied) ->  403;
 status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;
+status_code(user_already_exists) -> 409;
 status_code(entity_too_large) -> 400;
 status_code(no_such_bucket) -> 404;
 status_code({riak_connect_failed, _}) -> 503;
@@ -147,6 +151,8 @@ error_code_to_atom(ErrorCode) ->
             bucket_not_empty;
         "BucketAlreadyExists" ->
             bucket_already_exists;
+        "UserAlreadyExists" ->
+            user_already_exists;
         "NoSuchBucket" ->
             no_such_bucket;
         _ ->

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -17,7 +17,6 @@
          delete_object/2,
          from_bucket_name/1,
          get_admin_creds/0,
-         get_buckets/1,
          get_keys_and_objects/2,
          get_object/2,
          get_object/3,
@@ -93,7 +92,6 @@ create_bucket(KeyId, Bucket, _ACL) ->
         {error, Reason} ->
             {error, {riak_connect_failed, Reason}}
     end.
-
 
 %% @doc Create a new MOSS user
 -spec create_user(string(), string()) -> {ok, moss_user()}.
@@ -413,9 +411,9 @@ to_bucket_name(blocks, Name) ->
 %% ===================================================================
 
 %% @doc Check if a bucket is empty
--spec bucket_empty(string(), pid()) -> boolean().
+-spec bucket_empty(binary(), pid()) -> boolean().
 bucket_empty(Bucket, RiakPid) ->
-    ObjBucket = to_bucket_name(objects, list_to_binary(Bucket)),
+    ObjBucket = to_bucket_name(objects, Bucket),
     case list_keys(ObjBucket, RiakPid) of
         {ok, []} ->
             true;
@@ -434,7 +432,11 @@ bucket_exists(Buckets, CheckBucket) ->
     case SearchResults of
         [] ->
             false;
-        _ ->
+        {ok, _} ->
+            true;
+        {error, notfound} ->
+            false;
+        {error, _} ->
             true
     end.
 

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -88,7 +88,6 @@ create_bucket(KeyId, Bucket, _ACL) ->
                                        VClock,
                                        created,
                                        RiakPid),
-
             close_riak_connection(RiakPid),
             Res;
         {error, Reason} ->

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -102,8 +102,8 @@ create_user(Name, Email) ->
     case validate_email(Email) of
         ok ->
             {StanchionIp, StanchionPort, StanchionSSL} =
-                get_stanchion_data(),
-            User = user_record(UserName, Email),
+                stanchion_data(),
+            User = user_record(Name, Email),
             case get_admin_creds() of
                 {ok, AdminCreds} ->
                     %% Generate the user JSON document

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -94,9 +94,10 @@ create_bucket(KeyId, Bucket, _ACL) ->
             {error, {riak_connect_failed, Reason}}
     end.
 
+
 %% @doc Create a new MOSS user
 -spec create_user(string(), string()) -> {ok, moss_user()}.
-create_user(UserName, Email) ->
+create_user(Name, Email) ->
     %% Validate the email address
     case validate_email(Email) of
         ok ->
@@ -556,11 +557,11 @@ fetch_user(Key, RiakPid) ->
 
 %% @doc Generate a new set of access credentials for user.
 -spec generate_access_creds(string()) -> {binary(), binary()}.
-generate_access_creds(UserName) ->
-    BinUser = list_to_binary(UserName),
-    KeyID = generate_key(BinUser),
-    Secret = generate_secret(BinUser, KeyID),
-    {KeyID, Secret}.
+generate_access_creds(UserId) ->
+    UserBin = list_to_binary(UserId),
+    KeyId = generate_key(UserBin),
+    Secret = generate_secret(UserBin, KeyId),
+    {KeyId, Secret}.
 
 %% @doc Retrieve a MOSS user's information based on their id string.
 -spec get_user(string(), pid()) -> {ok, {term(), term()}} | {error, term()}.

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -124,7 +124,7 @@ accept_body(ReqData, Ctx=#context{user=User}) ->
 %% @doc Callback for deleting a bucket.
 -spec delete_resource(term(), term()) -> boolean().
 delete_resource(ReqData, Ctx=#context{user=User}) ->
-    BucketName = wrq:path_info(bucket, ReqData),
+    BucketName = list_to_binary(wrq:path_info(bucket, ReqData)),
     case riak_moss_utils:delete_bucket(User?MOSS_USER.key_id,
                                        BucketName) of
         ok ->


### PR DESCRIPTION
Changes so that user creation requests are serialized through stanchion. 

See [this](https://github.com/basho/riak_moss/pull/71) pull request discussion for instructions on creating a user with the new user requirements.
