### PR TITLE
Allow block sizes greater than default

### DIFF
--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -117,12 +117,7 @@ block_size() ->
         undefined ->
             ?DEFAULT_LFS_BLOCK_SIZE;
         {ok, BlockSize} ->
-            case BlockSize > ?DEFAULT_LFS_BLOCK_SIZE of
-                true ->
-                    ?DEFAULT_LFS_BLOCK_SIZE;
-                false ->
-                    BlockSize
-            end
+            BlockSize
     end.
 
 safe_block_size_from_manifest(#lfs_manifest{block_size=BlockSize}) ->


### PR DESCRIPTION
Fixes #171

Previously the block size configured
in app.config was ignored if it was
above the default block size. This change
allows it to be set arbitrarily.
