### PR TITLE
Refactor the forbidden/2 functions to ease access tracking

### DIFF
--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -39,87 +39,72 @@ malformed_request(RD, Ctx) ->
 %%      authenticated. Normally with HTTP
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
-forbidden(RD, Ctx=#context{auth_bypass=AuthBypass}) ->
-    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    AuthHeader = wrq:get_req_header("authorization", RD),
-    {AuthMod, KeyId, Signature} =
-        riak_moss_wm_utils:parse_auth_header(AuthHeader, AuthBypass),
+forbidden(RD, Ctx) ->
+    riak_moss_wm_utils:find_and_auth_user(RD, Ctx, fun check_permission/2).
+
+check_permission(RD, #context{user=User}=Ctx) ->
     Method = wrq:method(RD),
     RequestedAccess =
-        riak_moss_acl_utils:requested_access(Method,
-                                             wrq:req_qs(RD)),
-    case riak_moss_utils:get_user(KeyId) of
-        {ok, {User, UserVClock}} ->
-            case AuthMod:authenticate(RD, User?MOSS_USER.key_secret, Signature) of
-                ok ->
-                    %% Authentication succeeded, now perform
-                    %% ACL check to verify access permission.
-                    case Method == 'PUT' andalso
-                        RequestedAccess == 'WRITE' of
-                        true ->
-                            {false,
-                             RD,
-                             Ctx#context{user=User,
-                                         user_vclock=UserVClock,
-                                         bucket=Bucket}};
-                        _ ->
-                            case riak_moss_acl:bucket_access(Bucket,
-                                                             RequestedAccess,
-                                                             User?MOSS_USER.canonical_id) of
-                                true ->
-                                    {false, RD, Ctx#context{user=User,
-                                                            user_vclock=UserVClock,
-                                                            bucket=Bucket,
-                                                            requested_perm=RequestedAccess}};
-                                {true, _OwnerId} when RequestedAccess == 'WRITE' ->
-                                    %% Only bucket owners may delete buckets, deny access
-                                    riak_moss_s3_response:api_error(access_denied, RD, Ctx);
-                                {true, OwnerId} ->
-                                    case riak_moss_utils:get_user_by_index(?ID_INDEX,
-                                                                           list_to_binary(OwnerId)) of
-                                        {ok, {Owner, OwnerVClock}} ->
-                                            {false, RD, Ctx#context{user=Owner,
-                                                                    user_vclock=OwnerVClock,
-                                                                    bucket=Bucket,
-                                                                    requested_perm=RequestedAccess}};
-                                        {error, _} ->
-                                            riak_moss_s3_response:api_error(bucket_owner_unavailable, RD, Ctx)
-                                    end;
-                                false ->
-                                    %% ACL check failed, deny access
-                                    riak_moss_s3_response:api_error(access_denied, RD, Ctx)
-                            end
-                    end;
-                {error, _Reason} ->
-                    %% Authentication failed, deny access
-                    riak_moss_s3_response:api_error(access_denied, RD, Ctx)
-            end;
-        {error, no_user_key} ->
-            %% User record not provided, check for anonymous access
-            case riak_moss_acl:anonymous_bucket_access(Bucket,
-                                                       RequestedAccess) of
+        riak_moss_acl_utils:requested_access(Method, wrq:req_qs(RD)),
+    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
+    PermCtx = Ctx#context{bucket=Bucket,
+                          requested_perm=RequestedAccess},
+
+    case {Method, RequestedAccess} of
+        {_, 'WRITE'} when User == undefined ->
+            %% unauthed users may neither create nor delete buckets
+            riak_moss_wm_utils:deny_access(RD, PermCtx);
+        {'PUT', 'WRITE'} ->
+            %% authed users are always allowed to attempt bucket creation
+            {false, RD, PermCtx};
+        _ ->
+            %% only owners are allowed to delete buckets
+            case check_grants(PermCtx) of
+                true ->
+                    %% because users are not allowed to create/destroy
+                    %% buckets, we can assume that User is not
+                    %% undefined here
+                    {false, RD, PermCtx};
+                {true, _OwnerId} when RequestedAccess == 'WRITE' ->
+                    %% grants lied: this is a delete, and only the
+                    %% owner is allowed to do that; setting user for
+                    %% the request anyway, so the error tally is
+                    %% logged for them
+                    riak_moss_wm_utils:deny_access(RD, PermCtx);
                 {true, OwnerId} ->
-                    case riak_moss_utils:get_user_by_index(?ID_INDEX,
-                                                           list_to_binary(OwnerId)) of
-                        {ok, {Owner, OwnerVClock}} ->
-                            {false, RD, Ctx#context{user=Owner,
-                                                    user_vclock=OwnerVClock,
-                                                    bucket=Bucket,
-                                                    requested_perm=RequestedAccess}};
-                        {error, _} ->
-                            riak_moss_s3_response:api_error(bucket_owner_unavailable, RD, Ctx)
-                    end;
+                    %% this operation is allowed, but we need to get
+                    %% the owner's record, and log the access against
+                    %% them instead of the actor
+                    shift_to_owner(RD, PermCtx, OwnerId);
                 false ->
-                    %% Anonymous access not allowed, deny access
-                    riak_moss_s3_response:api_error(access_denied, RD, Ctx)
-            end;
-        {error, notfound} ->
-            %% Access not allowed, deny access
-            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx);
-        {error, Reason} ->
-            %% Access not allowed, deny access and log the reason
-            lager:error("Retrieval of user record for ~p failed. Reason: ~p", [KeyId, Reason]),
-            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
+                    riak_moss_wm_utils:deny_access(RD, PermCtx)
+            end
+    end.
+
+%% @doc Call the correct (anonymous or auth'd user) {@link
+%% riak_moss_acl} function to check permissions for this request.
+check_grants(#context{user=undefined,
+                      bucket=Bucket,
+                      requested_perm=RequestedAccess}) ->
+    riak_moss_acl:anonymous_bucket_access(Bucket, RequestedAccess);
+check_grants(#context{user=User,
+                      bucket=Bucket,
+                      requested_perm=RequestedAccess}) ->
+    riak_moss_acl:bucket_access(Bucket,
+                                RequestedAccess,
+                                User?MOSS_USER.canonical_id).
+
+%% @doc The {@link forbidden/2} decision passed, but the bucket
+%% belongs to someone else.  Switch to it if the owner's record can be
+%% retrieved.
+shift_to_owner(RD, Ctx, OwnerId) ->
+    case riak_moss_utils:get_user_by_index(?ID_INDEX,
+                                           list_to_binary(OwnerId)) of
+        {ok, {Owner, OwnerVClock}} ->
+            {false, RD, Ctx#context{user=Owner,
+                                    user_vclock=OwnerVClock}};
+        {error, _} ->
+            riak_moss_s3_response:api_error(bucket_owner_unavailable, RD, Ctx)
     end.
 
 %% @doc Get the list of methods this resource supports.

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -14,7 +14,9 @@
          iso_8601_to_rfc_1123/1,
          to_rfc_1123/1,
          streaming_get/1,
-         user_record_to_proplist/1]).
+         user_record_to_proplist/1,
+         find_and_auth_user/3,
+         deny_access/2]).
 
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
@@ -58,6 +60,74 @@ parse_auth_header("AWS " ++ Key, _) ->
 parse_auth_header(_, _) ->
     {riak_moss_blockall_auth, undefined, undefined}.
 
+%% @doc Lookup the user specified by the access headers, and call
+%% `Next(RD, NewCtx)' if there is no auth error.
+%%
+%% If a user was successfully authed, the `user' and `user_vclock'
+%% fields in the `#context' record passed to `Next' will be filled.
+%% If the access is instead anonymous, those fields will be left as
+%% they were passed to this function.
+%%
+%% If authorization fails (a bad key or signature is given, or the
+%% Riak lookup fails), a tuple suitable for returning from a
+%% webmachine resource's `forbidden/2' function is returned, with
+%% appropriate error message included.
+find_and_auth_user(RD, #context{auth_bypass=AuthBypass}=Ctx, Next) ->
+    case find_and_auth_user(RD, AuthBypass) of
+        {ok, User, UserVclock} ->
+            %% given keyid and signature matched, proceed
+            NewCtx = Ctx#context{user=User,
+                                 user_vclock=UserVclock},
+            Next(RD, NewCtx);
+        {error, no_user_key} ->
+            %% no keyid was given, proceed anonymously
+            Next(RD, Ctx);
+        {error, bad_auth} ->
+            %% given keyid was found, but signature didn't match
+            deny_access(RD, Ctx);
+        {error, _Reason} ->
+            %% no matching keyid was found, or lookup failed
+            deny_invalid_key(RD, Ctx)
+    end.
+
+%% @doc Look for an Authorization header in the request, and validate
+%% it if it exists.  Returns `{ok, User, UserVclock}' if validation
+%% succeeds, or `{error, KeyId, Reason}' if any step fails.
+find_and_auth_user(RD, AuthBypass) ->
+    AuthHeader = wrq:get_req_header("authorization", RD),
+    {AuthMod, KeyId, Signature} = parse_auth_header(AuthHeader, AuthBypass),
+    case riak_moss_utils:get_user(KeyId) of
+        {ok, {User, UserVclock}} ->
+            Secret = User?MOSS_USER.key_secret,
+            case AuthMod:authenticate(RD, Secret, Signature) of
+                ok ->
+                    {ok, User, UserVclock};
+                {error, _Reason} ->
+                    %% TODO: are the errors here of small enough
+                    %% number that we could just handle them in
+                    %% forbidden/2?
+                    {error, bad_auth}
+            end;
+        {error, NE} when NE == notfound; NE == no_user_key ->
+            %% anonymous access lookups don't need to be logged, and
+            %% auth failures are logged by other meands
+            {error, NE};
+        {error, Reason} ->
+            %% other failures, like Riak fetch timeout, be loud about
+            lager:error("Retrieval of user record for ~p failed. Reason: ~p",
+                        [KeyId, Reason]),
+            {error, Reason}
+    end.
+
+%% @doc Produce an access-denied error message from a webmachine
+%% resource's `forbidden/2' function.
+deny_access(RD, Ctx) ->
+    riak_moss_s3_response:api_error(access_denied, RD, Ctx).
+
+%% @doc Prodice an invalid-access-keyid error message from a
+%% webmachine resource's `forbidden/2' function.
+deny_invalid_key(RD, Ctx) ->
+    riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx).
 
 %% @doc Utility function for accessing
 %%      a riakc_obj without retrieving


### PR DESCRIPTION
The `forbidden/2` functions of `riak_moss_wm_key` and `riak_moss_wm_bucket` are where the hooks for access logging need to go.  The versions of these functions on the master branch are deeply nested and full of redundant code.  I had to refactor them on my logging branch to be able to understand where the hooks belonged.  This PR is my refactor without the logging hooks included, such that the refactor can be reviewed on its own.

While the diffs don't lie, I think they make the change look like more of a rewrite than it is.  The goal was to decrease nesting and remove redundant code.  It means there is a little bit of spaghetti, as functions call other functions instead of nesting their cases directly, but I think it has made the phases of authorization a little bit more componentized.  Please read and test.

No user-visible functionality should have changed, so if something _is_ different, yell loudly.
