### PR TITLE
Change no_such_user atom in riak_moss_wm_service:forbidden to no_user_key

### DIFF
--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -113,9 +113,13 @@ forbidden(RD, Ctx=#context{auth_bypass=AuthBypass}) ->
                     %% Anonymous access not allowed, deny access
                     riak_moss_s3_response:api_error(access_denied, RD, Ctx)
             end;
+        {error, notfound} ->
+            %% Access not allowed, deny access
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx);
         {error, Reason} ->
+            %% Access not allowed, deny access and log the reason
             lager:error("Retrieval of user record for ~p failed. Reason: ~p", [KeyId, Reason]),
-            riak_moss_s3_response:api_error(user_record_unavailable, RD, Ctx)
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
     end.
 
 %% @doc Get the list of methods this resource supports.

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -115,9 +115,13 @@ forbidden(RD, Ctx=#key_context{bucket=Bucket,
                     %% Anonymous access not allowed, deny access
                     riak_moss_s3_response:api_error(access_denied, RD, Ctx)
             end;
+        {error, notfound} ->
+            %% Access not allowed, deny access
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx);
         {error, Reason} ->
+            %% Access not allowed, deny access and log the reason
             lager:error("Retrieval of user record for ~p failed. Reason: ~p", [KeyId, Reason]),
-            riak_moss_s3_response:api_error(user_record_unavailable, RD, Ctx)
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
     end.
 
 forbidden('GET', RD, Ctx=#key_context{doc_metadata=undefined}) ->

--- a/src/riak_moss_wm_service.erl
+++ b/src/riak_moss_wm_service.erl
@@ -49,12 +49,16 @@ forbidden(RD, Ctx=#context{auth_bypass=AuthBypass}) ->
                     %% Authentication failed, deny access
                     riak_moss_s3_response:api_error(access_denied, RD, Ctx)
             end;
-        {error, no_such_user} ->
+        {error, no_user_key} ->
             %% Anonymous access not allowed, deny access
             riak_moss_s3_response:api_error(access_denied, RD, Ctx);
+        {error, notfound} ->
+            %% Access not allowed, deny access
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx);
         {error, Reason} ->
+            %% Access not allowed, deny access and log the reason
             lager:error("Retrieval of user record for ~p failed. Reason: ~p", [KeyId, Reason]),
-            riak_moss_s3_response:api_error(user_record_unavailable, RD, Ctx)
+            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
     end.
 
 %% @doc Get the list of methods this resource supports.


### PR DESCRIPTION
Unauthorized requests to the service resource (_i.e._ `GET /`) currently return a `503` error code when the more appropriate (imo) error response is `403`. This is due to an incorrect atom used to check responses from a call to `riak_moss_utils:get_user`. 
## Testing

Start riak, stanchion, and moss. On `master` of moss run `curl localhost:8080/ -v`. The response should be a `503`. Now checkout the `s158-fix-wm-service-user-atom` branch and rerun the curl query. The response this time should be `403`. 
