### PR TITLE
Change runner script path from bin to sbin so riak_moss start will work.

### DIFF
--- a/rel/vars.config
+++ b/rel/vars.config
@@ -30,7 +30,7 @@
 %% bin/riak_moss
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/bin"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
 {runner_bin_dir,     "{{target_dir}}"}.
 {runner_run_dir,     "{{target_dir}}"}.
 {runner_etc_dir,     "{{target_dir}}/etc"}.


### PR DESCRIPTION
The runner script was looking in `bin` instead of `sbin` for the `riak_moss` script so moss would not start.
