### PR TITLE
Add props and cluster_id members to the #lfs_manifest record

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -55,6 +55,8 @@
                  creation_time=now() :: erlang:timestamp()}).
 -type acl() :: #acl_v1{}.
 
+-type cluster_id() :: undefined | term().  % Type still in flux.
+
 -record(lfs_manifest_v2, {
         %% "global" properties
         %% -----------------------------------------------------------------
@@ -146,7 +148,36 @@
 
         %% The ACL for the version of the object represented
         %% by this manifest.
-        acl :: acl()
+        acl :: acl(),
+
+        %% There are a couple of cases where we want to add record
+        %% member'ish data without adding new members to the record,
+        %% e.g.
+        %%    1. Data for which the common value is 'undefined' or not
+        %%       used/set for this particular manifest
+        %%    2. Cases where we do want to change the structure of the
+        %%       record but don't want to go through the full code
+        %%       refactoring and backward-compatibility tap dance
+        %%       until sometime later.
+        props = [] :: proplists:proplist(),
+
+        %% cluster_id: A couple of uses, both short- and longer-term
+        %%  possibilities:
+        %%
+        %%  1. We don't have a good story in early 2012 for how to
+        %%     build a stable 2,000 node Riak cluster.  If MOSS can
+        %%     talk to multiple Riak clusters, then each individual
+        %%     cluster can be a size that we're comfortable
+        %%     supporting.
+        %%
+        %%  2. We may soon have Riak EE's replication have full
+        %%     plumbing to make it feasible to forward arbitrary
+        %%     traffic between clusters.  Then if a slave cluster is
+        %%     missing a data block, and read-repair cannot
+        %%     automagically fix the 'not_found' problem, then perhaps
+        %%     forwarding a get request to the source Riak cluster can
+        %%     fetch us the missing data.
+        cluster_id :: cluster_id()
     }).
 -type lfs_manifest() :: #lfs_manifest_v2{}.
 

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -32,6 +32,7 @@
          block_sequences_for_manifest/1,
          is_manifest/1,
          new_manifest/9,
+         new_manifest/11,
          remove_write_block/2,
          sorted_blocks_remaining/1]).
 
@@ -158,6 +159,20 @@ is_manifest(BinaryValue) ->
                    pos_integer(),
                    acl()) -> lfs_manifest().
 new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5, MetaData, BlockSize, Acl) ->
+    new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5, MetaData, BlockSize, Acl, [], undefined).
+
+-spec new_manifest(binary(),
+                   binary(),
+                   binary(),
+                   binary(),
+                   pos_integer(),
+                   term(),
+                   term(),
+                   pos_integer(),
+                   acl(),
+                   proplists:proplist(),
+                   cluster_id()) -> lfs_manifest().
+new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5, MetaData, BlockSize, Acl, Props, ClusterID) ->
     Blocks = ordsets:from_list(initial_blocks(ContentLength, BlockSize)),
     #lfs_manifest_v2{bkey={Bucket, FileName},
                      uuid=UUID,
@@ -168,7 +183,9 @@ new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5, Met
                      block_size=BlockSize,
                      write_blocks_remaining=Blocks,
                      metadata=MetaData,
-                     acl=Acl}.
+                     acl=Acl,
+                     props=Props,
+                     cluster_id=ClusterID}.
 
 %% @doc Remove a chunk from the
 %%      write_blocks_remaining field of Manifest


### PR DESCRIPTION
Fixes #174.  See comments right below the #lfs_manifest record definition for more reasoning behind adding the new record members.
