### PR TITLE
Server-side signature calculation can fail when using the base64url modu...

### DIFF
--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -66,7 +66,7 @@ calculate_signature(KeyData, RD) ->
            Date,
            AmazonHeaders,
            Resource],
-    base64url:encode_to_string(
+    base64:encode_to_string(
       crypto:sha_mac(KeyData, STS)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->


### PR DESCRIPTION
Just use the standard base64 module for signature calculation. It works for existing credentials as well as credentials generated with the base64url module.
