### PR TITLE
Changes to make maximum content length configurable.

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -60,7 +60,7 @@
 -define(USER_BUCKET, <<"moss.users">>).
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 -define(FREE_BUCKET_MARKER, <<"0">>).
--define(MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
+-define(DEFAULT_MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
 -define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
 -define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").
 -define(DEFAULT_STANCHION_IP, "127.0.0.1").

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -26,6 +26,7 @@
          block_name/3,
          block_name_to_term/1,
          block_size/0,
+         max_content_len/0,
          safe_block_size_from_manifest/1,
          file_uuid/1,
          finalize_manifest/2,
@@ -117,12 +118,17 @@ block_size() ->
         undefined ->
             ?DEFAULT_LFS_BLOCK_SIZE;
         {ok, BlockSize} ->
-            case BlockSize > ?DEFAULT_LFS_BLOCK_SIZE of
-                true ->
-                    ?DEFAULT_LFS_BLOCK_SIZE;
-                false ->
-                    BlockSize
-            end
+            BlockSize
+    end.
+
+%% @doc Return the configured block size
+-spec max_content_len() -> pos_integer().
+max_content_len() ->
+    case application:get_env(riak_moss, max_content_length) of
+        undefined ->
+            ?DEFAULT_MAX_CONTENT_LENGTH;
+        {ok, MaxContentLen} ->
+            MaxContentLen
     end.
 
 safe_block_size_from_manifest(#lfs_manifest{block_size=BlockSize}) ->

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -142,7 +142,7 @@ valid_entity_length(RD, Ctx) ->
                    list_to_integer(
                      wrq:get_req_header("Content-Length", RD))) of
                 Length when is_integer(Length) ->
-                    case Length =< ?MAX_CONTENT_LENGTH of
+                    case Length =< riak_moss_lfs_utils:max_content_len() of
                         false ->
                             riak_moss_s3_response:api_error(
                               entity_too_large, RD, Ctx);
@@ -156,7 +156,6 @@ valid_entity_length(RD, Ctx) ->
         _ ->
             {true, RD, Ctx}
     end.
-
 
 -spec content_types_provided(term(), term()) ->
     {[{string(), atom()}], term(), term()}.


### PR DESCRIPTION
- Create `max_content_len/0` function in `riak_moss_lfs_utils`.
- Change `MAX_CONTENT_LENGTH` macro to `DEFAULT_MAX_CONTENT_LENGTH`.
- Allow non-default maximum content length to be specified via
  `max_content_length` setting in the `app.config` file.
