### PR TITLE
`s3cmd info` fails due to KeyError

### DIFF
--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -151,27 +151,31 @@ waiting_value({object, _Pid, Reply}, #state{from=From}=State) ->
                     %% content length is a hack now
                     %% because we're forcing everything
                     %% to be a manifest
+                    Mfst = undefined,
                     ContentLength = 0,
                     ContentMd5 = <<>>,
                     NewState = State#state{value_cache=RawValue};
                 true ->
-                    DecodedValue = binary_to_term(RawValue),
-                    Metadata = riak_moss_lfs_utils:metadata_from_manifest(DecodedValue),
-                    ContentLength = riak_moss_lfs_utils:content_length(DecodedValue),
-                    ContentMd5 = riak_moss_lfs_utils:content_md5(DecodedValue),
-                    NewState = State#state{manifest=DecodedValue,
-                                           manifest_uuid=riak_moss_lfs_utils:file_uuid(DecodedValue)}
+                    Mfst = binary_to_term(RawValue),
+                    Metadata = riak_moss_lfs_utils:metadata_from_manifest(Mfst),
+                    ContentLength = riak_moss_lfs_utils:content_length(Mfst),
+                    ContentMd5 = riak_moss_lfs_utils:content_md5(Mfst),
+                    NewState = State#state{manifest=Mfst,
+                                           manifest_uuid=riak_moss_lfs_utils:file_uuid(Mfst)}
             end,
-            Meta1 = dict:store("content-type",
-                                    riakc_obj:get_content_type(Value),
-                                    Metadata),
-            Meta2 = dict:store("content-md5",
-                                    ContentMd5,
-                                    Meta1),
-            Meta3 = dict:store("content-length",
-                                    ContentLength,
-                                    Meta2),
-            Meta3
+            lists:foldl(
+              fun({K, V}, Dict) -> dict:store(K, V, Dict) end,
+              Metadata,
+              if Mfst == undefined ->
+                      [];
+                 true ->
+                      LastModified = riak_moss_wm_utils:iso_8601_to_rfc_1123(
+                                         riak_moss_lfs_utils:created(Mfst)),
+                      [{"last-modified", LastModified}]
+              end ++
+                  [{"content-type", riakc_obj:get_content_type(Value)},
+                   {"content-md5", ContentMd5},
+                   {"content-length", ContentLength}])
     end,
 
     NextState = case From of

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -139,7 +139,11 @@ produce_body(RD, #key_context{get_fsm_pid=GetFsmPid, doc_metadata=DocMeta}=Ctx) 
     ContentLength = dict:fetch("content-length", DocMeta),
     ContentMd5 = dict:fetch("content-md5", DocMeta),
     ETag = "\"" ++ riak_moss_utils:binary_to_hexlist(ContentMd5) ++ "\"",
-    NewRQ = wrq:set_resp_header("ETag",  ETag, RD),
+    NewRQ = lists:foldl(fun({K, V}, Rq) -> wrq:set_resp_header(K, V, Rq) end,
+                        RD,
+                        [{"ETag",  ETag},
+                         {"Last-Modified", dict:fetch("last-modified", DocMeta)}
+                        ]),
     riak_moss_get_fsm:continue(GetFsmPid),
     case ContentLength of
         0 ->

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -135,8 +135,9 @@ iso_8601_to_rfc_1123(Date) when is_binary(Date) ->
                       non_neg_integer(),
                       non_neg_integer()) -> string().
 iso_8601_format(Year, Month, Day, Hour, Min, Sec) ->
-    io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000Z",
-                  [Year, Month, Day, Hour, Min, Sec]).
+    lists:flatten(
+     io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000Z",
+                   [Year, Month, Day, Hour, Min, Sec])).
 
 b2i(Bin) ->
     list_to_integer(binary_to_list(Bin)).

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -11,6 +11,7 @@
          ensure_doc/1,
          iso_8601_datetime/0,
          to_iso_8601/1,
+         iso_8601_to_rfc_1123/1,
          streaming_get/1,
          user_record_to_proplist/1]).
 
@@ -108,6 +109,19 @@ to_iso_8601(Date) ->
             Date
     end.
 
+%% @doc Convert an ISO 8601 date to RFC 1123 date
+-spec iso_8601_to_rfc_1123(binary() | string()) -> string().
+iso_8601_to_rfc_1123(Date) when is_list(Date) ->
+    iso_8601_to_rfc_1123(iolist_to_binary(Date));
+iso_8601_to_rfc_1123(Date) when is_binary(Date) ->
+    %% e.g. "2012-02-17T18:22:50.000Z"
+    <<Yr:4/binary, _:1/binary, Mo:2/binary, _:1/binary, Da:2/binary,
+      _T:1/binary,
+      Hr:2/binary, _:1/binary, Mn:2/binary, _:1/binary, Sc:2/binary,
+      _/binary>> = Date,
+    httpd_util:rfc1123_date({{b2i(Yr), b2i(Mo), b2i(Da)},
+                             {b2i(Hr), b2i(Mn), b2i(Sc)}}).
+
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
@@ -123,3 +137,6 @@ to_iso_8601(Date) ->
 iso_8601_format(Year, Month, Day, Hour, Min, Sec) ->
     io_lib:format("~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000Z",
                   [Year, Month, Day, Hour, Min, Sec]).
+
+b2i(Bin) ->
+    list_to_integer(binary_to_list(Bin)).


### PR DESCRIPTION
Fixes #83

Add last-modified time to the dictionary that's stored in the
riak_moss_get_fsm's #state.metadata_cache.  Do some minor refactoring
to use lists:foldl/3 instead of explicit dict:store/3 and
wrq:set_resp_header/3 calls.

I also added riak_moss_wm_util:iso_8601_to_rfc_1123/1.  It's
a bit brute force, but I didn't see any utility functions lying
around to help.

Verification script: https://gist.github.com/07de3132a16ba5457100
