### PR TITLE
Allow for non-default canned ACL to be set at bucket creation time. 

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -60,7 +60,7 @@
 -define(USER_BUCKET, <<"moss.users">>).
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 -define(FREE_BUCKET_MARKER, <<"0">>).
--define(MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
+-define(DEFAULT_MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
 -define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
 -define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").
 -define(DEFAULT_STANCHION_IP, "127.0.0.1").

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -26,6 +26,7 @@
          block_name/3,
          block_name_to_term/1,
          block_size/0,
+         max_content_len/0,
          safe_block_size_from_manifest/1,
          file_uuid/1,
          finalize_manifest/2,
@@ -117,12 +118,17 @@ block_size() ->
         undefined ->
             ?DEFAULT_LFS_BLOCK_SIZE;
         {ok, BlockSize} ->
-            case BlockSize > ?DEFAULT_LFS_BLOCK_SIZE of
-                true ->
-                    ?DEFAULT_LFS_BLOCK_SIZE;
-                false ->
-                    BlockSize
-            end
+            BlockSize
+    end.
+
+%% @doc Return the configured block size
+-spec max_content_len() -> pos_integer().
+max_content_len() ->
+    case application:get_env(riak_moss, max_content_length) of
+        undefined ->
+            ?DEFAULT_MAX_CONTENT_LENGTH;
+        {ok, MaxContentLen} ->
+            MaxContentLen
     end.
 
 safe_block_size_from_manifest(#lfs_manifest{block_size=BlockSize}) ->

--- a/src/riak_moss_passthru_auth.erl
+++ b/src/riak_moss_passthru_auth.erl
@@ -12,20 +12,6 @@
 
 -export([authenticate/3]).
 
--spec authenticate(term(), string(), undefined) -> ok | {error, atom()}.
-authenticate(_RD, [], _) ->
-    %% TODO:
-    %% Even though we're
-    %% going to authorize
-    %% no matter what,
-    %% maybe it still makes sense
-    %% to pass the user on
-    {ok, unknown};
-authenticate(_RD, KeyId, _) ->
-    %% @TODO Also handle riak connection error
-    case riak_moss_utils:get_user(KeyId) of
-        {ok, User} ->
-            {ok, User};
-        _ ->
-            {error, invalid_authentication}
-    end.
+-spec authenticate(term(), string(), undefined) -> ok.
+authenticate(_RD, _KeyData, _) ->
+    ok.

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -204,10 +204,13 @@ accept_body(RD, Ctx=#context{user=User,
 accept_body(RD, Ctx=#context{user=User,
                              user_vclock=VClock,
                              bucket=Bucket}) ->
-    %% @TODO Check for `x-amz-acl' header to support
+    %% Check for `x-amz-acl' header to support
     %% non-default ACL at bucket creation time.
-    ACL = riak_moss_acl_utils:default_acl(User?MOSS_USER.display_name,
-                                          User?MOSS_USER.canonical_id),
+    ACL = riak_moss_acl_utils:canned_acl(
+            wrq:get_req_header("x-amz-acl", RD),
+            {User?MOSS_USER.display_name,
+             User?MOSS_USER.canonical_id},
+            undefined),
     case riak_moss_utils:create_bucket(User,
                                        VClock,
                                        Bucket,

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -142,7 +142,7 @@ valid_entity_length(RD, Ctx) ->
                    list_to_integer(
                      wrq:get_req_header("Content-Length", RD))) of
                 Length when is_integer(Length) ->
-                    case Length =< ?MAX_CONTENT_LENGTH of
+                    case Length =< riak_moss_lfs_utils:max_content_len() of
                         false ->
                             riak_moss_s3_response:api_error(
                               entity_too_large, RD, Ctx);
@@ -156,7 +156,6 @@ valid_entity_length(RD, Ctx) ->
         _ ->
             {true, RD, Ctx}
     end.
-
 
 -spec content_types_provided(term(), term()) ->
     {[{string(), atom()}], term(), term()}.


### PR DESCRIPTION
- Add `canned_acl/3` function to `riak_moss_acl_utils`. This function will be reused for objects as well which is the reason for the 3rd parameter.
- Unit test for `canned_acl/3`.
- Change bucket resource to use `canned_acl` instead of `default_acl` so that the value of `x-amz-acl` header is not ignored.
- Update the `riak_moss_passthru_auth` module. `s3cmd` only supports the `public-read` option when creating a bucket so the easiest way to test the changes is to set `auth_bypass` to `true` in the app.config file and use curl to issue requests.
## Testing

The supported values for the `x-amz-acl` are: _private_, _public-read_, _public-read-write_, _authenticated-read_, 
_bucket-owner-read_, and _bucket-owner-full-control_. There is also _log-delivery-write_, but we're not supporting that initially. Each of these maps to a canned ACL. Descriptions are [here](http://docs.amazonwebservices.com/AmazonS3/latest/dev/CannedACL.html).
- Create a bucket with _public-read_ with s3cmd and then verify the ACL is set properly: `s3cmd mb --acl-public s3://somebucket` and then `s3cmd info s3://somebucket` to fetch the ACL. The ACL should grant your user full control and the public group (_http://acs.amazonaws.com/groups/global/AllUsers_) read access.
- Stop moss, set `auth_bypass` to `true`, and restart moss.
- Use curl to create buckets with `x-amz-acl` set to each of _public-read-write_, _authenticated-read_, 
  _bucket-owner-read_, and _bucket-owner-full-control_ and then fetch the ACL for each and verify the expected permissions are granted. Note that _bucket-owner-read_ and _bucket-owner-full-control_ are treated the same as _private_ for buckets. 

Create a bucket: 
`curl localhost:8080/abucket -X PUT -H "authorization: <key_id_here>" -H "x-amz-acl: authenticated-read"`
Fetch the ACL: 
`curl localhost:8080/abucket?acl -H "authorization:  <key_id_here>"` 
