### PR TITLE
s3cmd get of empty file fails (no "ETag" HTTP header)

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -143,7 +143,7 @@ produce_body(RD, #key_context{get_fsm_pid=GetFsmPid, doc_metadata=DocMeta}=Ctx) 
     riak_moss_get_fsm:continue(GetFsmPid),
     case ContentLength of
         0 ->
-            {<<>>, RD, Ctx};
+            {<<>>, NewRQ, Ctx};
         _ ->
             {{known_length_stream, ContentLength, {<<>>, fun() -> riak_moss_wm_utils:streaming_get(GetFsmPid) end}},
              NewRQ, Ctx}


### PR DESCRIPTION
Fixes #117
- Avoid using `hd()` BIF on an empty list of blocks
- Use updated Webmachine state in `produce_body()` when ContentLength is 0.
