### PR TITLE
Changes to properly handle anonymous bucket access.

### DIFF
--- a/src/riak_moss_acl.erl
+++ b/src/riak_moss_acl.erl
@@ -42,7 +42,12 @@ anonymous_bucket_access(Bucket, RequestedAccess) ->
                     %% Only owners may delete buckets
                     false;
                 _ ->
-                    has_permission(Acl, RequestedAccess)
+                    case has_permission(Acl, RequestedAccess) of
+                        true ->
+                            {true, owner_id(Acl)};
+                        false ->
+                            false
+                    end
             end;
         {error, Reason} ->
             %% @TODO Think about bubbling this error up and providing
@@ -199,7 +204,7 @@ has_group_permission([{_, Perms} | RestGrants], RequestedAccess) ->
 has_permission(Acl, RequestedAccess) ->
     GroupGrants = group_grants(Acl?ACL.grants, []),
     case [Perms || {Grantee, Perms} <- GroupGrants,
-                   Grantee =:= ?ALL_USERS_GROUP] of
+                   Grantee =:= 'AllUsers'] of
         [] ->
             false;
         [Perms | _] ->

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -41,14 +41,14 @@ service_available(RD, Ctx) ->
 %%      The passthru auth can be used either with a KeyID or
 %%      anonymously by leving the header empty.
 -spec parse_auth_header(string(), boolean()) -> {atom(),
-                                                 string() | unknown_auth_scheme,
+                                                 string() | undefined,
                                                  string() | undefined}.
 parse_auth_header(KeyId, true) when KeyId =/= undefined ->
     {riak_moss_passthru_auth, KeyId, undefined};
 parse_auth_header(_, true) ->
     {riak_moss_passthru_auth, [], undefined};
 parse_auth_header(undefined, false) ->
-    {riak_moss_blockall_auth, unkown_auth_scheme, undefined};
+    {riak_moss_blockall_auth, undefined, undefined};
 parse_auth_header("AWS " ++ Key, _) ->
     case string:tokens(Key, ":") of
         [KeyId, KeyData] ->
@@ -56,7 +56,7 @@ parse_auth_header("AWS " ++ Key, _) ->
         Other -> Other
     end;
 parse_auth_header(_, _) ->
-    {riak_moss_blockall_auth, unkown_auth_scheme, undefined}.
+    {riak_moss_blockall_auth, undefined, undefined}.
 
 
 %% @doc Utility function for accessing
@@ -132,7 +132,7 @@ to_rfc_1123(Date) when is_list(Date) ->
         bad_date ->
             iso_8601_to_rfc_1123(Date)
     end.
-    
+
 %% @doc Convert an ISO 8601 date to RFC 1123 date
 -spec iso_8601_to_rfc_1123(binary() | string()) -> string().
 iso_8601_to_rfc_1123(Date) when is_list(Date) ->


### PR DESCRIPTION
1. Change atom used for `key_id` when no auth header is specified in
   riak_moss_wm_utils:parse_auth_header.
2. Fix match condition used in riak_moss_acl:has_permission/2. It should look for a match for the `'AllUsers'` atom instead of the `AllUsers` URI.
## Testing
1. Create a bucket using an existing account: `s3cmd -c ~/.mosscfg mb s3://testbucket`.
2. Set the bucket to have public read access: `s3cmd -c ~/.mosscfg setacl -P s3://testbucket`.
3. List the bucket info: `curl http://localhost:8080/testbucket` and you should see something similar to the following output:

```
<?xml version="1.0" encoding="UTF-8"?>
<ListBucketResult>
  <Name>testbucket</Name>
  <Prefix/>
  <Marker/>
  <MaxKeys>1000</MaxKeys>
  <Delimiter>/</Delimiter>
  <IsTruncated>false</IsTruncated>
</ListBucketResult>
```

Using `master` step 3 would result in a `500 Internal Server Error`. 
