### PR TITLE
S157 multi backend

### DIFF
--- a/README.multi-backend.txt
+++ b/README.multi-backend.txt
@@ -44,7 +44,7 @@ Step 2: Edit the Riak "app.config" file to configure the multi backend
                 /opt/riak/data
 
             Riak developer source data directory path:
-                ./rel/riak/data
+                ./data
 
     Step b: Use a text editor to edit the 'riak_kv' section of the Riak
             "app.config" file.

--- a/README.multi-backend.txt
+++ b/README.multi-backend.txt
@@ -1,0 +1,80 @@
+Configuring Riak KV's multi backend storage manager for use with Riak CS
+========================================================================
+
+TODO: Proofread all of these paths and steps.
+
+Step 1: Copy the storage manager object code (a single BEAM file) from
+        the Riak CS package to the Riak package's patch dir.
+
+    Step a: Locate the multi backend storage manager object code.
+
+            RCS Linux installation path:
+                /usr/lib64/riak_cs/lib/riak_moss-*/ebin/riak_cs_kv_multi_backend.beam
+            RCS Solaris installation path:
+                /opt/riak_cs/lib/riak_moss-*/ebin/riak_cs_kv_multi_backend.beam
+
+            Developer source (after a "make stage" or "make dev" compilation):
+                ./rel/riak_cs/lib/riak_moss-*/ebin/riak_cs_kv_multi_backend.beam
+
+    Step b: Locate the patch directory for Riak
+
+            RCS Linux installation path:
+                /usr/lib64/riak/lib/basho-patches
+
+            RCS Solaris installation path:
+                /opt/riak/lib/basho-patches
+
+            Developer source (after a "make stage" or "make dev" compilation):
+                ./rel/riak/lib/basho-patches
+
+    Step c: Copy the BEAM file from step a to the directory in step b.
+            For example:
+
+                cp /usr/lib64/riak_cs/lib/riak_moss-*/ebin/riak_cs_kv_multi_backend.beam /usr/lib64/riak/lib/basho-patches
+
+Step 2: Edit the Riak "app.config" file to configure the multi backend
+        storage manager
+
+    Step a: Identify the directory that will be storing Riak's data.
+
+            Riak Linux data directory path:
+                /var/lib/riak
+
+            Riak Solaris data directory path:
+                /opt/riak/data
+
+            Riak developer source data directory path:
+                ./rel/riak/data
+
+    Step b: Use a text editor to edit the 'riak_kv' section of the Riak
+            "app.config" file.
+
+            Riak Linux config file path:
+                /etc/riak/app.config
+
+            Riak Solaris config file path:
+                /opt/riak/etc/app.config
+
+            Riak developer source config file path:
+                ./rel/riak/etc/app.config
+
+    Remove the default backend configuration statement:
+
+        {storage_backend, riak_kv_bitcask_backend},
+
+    ... with the following lines.  In all places where the string
+    DATADIR appears, substitute the data directory path from step a.
+
+        {storage_backend, riak_cs_kv_multi_backend},
+        {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
+        {multi_backend_default, be_default},
+        {multi_backend, [
+           % format: {name, module, [Configs]}
+           {be_default, riak_kv_eleveldb_backend, [
+             {max_open_files, 50},
+             {data_root, "DATADIR/leveldb"}
+           ]},
+           {be_blocks, riak_kv_bitcask_backend, [
+             {data_root, "DATADIR/bitcask"}
+          ]}
+         ]},

--- a/src/riak_cs_kv_multi_backend.erl
+++ b/src/riak_cs_kv_multi_backend.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riak_multi_backend: switching between multiple storage engines
+%% riak_cs_kv_multi_backend: switching between multiple storage engines
 %%
 %% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -20,7 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module (riak_kv_multi_backend).
+-module (riak_cs_kv_multi_backend).
 -behavior(riak_kv_backend).
 
 %% KV Backend API

--- a/src/riak_cs_kv_multi_backend.erl
+++ b/src/riak_cs_kv_multi_backend.erl
@@ -1,0 +1,703 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_multi_backend: switching between multiple storage engines
+%%
+%% Copyright (c) 2007-2010 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module (riak_kv_multi_backend).
+-behavior(riak_kv_backend).
+
+%% KV Backend API
+-export([api_version/0,
+         capabilities/1,
+         capabilities/2,
+         start/2,
+         stop/1,
+         get/3,
+         put/5,
+         delete/4,
+         drop/1,
+         fold_buckets/4,
+         fold_keys/4,
+         fold_objects/4,
+         is_empty/1,
+         status/1,
+         callback/3]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-define(API_VERSION, 1).
+-define(CAPABILITIES, [async_fold]).
+
+-record (state, {backends :: [{atom(), atom(), term()}],
+                 bprefix_list :: [{binary(), atom()}],
+                 default_backend :: atom()}).
+
+-type state() :: #state{}.
+-type config() :: [{atom(), term()}].
+
+%% @doc riak_kv_multi_backend allows you to run multiple backends within a
+%% single Riak instance. The 'backend' property of a bucket specifies
+%% the backend in which the object should be stored. If no 'backend'
+%% is specified, then the 'multi_backend_default' setting is used.
+%% If this is unset, then the first defined backend is used.
+%%
+%% If the 'multi_backend_prefix_list' list is defined and is non-empty,
+%% that list determines bucket name prefixes -> backend names.  (Default
+%% value = empty list.)  For example:
+%%
+%%     {multi_backend_prefix_list, [{<<"c">>, be_1}, {<<"p">>, be_2}]},
+%%
+%% ... would use the backend named 'be_1' for all buckets that begin
+%% with the prefix "c" and use the backend named 'be_2' for all
+%% backends that begin with the prefix "p".
+%%
+%% NOTE: The 'multi_backend_prefix_list' is checked *prior* to
+%%       checking the bucket-specific configuration in Core's ring.
+%%       (By definition, bucket-specific configuration must match the
+%%       entire bucket name.)
+%%
+%% === Configuration ===
+%%
+%%     {storage_backend, riak_kv_multi_backend},
+%%     {multi_backend_default, first_backend},
+%%     %% format for PrefixTuples: {<<"bucket_prefix_string">>, backend_name}
+%%     {multi_backend_prefix_list, [PrefixTuples]},
+%%     {multi_backend, [
+%%       % format: {name, module, [Configs]}
+%%       {first_backend, riak_xxx_backend, [
+%%         {config1, ConfigValue1},
+%%         {config2, ConfigValue2}
+%%       ]},
+%%       {second_backend, riak_yyy_backend, [
+%%         {config1, ConfigValue1},
+%%         {config2, ConfigValue2}
+%%       ]}
+%%     ]}
+%%
+%%
+%% Then, tell a bucket which one to use...
+%%
+%%     riak_core_bucket:set_bucket(&lt;&lt;"MY_BUCKET"&gt;&gt;, [{backend, second_backend}])
+%%
+%%
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Return the major version of the
+%% current API.
+-spec api_version() -> {ok, integer()}.
+api_version() ->
+    {ok, ?API_VERSION}.
+
+%% @doc Return the capabilities of the backend.
+-spec capabilities(state()) -> {ok, [atom()]}.
+capabilities(State) ->
+    %% Expose ?CAPABILITIES plus the intersection of all child
+    %% backends. (This backend creates a shim for any backends that
+    %% don't support async_fold.)
+    F = fun({_, Mod, ModState}, Acc) ->
+                {ok, S1} = Mod:capabilities(ModState),
+                S2 = ordsets:from_list(S1),
+                ordsets:intersection(Acc, S2)
+        end,
+    Caps1 = lists:foldl(F, ordsets:new(), State#state.backends),
+    Caps2 = ordsets:to_list(Caps1),
+
+    Capabilities = lists:usort(?CAPABILITIES ++ Caps2),
+    {ok, Capabilities}.
+
+%% @doc Return the capabilities of the backend.
+-spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+capabilities(Bucket, State) when is_binary(Bucket) ->
+    {_Name, Mod, ModState} = get_backend(Bucket, State),
+    Mod:capabilities(ModState);
+capabilities(_Bucket, State) ->
+    capabilities(State).
+
+%% @doc Start the backends
+-spec start(integer(), config()) -> {ok, state()} | {error, term()}.
+start(Partition, Config) ->
+    %% Sanity checking
+    BPrefixList =  app_helper:get_prop_or_env(multi_backend_prefix_list, Config,
+                                              riak_kv, []),
+    Defs =  app_helper:get_prop_or_env(multi_backend, Config, riak_kv),
+    if Defs =:= undefined ->
+            {error, multi_backend_config_unset};
+       not is_list(Defs) ->
+            {error, {invalid_config_setting,
+                     multi_backend,
+                     list_expected}};
+       length(Defs) =< 0 ->
+            {error, {invalid_config_setting,
+                     multi_backend,
+                     list_is_empty}};
+       true ->
+            {First, _, _} = hd(Defs),
+
+            %% Get the default
+            DefaultBackend = app_helper:get_prop_or_env(multi_backend_default, Config, riak_kv, First),
+            case lists:keymember(DefaultBackend, 1, Defs) of
+                true ->
+                    %% Start the backends
+                    BackendFun = start_backend_fun(Partition),
+                    {Backends, Errors} =
+                        lists:foldl(BackendFun, {[], []}, Defs),
+                    case {Errors, bprefix_sanity_check(Backends,BPrefixList)} of
+                        {[], ok} ->
+                            {ok, #state{backends=Backends,
+                                        bprefix_list=BPrefixList,
+                                        default_backend=DefaultBackend}};
+                        {[], BPrefixErrors} ->
+                            {error, BPrefixErrors};
+                        {_, _} ->
+                            {error, Errors}
+                    end;
+                false ->
+                    {error, {invalid_config_setting,
+                             multi_backend_default,
+                             backend_not_found}}
+            end
+    end.
+
+%% @private
+start_backend_fun(Partition) ->
+    fun({Name, Module, ModConfig}, {Backends, Errors}) ->
+            try
+                case start_backend(Name,
+                                   Module,
+                                   Partition,
+                                   ModConfig) of
+                    {Module, Reason} ->
+                        {Backends,
+                         [{Module, Reason} | Errors]};
+                    Backend ->
+                        {[Backend | Backends],
+                         Errors}
+                end
+            catch _:Error ->
+                    {Backends,
+                     [{Module, Error} | Errors]}
+            end
+    end.
+
+%% @private
+start_backend(Name, Module, Partition, Config) ->
+    try
+        case Module:start(Partition, Config) of
+            {ok, State} ->
+                {Name, Module, State};
+            {error, Reason} ->
+                {Module, Reason}
+        end
+    catch
+        _:Reason1 ->
+             {Module, Reason1}
+    end.
+
+%% @doc Stop the backends
+-spec stop(state()) -> ok.
+stop(#state{backends=Backends}) ->
+    [Module:stop(SubState) || {_, Module, SubState} <- Backends],
+    ok.
+
+%% @doc Retrieve an object from the backend
+-spec get(riak_object:bucket(), riak_object:key(), state()) ->
+                 {ok, any(), state()} |
+                 {ok, not_found, state()} |
+                 {error, term(), state()}.
+get(Bucket, Key, State) ->
+    {Name, Module, SubState} = get_backend(Bucket, State),
+    case Module:get(Bucket, Key, SubState) of
+        {ok, Value, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {ok, Value, NewState};
+        {error, Reason, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {error, Reason, NewState}
+    end.
+
+%% @doc Insert an object with secondary index
+%% information into the kv backend
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, IndexSpecs, Value, State) ->
+    {Name, Module, SubState} = get_backend(Bucket, State),
+    case Module:put(Bucket, PrimaryKey, IndexSpecs, Value, SubState) of
+        {ok, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {ok, NewState};
+        {error, Reason, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {error, Reason, NewState}
+    end.
+
+%% @doc Delete an object from the backend
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
+                    {ok, state()} |
+                    {error, term(), state()}.
+delete(Bucket, Key, IndexSpecs, State) ->
+    {Name, Module, SubState} = get_backend(Bucket, State),
+    case Module:delete(Bucket, Key, IndexSpecs, SubState) of
+        {ok, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {ok, NewState};
+        {error, Reason, NewSubState} ->
+            NewState = update_backend_state(Name, Module, NewSubState, State),
+            {error, Reason, NewState}
+    end.
+
+%% @doc Fold over all the buckets
+-spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
+                   any(),
+                   [{atom(), term()}],
+                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
+    fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State).
+
+%% @doc Fold over all the keys for one or all buckets.
+-spec fold_keys(riak_kv_backend:fold_keys_fun(),
+                any(),
+                [{atom(), term()}],
+                state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_keys(FoldKeysFun, Acc, Opts, State) ->
+    case proplists:get_value(bucket, Opts) of
+        undefined ->
+            fold_all(fold_keys, FoldKeysFun, Acc, Opts, State);
+        Bucket ->
+            fold_in_bucket(Bucket, fold_keys, FoldKeysFun, Acc, Opts, State)
+    end.
+
+%% @doc Fold over all the objects for one or all buckets.
+-spec fold_objects(riak_kv_backend:fold_objects_fun(),
+                   any(),
+                   [{atom(), term()}],
+                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_objects(FoldObjectsFun, Acc, Opts, State) ->
+    case proplists:get_value(bucket, Opts) of
+        undefined ->
+            fold_all(fold_objects, FoldObjectsFun, Acc, Opts, State);
+        Bucket ->
+            fold_in_bucket(Bucket, fold_objects, FoldObjectsFun, Acc, Opts, State)
+    end.
+
+%% @doc Delete all objects from the different backends
+-spec drop(state()) -> {ok, state()} | {error, term(), state()}.
+drop(#state{backends=Backends}=State) ->
+    Fun = fun({Name, Module, SubState}) ->
+                  case Module:drop(SubState) of
+                      {ok, NewSubState} ->
+                          {Name, Module, NewSubState};
+                      {error, Reason, NewSubState} ->
+                          {error, Reason, NewSubState}
+                  end
+          end,
+    DropResults = [Fun(Backend) || Backend <- Backends],
+    {Errors, UpdBackends} =
+        lists:splitwith(fun error_filter/1, DropResults),
+    case Errors of
+        [] ->
+            {ok, State#state{backends=UpdBackends}};
+        _ ->
+            {error, Errors, State#state{backends=UpdBackends}}
+    end.
+
+%% @doc Returns true if the backend contains any
+%% non-tombstone values; otherwise returns false.
+-spec is_empty(state()) -> boolean().
+is_empty(#state{backends=Backends}) ->
+    Fun = fun({_, Module, SubState}) ->
+                  Module:is_empty(SubState)
+          end,
+    lists:all(Fun, Backends).
+
+%% @doc Get the status information for this backend
+-spec status(state()) -> [{atom(), term()}].
+status(#state{backends=Backends}) ->
+    %% @TODO Reexamine how this is handled
+    [{N, Mod:status(ModState)} || {N, Mod, ModState} <- Backends].
+
+%% @doc Register an asynchronous callback
+-spec callback(reference(), any(), state()) -> {ok, state()}.
+callback(Ref, Msg, #state{backends=Backends}=State) ->
+    %% Pass the callback on to all submodules - their responsbility to
+    %% filter out if they need it.
+    [Mod:callback(Ref, Msg, ModState) || {_N, Mod, ModState} <- Backends],
+    {ok, State}.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @private
+%% Given a Bucket name and the State, return the
+%% backend definition. (ie: {Name, Module, SubState})
+get_backend(Bucket, #state{backends=Backends,
+                           bprefix_list=BPrefixList} = State) ->
+    case match_bucket_prefix(Bucket, BPrefixList) of
+        undefined ->
+            get_backend_bucketprops(Bucket, State);
+        BackendName ->
+            %% Sanity check at start() => keyfind will always succeed
+            lists:keyfind(BackendName, 1, Backends)
+    end.
+
+get_backend_bucketprops(Bucket, #state{backends=Backends,
+                                       default_backend=DefaultBackend}) ->
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    BackendName = proplists:get_value(backend, BucketProps, DefaultBackend),
+    %% Ensure that a backend by that name exists...
+    case lists:keyfind(BackendName, 1, Backends) of
+        false -> throw({?MODULE, undefined_backend, BackendName});
+        Backend -> Backend
+    end.
+
+%% @private
+%% @doc Update the state for one of the
+%% composing backends of this multi backend.
+update_backend_state(Backend,
+                     Module,
+                     ModState,
+                     State=#state{backends=Backends}) ->
+    NewBackends = lists:keyreplace(Backend,
+                                   1,
+                                   Backends,
+                                   {Backend, Module, ModState}),
+    State#state{backends=NewBackends}.
+
+%% @private
+%% @doc Shared code used by all the backend fold functions.
+fold_all(ModFun, FoldFun, Acc, Opts, State) ->
+    Backends = State#state.backends,
+    try
+        AsyncFold = lists:member(async_fold, Opts),
+        {Acc0, AsyncWorkList} =
+            lists:foldl(backend_fold_fun(ModFun,
+                                         FoldFun,
+                                         Opts,
+                                         AsyncFold),
+                        {Acc, []},
+                        Backends),
+
+        %% We have now accumulated the results for all of the
+        %% synchronous backends. The next step is to wrap the
+        %% asynchronous work in a function that passes the accumulator
+        %% to each successive piece of asynchronous work.
+        case AsyncWorkList of
+            [] ->
+                %% Just return the synchronous results
+                {ok, Acc0};
+            _ ->
+                AsyncWork =
+                    fun() ->
+                            lists:foldl(async_fold_fun(), Acc0, AsyncWorkList)
+                    end,
+                {async, AsyncWork}
+        end
+    catch
+        Error ->
+            Error
+    end.
+
+fold_in_bucket(Bucket, ModFun, FoldFun, Acc, Opts, State) ->
+    {_Name, Module, SubState} = get_backend(Bucket, State),
+    Module:ModFun(FoldFun,
+                  Acc,
+                  Opts,
+                  SubState).
+
+%% @private
+backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold) ->
+    fun({_, Module, SubState}, {Acc, WorkList}) ->
+            %% Get the backend capabilities to determine
+            %% if it supports asynchronous folding.
+            {ok, ModCaps} = Module:capabilities(SubState),
+            case AsyncFold andalso
+                lists:member(async_fold, ModCaps) of
+                true ->
+                    AsyncWork =
+                        fun(Acc1) ->
+                                Module:ModFun(FoldFun,
+                                              Acc1,
+                                              Opts,
+                                              SubState)
+                        end,
+                    {Acc, [AsyncWork | WorkList]};
+                false ->
+                    Result = Module:ModFun(FoldFun,
+                                           Acc,
+                                           Opts,
+                                           SubState),
+                    case Result of
+                        {ok, Acc1} ->
+                            {Acc1, WorkList};
+                        {error, Reason} ->
+                            throw({error, {Module, Reason}})
+                    end
+            end
+    end.
+
+async_fold_fun() ->
+    fun(AsyncWork, Acc) ->
+            case AsyncWork(Acc) of
+                {ok, Acc1} ->
+                    Acc1;
+                {async, AsyncFun} ->
+                    AsyncFun();
+                {error, Reason} ->
+                    throw({error, Reason})
+            end
+    end.
+
+%% @private
+%% @doc Function to filter error results when
+%% calling a function on the entire list of
+%% backends composing this multi backend.
+error_filter({error, _, _}) ->
+    true;
+error_filter(_) ->
+    false.
+
+%% @private
+%% @edoc Check sanity of the BPrefixList against the backends we've started.
+bprefix_sanity_check(Backends, BPrefixList) ->
+    BackendNames = [Name || {Name, _Mod, _St} <- Backends],
+    MyNames = [Name || {_BPrefix, Name} <- BPrefixList],
+    case MyNames -- BackendNames of
+        [] ->
+            ok;
+        UnknownNames ->
+            {unknown_backend_names, UnknownNames}
+    end.
+
+%% @private
+%% @edoc Check BucketName against a list of prefixes
+match_bucket_prefix(_Bucket, []) ->
+    undefined;
+%% match_bucket_prefix(Bucket, [{Prefix, _Name}|BPrefixList])
+%%   when size(Bucket) < size(Prefix) ->
+%%     match_bucket_prefix(Bucket, BPrefixList);
+match_bucket_prefix(Bucket, [{Prefix, Name}|BPrefixList]) ->
+    PrefixSize = size(Prefix),
+    case Bucket of
+        <<Prefix:PrefixSize/binary, _/binary>> ->
+            Name;
+        _ ->
+            match_bucket_prefix(Bucket, BPrefixList)
+    end.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+%% @private
+multi_backend_test_() ->
+    {foreach,
+     fun() ->
+             crypto:start(),
+
+             %% start the ring manager
+             {ok, P1} = riak_core_ring_events:start_link(),
+             {ok, P2} = riak_core_ring_manager:start_link(test),
+             application:load(riak_core),
+             application:set_env(riak_core, default_bucket_props, []),
+
+             %% Have to do some prep for bitcask
+             application:load(bitcask),
+             ?assertCmd("rm -rf test/bitcask-backend"),
+             application:set_env(bitcask, data_root, "test/bitcask-backend"),
+
+             [P1, P2]
+     end,
+     fun([P1, P2]) ->
+             crypto:stop(),
+             ?assertCmd("rm -rf test/bitcask-backend"),
+             unlink(P1),
+             unlink(P2),
+             catch exit(P1, kill),
+             catch exit(P2, kill),
+             wait_until_dead(P1),
+             wait_until_dead(P2)
+     end,
+     [
+      fun(_) ->
+              {"simple test",
+               fun() ->
+                       riak_core_bucket:set_bucket(<<"b1">>, [{backend, first_backend}]),
+                       riak_core_bucket:set_bucket(<<"b2">>, [{backend, second_backend}]),
+
+                       %% Run the standard backend test...
+                       Config = sample_config(),
+                       riak_kv_backend:standard_test(?MODULE, Config)
+               end
+              }
+      end,
+      fun(_) ->
+              {"get_backend_test",
+               fun() ->
+                       riak_core_bucket:set_bucket(<<"b1">>, [{backend, first_backend}]),
+                       riak_core_bucket:set_bucket(<<"b2">>, [{backend, second_backend}]),
+
+                       %% Start the backend...
+                       {ok, State} = start(42, sample_config()),
+
+                       %% Check our buckets...
+                       {first_backend, riak_kv_memory_backend, _} = get_backend(<<"b1">>, State),
+                       {second_backend, riak_kv_memory_backend, _} = get_backend(<<"b2">>, State),
+
+                       %% Check the default...
+                       {second_backend, riak_kv_memory_backend, _} = get_backend(<<"b3">>, State),
+                       ok
+               end
+              }
+      end,
+      fun(_) ->
+              {"start error with invalid backend test",
+               fun() ->
+                       %% Attempt to start the backend with a
+                       %% nonexistent backend specified
+                       ?assertEqual({error, [{riak_kv_devnull_backend, undef}]},
+                                    start(42, bad_backend_config()))
+               end
+              }
+      end
+     ]
+    }.
+
+-ifdef(EQC).
+
+%% @private
+eqc_test_() ->
+    {spawn,
+     [{inorder,
+       [{setup,
+         fun setup/0,
+         fun cleanup/1,
+         [?_assertEqual(true,
+                        backend_eqc:test(?MODULE, true, sample_config())),
+          ?_assertEqual(true,
+                        backend_eqc:test(?MODULE, true, async_fold_config()))
+         ]}]}]}.
+
+setup() ->
+    %% Start the ring manager...
+    crypto:start(),
+    {ok, P1} = riak_core_ring_events:start_link(),
+    {ok, P2} = riak_core_ring_manager:start_link(test),
+
+    %% Set some buckets...
+    application:load(riak_core), % make sure default_bucket_props is set
+    application:set_env(riak_core, default_bucket_props, []),
+    riak_core_bucket:set_bucket(<<"b1">>, [{backend, first_backend}]),
+    riak_core_bucket:set_bucket(<<"b2">>, [{backend, second_backend}]),
+
+    {P1, P2}.
+
+cleanup({P1, P2}) ->
+    crypto:stop(),
+    application:stop(riak_core),
+
+    unlink(P1),
+    unlink(P2),
+    catch exit(P1, kill),
+    catch exit(P2, kill),
+    wait_until_dead(P1),
+    wait_until_dead(P2).
+
+async_fold_config() ->
+    [
+     {storage_backend, riak_kv_multi_backend},
+     {multi_backend_default, second_backend},
+      {multi_backend, [
+                      {first_backend, riak_kv_memory_backend, []},
+                      {second_backend, riak_kv_memory_backend, []}
+                     ]}
+    ].
+
+-endif. % EQC
+
+%% Check extra callback messages are ignored by backends
+extra_callback_test() ->
+    %% Have to do some prep for bitcask
+    application:load(bitcask),
+    ?assertCmd("rm -rf test/bitcask-backend"),
+    application:set_env(bitcask, data_root, "test/bitcask-backend"),
+
+    %% Have to do some prep for eleveldb
+    application:load(eleveldb),
+    ?assertCmd("rm -rf test/eleveldb-backend"),
+    application:set_env(eleveldb, data_root, "test/eleveldb-backend"),
+
+    %% Start up multi backend
+    Config = [{storage_backend, riak_kv_multi_backend},
+              {multi_backend_default, memory},
+              {multi_backend,
+               [{bitcask, riak_kv_bitcask_backend, []},
+                {memory, riak_kv_memory_backend, []},
+                {eleveldb, riak_kv_eleveldb_backend, []}]}],
+    {ok, State} = start(0, Config),
+    callback(make_ref(), ignore_me, State),
+    stop(State),
+    application:stop(bitcask).
+
+bad_config_test() ->
+    ErrorReason = multi_backend_config_unset,
+    ?assertEqual({error, ErrorReason}, start(0, [])).
+
+sample_config() ->
+    [
+     {storage_backend, riak_kv_multi_backend},
+     {multi_backend_default, second_backend},
+      {multi_backend, [
+                      {first_backend, riak_kv_memory_backend, []},
+                      {second_backend, riak_kv_memory_backend, []}
+                     ]}
+    ].
+
+bad_backend_config() ->
+    [
+     {storage_backend, riak_kv_multi_backend},
+     {multi_backend_default, second_backend},
+      {multi_backend, [
+                      {first_backend, riak_kv_devnull_backend, []},
+                      {second_backend, riak_kv_memory_backend, []}
+                     ]}
+    ].
+
+%% Minor sin of cut-and-paste....
+wait_until_dead(Pid) when is_pid(Pid) ->
+    Ref = monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, _Obj, Info} ->
+            Info
+    after 10*1000 ->
+            exit({timeout_waiting_for, Pid})
+    end;
+wait_until_dead(_) ->
+    ok.
+
+-endif.

--- a/src/riak_kv_fs2_backend.erl
+++ b/src/riak_kv_fs2_backend.erl
@@ -1,0 +1,351 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_fs2_backend: storage engine based on basic filesystem access
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+% @doc riak_kv_fs2_backend is filesystem storage system, Mark III
+
+-module(riak_kv_fs2_backend).
+-behavior(riak_kv_backend).
+
+%% KV Backend API
+-export([api_version/0,
+         capabilities/1,
+         capabilities/2,
+         start/2,
+         stop/1,
+         get/3,
+         put/5,
+         delete/4,
+         drop/1,
+         fold_buckets/4,
+         fold_keys/4,
+         fold_objects/4,
+         is_empty/1,
+         status/1,
+         callback/3]).
+
+-define(API_VERSION, 1).
+-define(CAPABILITIES, []).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-record(state, {dir}).
+-type state() :: #state{}.
+-type config() :: [{atom(), term()}].
+
+%% @doc Return the major version of the
+%% current API.
+-spec api_version() -> {ok, integer()}.
+api_version() ->
+    {ok, ?API_VERSION}.
+
+%% @doc Return the capabilities of the backend.
+-spec capabilities(state()) -> {ok, [atom()]}.
+capabilities(_) ->
+    {ok, ?CAPABILITIES}.
+
+%% @doc Return the capabilities of the backend.
+-spec capabilities(riak_object:bucket(), state()) -> {ok, [atom()]}.
+capabilities(_, _) ->
+    {ok, ?CAPABILITIES}.
+
+%% @doc Start this backend.  'riak_kv_fs_backend_root' must be set in
+%%      Riak's application environment.  It must be set to a string
+%%      representing the base directory where this backend should
+%%      store its files.
+-spec start(integer(), config()) -> {ok, state()} | {error, term()}.
+start(Partition, Config) ->
+    PartitionName = integer_to_list(Partition),
+    ConfigRoot = app_helper:get_prop_or_env(fs_backend_data_root, Config, riak_kv),
+    if
+        ConfigRoot =:= undefined ->
+            riak:stop("fs_backend_data_root unset, failing");
+        true ->
+            ok
+    end,
+    Dir = filename:join([ConfigRoot,PartitionName]),
+    {filelib:ensure_dir(Dir), #state{dir=Dir}}.
+
+-spec stop(state()) -> ok.
+stop(_State) -> ok.
+
+%% @doc Get the object stored at the given bucket/key pair
+-spec get(riak_object:bucket(), riak_object:key(), state()) ->
+                 {ok, any(), state()} |
+                 {ok, not_found, state()} |
+                 {error, term(), state()}.
+get(Bucket, Key, State) ->
+    File = location(State, {Bucket, Key}),
+    case filelib:is_file(File) of
+        false -> {error, not_found, State};
+        true -> {ok, element(2, file:read_file(File)), State}
+    end.
+
+%% @spec atomic_write(File :: string(), Val :: binary()) ->
+%%       ok | {error, Reason :: term()}
+%% @doc store a atomic value to disk. Write to temp file and rename to
+%%       normal path.
+atomic_write(File, Val) ->
+    FakeFile = File ++ ".tmpwrite",
+    case file:write_file(FakeFile, Val) of
+        ok ->
+            file:rename(FakeFile, File);
+        X -> X
+    end.
+
+%% @doc Store Val under Bkey
+-type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
+                 {ok, state()} |
+                 {error, term(), state()}.
+put(Bucket, PrimaryKey, _IndexSpecs, Val, State) ->       
+    File = location(State, {Bucket, PrimaryKey}),
+    case filelib:ensure_dir(File) of
+        ok         -> {atomic_write(File, Val), State};
+        {error, X} -> {error, X, State}
+    end.
+
+%% @doc Delete the object stored at BKey
+-spec delete(riak_object:bucket(), riak_object:key(), [index_spec()], state()) ->
+                    {ok, state()} |
+                    {error, term(), state()}.
+delete(Bucket, Key, _IndexSpecs, State) ->
+    File = location(State, {Bucket, Key}),
+    case file:delete(File) of
+        ok -> {ok, State};
+        {error, enoent} -> {ok, State};
+        {error, Err} -> {error, Err, State}
+    end.
+
+-ifdef(SLF_COMMENT).
+
+%% @spec list(state()) -> [{Bucket :: riak_object:bucket(),
+%%                          Key :: riak_object:key()}]
+%% @doc Get a list of all bucket/key pairs stored by this backend
+list(State) ->
+    % this is slow slow slow
+    %                                              B,N,N,N,K
+    [location_to_bkey(X) || X <- filelib:wildcard("*/*/*/*/*",
+                                                  State#state.dir)].
+
+
+%% @spec list_bucket(state(), riak_object:bucket()) ->
+%%           [riak_object:key()]
+%% @doc Get a list of the keys in a bucket
+list_bucket(State, Bucket) ->
+    case Bucket of
+        '_' ->
+            lists:usort(lists:map(fun({B, _}) -> B end, list(State)));
+        {filter, B, Fun} ->
+            [ hd(K) || K <-
+                lists:filter(Fun,
+                    [ EV || EV <- lists:map(fun(K) ->
+                                                case K of
+                                                    {B, Key} -> [Key];
+                                                    _ -> []
+                                                end
+                                            end, list(State)),
+                            EV /= [] ]) ];
+        _ ->
+            B64 = encode_bucket(Bucket),
+            L = length(State#state.dir),
+            [ K || {_,K} <- [ location_to_bkey(lists:nthtail(L, X)) ||
+                                X <- filelib:wildcard(
+                                       filename:join([State#state.dir,
+                                                      B64,"*/*/*/*"])) ]]
+    end.
+
+is_empty(State) -> ?MODULE:list(State) =:= [].
+
+fold(State, Fun0, Acc) ->
+    Fun = fun(BKey, AccIn) -> 
+                  case ?MODULE:get(State, BKey) of
+                      {ok, Bin} ->
+                          Fun0(BKey, Bin, AccIn);
+                      _ ->
+                          AccIn
+                  end
+          end,
+    lists:foldl(Fun, Acc, ?MODULE:list(State)).
+
+-endif. % SLF_COMMENT
+
+%% @doc Fold over all the buckets.
+-spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
+                   any(),
+                   [],
+                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_buckets(_FoldBucketsFun, Acc, _Opts, _S) ->
+    Acc.                                        % lazy!
+
+%% @doc Fold over all the keys for one or all buckets.
+-spec fold_keys(riak_kv_backend:fold_keys_fun(),
+                any(),
+                [{atom(), term()}],
+                state()) -> {ok, term()} | {async, fun()} | {error, term()}.
+fold_keys(_FoldKeysFun, Acc, _Opts, _S) ->
+    Acc.                                        % lazy!
+
+%% @doc Fold over all the objects for one or all buckets.
+-spec fold_objects(riak_kv_backend:fold_objects_fun(),
+                   any(),
+                   [{atom(), term()}],
+                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+fold_objects(_FoldObjectsFun, Acc, _Opts, _S) ->
+    Acc.                                        % lazy!
+
+-spec drop(state()) -> {ok, state()} | {error, term(), state()}.
+drop(State) ->
+    [file:delete(location(State, BK)) || BK <- ?MODULE:list(State)],
+    Cmd = io_lib:format("rm -Rf ~s", [State#state.dir]),
+    os:cmd(Cmd),
+    {ok, State}.
+
+-spec is_empty(state()) -> boolean().
+is_empty(S) ->
+    ?MODULE:list(S) == [].
+
+-spec status(state()) -> [{atom(), term()}].
+status(_S) ->
+    [no_status_sorry].
+
+-spec callback(reference(), any(), state()) -> {ok, state()}.
+callback(_Ref, _Term, S) ->
+    {ok, S}.
+
+%% @spec location(state(), {riak_object:bucket(), riak_object:key()})
+%%          -> string()
+%% @doc produce the file-path at which the object for the given Bucket
+%%      and Key should be stored
+location(State, {Bucket, Key}) ->
+    B64 = encode_bucket(Bucket),
+    K64 = encode_key(Key),
+    [N1,N2,N3] = nest(K64),
+    filename:join([State#state.dir, B64, N1, N2, N3, K64]).
+
+-ifdef(SLF_COMMENT).
+
+%% @spec location_to_bkey(string()) ->
+%%           {riak_object:bucket(), riak_object:key()}
+%% @doc reconstruct a Riak bucket/key pair, given the location at
+%%      which its object is stored on-disk
+location_to_bkey(Path) ->
+    [B64,_,_,_,K64] = string:tokens(Path, "/"),
+    {decode_bucket(B64), decode_key(K64)}.
+
+%% @spec decode_bucket(string()) -> binary()
+%% @doc reconstruct a Riak bucket, given a filename
+%% @see encode_bucket/1
+decode_bucket(B64) ->
+    base64:decode(dirty(B64)).
+
+%% @spec decode_key(string()) -> binary()
+%% @doc reconstruct a Riak object key, given a filename
+%% @see encode_key/1
+decode_key(K64) ->
+    base64:decode(dirty(K64)).
+
+-endif. % SLF_LAZY
+
+-ifdef(TEST).
+%% @spec dirty(string()) -> string()
+%% @doc replace filename-troublesome base64 characters
+%% @see clean/1
+dirty(Str64) ->
+    lists:map(fun($-) -> $=;
+                 ($_) -> $+;
+                 ($,) -> $/;
+                 (C)  -> C
+              end,
+              Str64).
+-endif. % TEST
+
+%% @spec encode_bucket(binary()) -> string()
+%% @doc make a filename out of a Riak bucket
+encode_bucket(Bucket) ->
+    clean(base64:encode_to_string(Bucket)).
+
+%% @spec encode_key(binary()) -> string()
+%% @doc make a filename out of a Riak object key
+encode_key(Key) ->
+    clean(base64:encode_to_string(Key)).
+
+%% @spec clean(string()) -> string()
+%% @doc remove characters from base64 encoding, which may
+%%      cause trouble with filenames
+clean(Str64) ->
+    lists:map(fun($=) -> $-;
+                 ($+) -> $_;
+                 ($/) -> $,;
+                 (C)  -> C
+              end,
+              Str64).
+
+%% @spec nest(string()) -> [string()]
+%% @doc create a directory nesting, to keep the number of
+%%      files in a directory smaller
+nest(Key) -> nest(lists:reverse(string:substr(Key, 1, 6)), 3, []).
+nest(_, 0, Parts) -> Parts;
+nest([Nb,Na|Rest],N,Acc) ->
+    nest(Rest, N-1, [[Na,Nb]|Acc]);
+nest([Na],N,Acc) ->
+    nest([],N-1,[[Na]|Acc]);
+nest([],N,Acc) ->
+    nest([],N-1,["0"|Acc]).
+
+%%
+%% Test
+%%
+-ifdef(TEST).
+
+%% Broken test:
+%% simple_test() ->
+%%    ?assertCmd("rm -rf test/fs-backend"),
+%%    Config = [{riak_kv_fs_backend_root, "test/fs-backend"}],
+%%    riak_kv_backend:standard_test(?MODULE, Config).
+
+dirty_clean_test() ->
+    Dirty = "abc=+/def",
+    Clean = clean(Dirty),
+    [ ?assertNot(lists:member(C, Clean)) || C <- "=+/" ],
+    ?assertEqual(Dirty, dirty(Clean)).
+
+nest_test() ->
+    ?assertEqual(["ab","cd","ef"],nest("abcdefg")),
+    ?assertEqual(["ab","cd","ef"],nest("abcdef")),
+    ?assertEqual(["a","bc","de"], nest("abcde")),
+    ?assertEqual(["0","ab","cd"], nest("abcd")),
+    ?assertEqual(["0","a","bc"],  nest("abc")),
+    ?assertEqual(["0","0","ab"],  nest("ab")),
+    ?assertEqual(["0","0","a"],   nest("a")),
+    ?assertEqual(["0","0","0"],   nest([])).
+
+-ifdef(EQC).
+%% Broken test:
+%% eqc_test() ->
+%%     Cleanup = fun(_State,_Olds) -> os:cmd("rm -rf test/fs-backend") end,
+%%     Config = [{riak_kv_fs_backend_root, "test/fs-backend"}],
+%%     ?assertCmd("rm -rf test/fs-backend"),
+%%     ?assertEqual(true, backend_eqc:test(?MODULE, false, Config, Cleanup)).
+-endif. % EQC
+-endif. % TEST


### PR DESCRIPTION
- Add multi backend source that has a bucket name prefix matching feature
- Add README.multi-backend.txt file with (still buggy) instructions for configuring the multi backend for Riak
- Add the still-unfinished fs2 backend, based originally on the Riak 0.14 riak_fs_backend.erl and updated
  enough capability to put & get objects and to use on-disk checksums.
