### PR TITLE
Handle HEAD requests in riak_moss_acl_utils:requested_access.

### DIFF
--- a/src/riak_moss_acl_utils.erl
+++ b/src/riak_moss_acl_utils.erl
@@ -83,7 +83,9 @@ requested_access(Method, QueryString) ->
         andalso
         AclRequest == true->
             'READ_ACP';
-        Method == 'GET' ->
+        (Method == 'GET'
+         orelse
+         Method == 'HEAD') ->
             'READ';
         Method == 'PUT'
         andalso


### PR DESCRIPTION
## Testing

On `master`, doing an `s3cmd info` on a bucket object should yield a `403` response, but with the changes on this branch it should result in a parsing error from s3cmd. This may seem like no improvement, but capturing the packets of the requests made by s3cmd should show that on `master` a `HEAD` request for the object is made and a `403` is returned. Using this branch should show the `HEAD` request receive a `200` and the following `GET` request for the `/?acl` subresource should also receive a `200`, but will also return the contents of the object and when s3cmd tries to parse that as an ACL document it results in the parsing error.
