### PR TITLE
Fix EUnit test setup in riak_moss_get_fsm_test:setup().

### DIFF
--- a/test/riak_moss_get_fsm_test.erl
+++ b/test/riak_moss_get_fsm_test.erl
@@ -16,8 +16,7 @@ setup() ->
     application:load(riak_moss),
     application:set_env(sasl, sasl_error_logger, {file, "moss_get_fsm_sasl.log"}),
     error_logger:tty(false),
-    application:start(lager),
-    lager:set_loglevel(lager_console_backend, info).
+    application:start(lager).
 
 %% TODO:
 %% Implement this


### PR DESCRIPTION
Fixes this error:

```
module 'riak_moss_get_fsm_test'
  *** context setup failed ***
::exit:{noproc,{gen_event,call,
                        [lager_event,lager_console_backend,
                         {set_loglevel,info},
                         infinity]}}
  in function gen_event:call1/4
  in call from lager:set_loglevel/2
```
