### PR TITLE
Check group grants even if user has other grants specified in the ACL.

### DIFF
--- a/src/riak_moss_acl.erl
+++ b/src/riak_moss_acl.erl
@@ -216,12 +216,13 @@ has_permission(Acl, RequestedAccess) ->
 -spec has_permission(acl_v1(), atom(), string()) -> boolean().
 has_permission(Acl, RequestedAccess, CanonicalId) ->
     Grants = Acl?ACL.grants,
+    GroupGrants = group_grants(Acl?ACL.grants, []),
     case user_grant(Grants, CanonicalId) of
         undefined ->
-            GroupGrants = group_grants(Acl?ACL.grants, []),
             has_group_permission(GroupGrants, RequestedAccess);
         {_, Perms} ->
-            check_permission(RequestedAccess, Perms)
+            check_permission(RequestedAccess, Perms) orelse
+                has_group_permission(GroupGrants, RequestedAccess)
     end.
 
 %% @doc Determine if a user is the owner of a system entity.


### PR DESCRIPTION
Group grants were ignored if the user issuing the request had other
permissions in the ACL. This change makes sure group grants are also
check in that case.
## Testing
1. Create a bucket with public read access: `s3cmd mb -P s3://testbucket`
2. Add `READ_ACP` permissions for a user who is not the bucket owner: `s3cmd setacl --acl-grant=read_acp:<user_email_here> s3://testbucket`
3. Attempt to get the bucket's info using the credentials of the non-bucket-owner user: `s3cmd info s3://testbucket`

On `master` this should fail with a `403 Forbidden` error, but should work using the `s177-fix-group-grant-check` branch.
