### PR TITLE
Fix dependencies to match those of 0.1.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,12 +11,12 @@
 {reset_after_eunit, true}.
 
 {deps, [
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {branch, "jem-solaris-template"}}},
-        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "wrd-content-length-with-streaming"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
-        {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},
-        {sext, ".*", {git, "git://github.com/esl/sext", "master"}},
-        {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {branch, "master"}}},
-        {stanchion, ".*", {git, "git@github.com:basho/stanchion", {branch, "master"}}}
+        {node_package, "0.1.0", {git, "git://github.com/basho/node_package", {tag, "0.1.0"}}},
+        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.9.0-11-gec837c8"}}},
+        {riakc, "1.2.1", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.2.1-2-g398c0ea"}}},
+        {lager, "1.0.0", {git, "git://github.com/basho/lager", {tag, "1.0.0-2-gb46e377"}}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "0.61-2-gfdfd63c"}}},
+        {sext, ".*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
+        {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "70a5b0475"}}},
+        {stanchion, "0.1.0", {git, "git@github.com:basho/stanchion", {tag, "0.1.0-1-g62a352d"}}}
        ]}.


### PR DESCRIPTION
0.1.1 had its dependencies get squashed by a mistaken merge somewhere.   This is setting the dependencies back to those of 0.1.0.
