### PR TITLE
Return an empty ACL on acl requests for objects.

### DIFF
--- a/src/riak_moss_acl_utils.erl
+++ b/src/riak_moss_acl_utils.erl
@@ -22,6 +22,7 @@
          default_acl/2,
          acl_from_xml/1,
          acl_to_xml/1,
+         empty_acl_xml/0,
          requested_access/2
         ]).
 
@@ -69,6 +70,17 @@ acl_to_xml(Acl) ->
              {'DisplayName', [OwnerName]}
             ]},
            {'AccessControlList', grants_xml(Acl?ACL.grants)}
+          ]}],
+    unicode:characters_to_binary(
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
+
+%% @doc Convert an internal representation of an ACL
+%% into XML.
+-spec empty_acl_xml() -> binary().
+empty_acl_xml() ->
+    XmlDoc =
+        [{'AccessControlPolicy',
+          [
           ]}],
     unicode:characters_to_binary(
       xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).


### PR DESCRIPTION
- Add `empty_acl_xml` function to `riak_moss_acl_utils`.
- Return empty acl in `riak_moss_wm_key:produce_body` when requested
  permission is `READ_ACP`.
## Testing

On `s138-requested-access-head`, doing an `s3cmd info` on a bucket object should yield a parsing error from s3cmd, but using the changes from this branch the command should successfully return the file size, last modified date, mime type, and md5 sum for the object. 
