### PR TITLE
Change LFS chunk naming scheme

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -25,7 +25,14 @@
           creation_date :: string(),
           modification_time :: erlang:timestamp(),
           acl :: acl_v1()}).
--type moss_bucket() :: #moss_bucket_v1{}.
+-record(moss_bucket_v2, {
+          name :: string(),
+          last_action :: created | deleted,
+          bucket_id :: binary(),
+          creation_date :: string(),
+          modification_time :: erlang:timestamp(),
+          acl :: acl_v1()}).
+-type moss_bucket() :: #moss_bucket_v2{}.
 -type bucket_operation() :: create | delete | update_acl.
 -type bucket_action() :: created | deleted.
 
@@ -42,6 +49,7 @@
                       putctype :: string(),
                       bucket :: binary(),
                       key :: list(),
+                      moss_bucket :: false | #moss_bucket_v2{} | #moss_bucket_v1{},
                       size :: non_neg_integer()}).
 
 -type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
@@ -55,7 +63,7 @@
 -type acl_v1() :: #acl_v1{}.
 
 -define(ACL, #acl_v1).
--define(MOSS_BUCKET, #moss_bucket_v1).
+-define(MOSS_BUCKET, #moss_bucket_v2).
 -define(MOSS_USER, #moss_user_v1).
 -define(USER_BUCKET, <<"moss.users">>).
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -157,13 +157,13 @@ finalize_manifest(Manifest, MD5) ->
 
 %% @doc A set of all of the blocks that
 %%      make up the file.
--spec initial_blocks(pos_integer()) -> set().
+-spec initial_blocks(pos_integer()) -> [pos_integer()].
 initial_blocks(ContentLength) ->
     initial_blocks(ContentLength, block_size()).
 
 %% @doc A set of all of the blocks that
 %%      make up the file.
--spec initial_blocks(pos_integer(), pos_integer()) -> set().
+-spec initial_blocks(pos_integer(), pos_integer()) -> [pos_integer()].
 initial_blocks(ContentLength, BlockSize) ->
     UpperBound = block_count(ContentLength, BlockSize),
     lists:seq(0, (UpperBound - 1)).

--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -104,12 +104,14 @@ block_keynames(KeyName, UUID, BlockList) ->
         {BlockSeq, block_name(KeyName, UUID, BlockSeq)} end,
     lists:map(MapFun, BlockList).
 
-block_name(Key, UUID, Number) ->
-    sext:encode({Key, Number, UUID}).
+block_name(_Key, UUID, Number) ->
+    %% 16 bits & 1MB chunk size = 64GB max object size
+    %% 24 bits & 1MB chunk size = 16TB max object size
+    %% 32 bits & 1MB chunk size = 4PB max object size
+    <<UUID/binary, Number:32>>.
 
-block_name_to_term(Name) ->
-    {Key, Number, UUID} = sext:decode(Name),
-    {Key, UUID, Number}.
+block_name_to_term(<<UUID:16/binary, Number:32>>) ->
+    {UUID, Number}.
 
 %% @doc Return the configured block size
 -spec block_size() -> pos_integer().

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -42,8 +42,8 @@
 -compile(export_all).
 -endif.
 
--define(OBJECT_BUCKET_PREFIX, <<"objects:">>).
--define(BLOCK_BUCKET_PREFIX, <<"blocks:">>).
+-define(OBJECT_BUCKET_PREFIX, <<"0o:">>).       % Version # = 0
+-define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0
 
 -type xmlElement() :: #xmlElement{}.
 

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -552,6 +552,10 @@ bucket_record(Name, Operation) ->
     end,
     ?MOSS_BUCKET{name=Name,
                  last_action=Action,
+                 %% SLF TODO: If Action == deleted, then what will break
+                 %%           downstream if this bucket_id doesn't match
+                 %%           the bucket's actual bucket_id?
+                 bucket_id=druuid:v4(),
                  creation_date=riak_moss_wm_utils:iso_8601_datetime(),
                  modification_time=erlang:now()}.
 

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -64,10 +64,11 @@ parse_auth_header(_, _) ->
 %%      it again if it's already in the
 %%      Ctx
 -spec ensure_doc(term()) -> term().
-ensure_doc(Ctx=#key_context{get_fsm_pid=undefined, bucket=Bucket, key=Key}) ->
+ensure_doc(Ctx=#key_context{get_fsm_pid=undefined, bucket=Bucket, moss_bucket=MossBucket, key=Key}) ->
+    BucketId = MossBucket?MOSS_BUCKET.bucket_id,
     %% start the get_fsm
     BinKey = list_to_binary(Key),
-    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(node(), [Bucket, BinKey]),
+    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(node(), [Bucket, BucketId, BinKey]),
     Metadata = riak_moss_get_fsm:get_metadata(Pid),
     Ctx#key_context{get_fsm_pid=Pid, doc_metadata=Metadata};
 ensure_doc(Ctx) -> Ctx.

--- a/test/riak_moss_delete_fsm_eqc.erl
+++ b/test/riak_moss_delete_fsm_eqc.erl
@@ -77,6 +77,7 @@ prop_delete_fsm() ->
                    {ok, FsmPid} =
                        ?TESTMODULE:test_link([{deleter_pid, DummyPid}],
                                              Bucket,
+                                             <<"bucket_id">>,
                                              FileName,
                                              10000),
 

--- a/test/riak_moss_deleter_test.erl
+++ b/test/riak_moss_deleter_test.erl
@@ -37,6 +37,7 @@ initialize_case({DeleterPid, ReceiverPid}) ->
     Result = riak_moss_deleter:initialize(DeleterPid,
                                           ReceiverPid,
                                           <<"testbucket">>,
+                                          <<"testbucket_id">>,
                                           <<"testfile">>),
     {"initialize response test",
      fun() ->

--- a/test/riak_moss_get_fsm_eqc.erl
+++ b/test/riak_moss_get_fsm_eqc.erl
@@ -99,7 +99,7 @@ prop_get_fsm() ->
 %%====================================================================
 
 start_fsm(ContentLength, BlockSize) ->
-    {ok, FSMPid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
+    {ok, FSMPid} = riak_moss_get_fsm:test_link(<<"bucket">>, <<"bucket_id">>, <<"key">>, ContentLength, BlockSize),
     _Metadata = riak_moss_get_fsm:get_metadata(FSMPid),
     riak_moss_get_fsm:continue(FSMPid),
     FSMPid.

--- a/test/riak_moss_put_fsm_eqc.erl
+++ b/test/riak_moss_put_fsm_eqc.erl
@@ -80,6 +80,7 @@ prop_put_fsm() ->
                    {ok, FsmPid} =
                        ?TESTMODULE:test_link([{writer_pid, DummyPid}],
                                              Bucket,
+                                             <<"bucket_id">>,
                                              FileName,
                                              ContentLength,
                                              "text/plain",

--- a/test/riak_moss_writer_test.erl
+++ b/test/riak_moss_writer_test.erl
@@ -37,6 +37,7 @@ initialize_case({WriterPid, ReceiverPid}) ->
     Result = riak_moss_writer:initialize(WriterPid,
                                          ReceiverPid,
                                          <<"testbucket">>,
+                                         <<"testbucket_id">>,
                                          <<"testfile">>,
                                          1024,
                                         "text/plain"),


### PR DESCRIPTION
Fixes #175, partially.
- Change KV bucket naming convention for S3 object bucket and LFS block bucket.
- Change KV key naming convention for LFS block keys.

Still missing: changes to stanchion to create a UUID for each S3 bucket so that the KV bucket name can be a fixed size.
