### PR TITLE
Properly clean up processes and connections on object requests.

### DIFF
--- a/src/riak_moss_reader.erl
+++ b/src/riak_moss_reader.erl
@@ -62,6 +62,10 @@ get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
 %% @doc Initialize the server.
 -spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
 init([CallerPid]) ->
+    %% Ensure the the terminate callback is called if the
+    %% supervisor shuts us down.
+    process_flag(trap_exit, true),
+
     %% Get a connection to riak
     case riak_moss_utils:riak_connection() of
         {ok, RiakPid} ->
@@ -105,7 +109,7 @@ handle_info(_Info, State) ->
 %% @doc Unused.
 -spec terminate(term(), state()) -> ok.
 terminate(_Reason, #state{riakc_pid=RiakcPid}) ->
-    riakc_pb_socket:stop(RiakcPid).
+    riak_moss_utils:close_riak_connection(RiakcPid).
 
 %% @doc Unused.
 -spec code_change(term(), state(), term()) ->


### PR DESCRIPTION
These changes address the following:
- HEAD requests for an object leave processes alive and a riak connection open.
- GET requests for object ACLs leave processes alive and riak
  connections open.
- `riak_moss_reader` `terminate` callback was not being when the
  supervisor shut down a reader process because it was not set to
  trap exits.
## Testing
1. Start riak, stanchion, and moss (_master_ branch to start with).
2. Get the pid of moss and optionally store it away as `MOSSPID`.
3. Get a baseline process count and established connection count for moss. `length(processes())` from moss console and `lsof -p $MOSSPID | grep -c ESTABLISHED` from shell. 
4. Fetch a zero length file and observe that the process count increases by 3 and the number of established connections increases by 1. 
5. Use the `s3cmd info` command to get the info for an object. This command does a `HEAD` for the object and a `GET` for the object's ACL under the covers. The process count should increase by 6 and the number of established connections should increment by 2. 
6. Now check out the `s160-close-head-get-connections` branch of moss and restart moss or reload the `riak_moss_wm_key` and `riak_moss_reader` modules.
7. Repeat steps _4_ and _5_ and verify that now the process count and the established connection count remain flat when running each respective command.
## Note

These changes should obviate the need for [this](https://github.com/basho/riak_moss/pull/76) pr.
