### PR TITLE
"s3cmd info" fetches entire object

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -20,6 +20,7 @@
                       putctype :: string(),
                       bucket :: list(),
                       key :: list(),
+                      method :: atom(),
                       size :: non_neg_integer()}).
 
 -define(USER_BUCKET, <<"moss.users">>).

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -135,16 +135,16 @@ content_types_provided(RD, Ctx) ->
     end.
 
 -spec produce_body(term(), term()) -> {iolist()|binary(), term(), term()}.
-produce_body(#wm_reqdata{method=Method}=RD,
-             #key_context{get_fsm_pid=GetFsmPid, doc_metadata=DocMeta}=Ctx) ->
+produce_body(RD, #key_context{get_fsm_pid=GetFsmPid, doc_metadata=DocMeta}=Ctx) ->
     ContentLength = dict:fetch("content-length", DocMeta),
     ContentMd5 = dict:fetch("content-md5", DocMeta),
     ETag = "\"" ++ riak_moss_utils:binary_to_hexlist(ContentMd5) ++ "\"",
     NewRQ = wrq:set_resp_header("ETag",  ETag, RD),
     riak_moss_get_fsm:continue(GetFsmPid),
-    if ContentLength == 0; Method == 'HEAD' ->
+    case ContentLength of
+        0 ->
             {<<>>, RD, Ctx};
-       true ->
+        _ ->
             {{known_length_stream, ContentLength, {<<>>, fun() -> riak_moss_wm_utils:streaming_get(GetFsmPid) end}},
              NewRQ, Ctx}
     end.

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -60,11 +60,16 @@ parse_auth_header(_, _) ->
 %%      it again if it's already in the
 %%      Ctx
 -spec ensure_doc(term()) -> term().
-ensure_doc(Ctx=#key_context{get_fsm_pid=undefined, bucket=Bucket, key=Key}) ->
+ensure_doc(Ctx=#key_context{get_fsm_pid=undefined, bucket=Bucket, key=Key,
+                            method=Method}) ->
     %% start the get_fsm
     BinBucket = list_to_binary(Bucket),
     BinKey = list_to_binary(Key),
-    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(node(), [BinBucket, BinKey]),
+    ManifestOnly = case Method of 'HEAD' -> true;
+                                  _      -> false
+                   end,
+    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(
+                  node(), [BinBucket, BinKey, ManifestOnly]),
     Metadata = riak_moss_get_fsm:get_metadata(Pid),
     Ctx#key_context{get_fsm_pid=Pid, doc_metadata=Metadata};
 ensure_doc(Ctx) -> Ctx.


### PR DESCRIPTION
Fixes #119

Added HTTP method to #key_context record to allow starting
of the riak_moss_get_fsm so that that FSM can avoid fetching
all of the object's chunks.
