### PR TITLE
Sometimes the date is already in rfc 1123 format

### DIFF
--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -169,7 +169,7 @@ waiting_value({object, _Pid, Reply}, #state{from=From}=State) ->
               if Mfst == undefined ->
                       [];
                  true ->
-                      LastModified = riak_moss_wm_utils:iso_8601_to_rfc_1123(
+                      LastModified = riak_moss_wm_utils:to_rfc_1123(
                                          riak_moss_lfs_utils:created(Mfst)),
                       [{"last-modified", LastModified}]
               end ++

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -12,6 +12,7 @@
          iso_8601_datetime/0,
          to_iso_8601/1,
          iso_8601_to_rfc_1123/1,
+         to_rfc_1123/1,
          streaming_get/1,
          user_record_to_proplist/1]).
 
@@ -122,6 +123,16 @@ to_iso_8601(Date) ->
             Date
     end.
 
+-spec to_rfc_1123(string()) -> string().
+to_rfc_1123(Date) when is_list(Date) ->
+    case httpd_util:convert_request_date(Date) of
+        {{_Year, _Month, _Day}, {_Hour, _Min, _Sec}} ->
+            %% Date is already in RFC 1123 format
+            Date;
+        bad_date ->
+            iso_8601_to_rfc_1123(Date)
+    end.
+    
 %% @doc Convert an ISO 8601 date to RFC 1123 date
 -spec iso_8601_to_rfc_1123(binary() | string()) -> string().
 iso_8601_to_rfc_1123(Date) when is_list(Date) ->


### PR DESCRIPTION
Found during testing of 0.0.3 -> 0.1.0 migrated data.

The error occurred after trying to GET a file, post migration

```
05:16:42.125 [error] CRASH REPORT Process <0.162.0> with 0 neighbours crashed with reason: bad argument in call to erlang:list_to_integer("Sat,") in riak_moss_wm_utils:b2i/1
05:16:42.125 [error] Supervisor riak_moss_get_fsm_sup had child undefined started with {riak_moss_get_fsm,start_link,undefined} at <0.162.0> exit with reason bad argument in call to erlang:list_to_integer("Sat,") in riak_moss_wm_utils:b2i/1 in context child_terminated
05:16:42.126 [error] webmachine error: path="/foo/test.xml"
{exit,{{badarg,[{erlang,list_to_integer,["Sat,"]},{riak_moss_wm_utils,b2i,1},{riak_moss_wm_utils,iso_8601_to_rfc_1123,1},{riak_moss_get_fsm,waiting_value,2},{gen_fsm,handle_msg,7},{proc_lib,init_p_do_apply,3}]},{gen_fsm,sync_send_event,[<0.162.0>,get_metadata,60000]}},[{gen_fsm,sync_send_event,3},{riak_moss_wm_utils,ensure_doc,1},{riak_moss_wm_key,forbidden,3},{webmachine_resource,resource_call,3},{webmachine_resource,do,3},{webmachine_decision_core,resource_call,1},{webmachine_decision_core,decision,1},{webmachine_decision_core,handle_request,2}]}
```

It looks like it thinks "Sat, " is a year, because it's expecting an iso 8601 date, but is getting a rfc 1123 date. Since an rfc 1123 date is what it wants, this is not a tragedy. I added a check to see if it's already in the correct format, shamelessly lifted from to_iso_8601/1.
