### PR TITLE
Add url-safe base64 encoding module and change all base64 encoding to use it.

### DIFF
--- a/src/base64url.erl
+++ b/src/base64url.erl
@@ -1,0 +1,71 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2009-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc base64url is a wrapper around the base64 module to produce
+%%      base64-compatible encodings that are URL safe.
+%%      The / character in normal base64 encoding is replaced with
+%%      the _ character, and + is replaced with -.
+%%      This replacement scheme is named "base64url" by
+%%      http://en.wikipedia.org/wiki/Base64
+
+-module(base64url).
+
+-export([decode/1,
+         decode_to_string/1,
+         encode/1,
+         encode_to_string/1,
+         mime_decode/1,
+         mime_decode_to_string/1]).
+
+decode(Base64url) ->
+    base64:decode(urldecode(Base64url)).
+
+decode_to_string(Base64url) ->
+    base64:decode_to_string(urldecode(Base64url)).
+
+mime_decode(Base64url) ->
+    base64:mime_decode(urldecode(Base64url)).
+
+mime_decode_to_string(Base64url) ->
+    base64:mime_decode_to_string(urldecode(Base64url)).
+
+encode(Data) ->
+    urlencode(base64:encode(Data)).
+
+encode_to_string(Data) ->
+    urlencode(base64:encode_to_string(Data)).
+
+urlencode(Base64) when is_list(Base64) ->
+    [urlencode_digit(D) || D <- Base64];
+urlencode(Base64) when is_binary(Base64) ->
+    << << (urlencode_digit(D)) >> || <<D>> <= Base64 >>.
+
+urldecode(Base64url) when is_list(Base64url) ->
+    [urldecode_digit(D) || D <- Base64url ];
+urldecode(Base64url) when is_binary(Base64url) ->
+    << << (urldecode_digit(D)) >> || <<D>> <= Base64url >>.
+
+urlencode_digit($/) -> $_;
+urlencode_digit($+) -> $-;
+urlencode_digit(D)  -> D.
+
+urldecode_digit($_) -> $/;
+urldecode_digit($-) -> $+;
+urldecode_digit(D)  -> D.

--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -74,7 +74,7 @@ calculate_signature(KeyData, RD) ->
            Date,
            AmazonHeaders,
            Resource],
-    base64:encode_to_string(
+    base64url:encode_to_string(
       crypto:sha_mac(KeyData, STS)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -602,7 +602,7 @@ generate_key(UserName) ->
     Ctx = crypto:hmac_init(sha, UserName),
     Ctx1 = crypto:hmac_update(Ctx, druuid:v4()),
     Key = crypto:hmac_final_n(Ctx1, 15),
-    string:to_upper(base64:encode_to_string(Key)).
+    string:to_upper(base64url:encode_to_string(Key)).
 
 %% @doc Generate a secret access token for a user
 -spec generate_secret(binary(), string()) -> string().
@@ -614,7 +614,7 @@ generate_secret(UserName, Key) ->
     Ctx2 = crypto:hmac_init(sha, UserName),
     Ctx3 = crypto:hmac_update(Ctx2, druuid:v4()),
     SecretPart2 = crypto:hmac_final_n(Ctx3, Bytes),
-    base64:encode_to_string(
+    base64url:encode_to_string(
       iolist_to_binary(<< SecretPart1:Bytes/binary,
                           SecretPart2:Bytes/binary >>)).
 


### PR DESCRIPTION
Since there are occasions where the user key ids will be used in URLs, let's make them URL-safe.
