### PR TITLE
Fixed-length bucket names for objects and blocks buckets.

### DIFF
--- a/src/riak_moss_lfs_utils.erl
+++ b/src/riak_moss_lfs_utils.erl
@@ -56,12 +56,14 @@ block_keynames(KeyName, UUID, BlockList) ->
                      {BlockSeq, block_name(KeyName, UUID, BlockSeq)} end,
     lists:map(MapFun, BlockList).
 
-block_name(Key, UUID, Number) ->
-    sext:encode({Key, Number, UUID}).
+block_name(_Key, UUID, Number) ->
+    %% 16 bits & 1MB chunk size = 64GB max object size
+    %% 24 bits & 1MB chunk size = 16TB max object size
+    %% 32 bits & 1MB chunk size = 4PB max object size
+    <<UUID/binary, Number:32>>.
 
-block_name_to_term(Name) ->
-    {Key, Number, UUID} = sext:decode(Name),
-    {Key, UUID, Number}.
+block_name_to_term(<<UUID:16/binary, Number:32>>) ->
+    {UUID, Number}.
 
 %% @doc Return the configured block size
 -spec block_size() -> pos_integer().

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -43,8 +43,8 @@
 -compile(export_all).
 -endif.
 
--define(OBJECT_BUCKET_PREFIX, <<"objects:">>).
--define(BLOCK_BUCKET_PREFIX, <<"blocks:">>).
+-define(OBJECT_BUCKET_PREFIX, <<"0o:">>).       % Version # = 0
+-define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0
 
 -type xmlElement() :: #xmlElement{}.
 

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -448,10 +448,14 @@ set_object_acl(Bucket, Key, Manifest, Acl) ->
 %% Get the proper bucket name for either the MOSS object
 %% bucket or the data block bucket.
 -spec to_bucket_name([objects | blocks], binary()) -> binary().
-to_bucket_name(objects, Name) ->
-    <<?OBJECT_BUCKET_PREFIX/binary, Name/binary>>;
-to_bucket_name(blocks, Name) ->
-    <<?BLOCK_BUCKET_PREFIX/binary, Name/binary>>.
+to_bucket_name(Type, Bucket) ->
+    case Type of
+        objects ->
+            Prefix = ?OBJECT_BUCKET_PREFIX;
+        blocks ->
+            Prefix = ?BLOCK_BUCKET_PREFIX
+    end,
+    crypto:md5(<<Prefix/binary, Bucket/binary>>).
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
Use an md5 hash of the bucket prefix and the `riak_cs` bucket name as the `riak` bucket name for the `objects` and `blocks` buckets for a `riak_cs` bucket. This ensures that the `riak` bucket names have a fixed size and that straightforward to determine them fromthe `riak_cs` bucket name.

This does not include any checks for collisions where the requested bucket may hash to the same digest as another bucket in the system and result in unauthorized access to the existing bucket. This check will be much more straightforward to add once the object ACL pull request has been merged. A separate task is on the sprintly board for that.
## Testing

Ensure that put, get, and delete of a file work as expected.
