### PR TITLE
Set default admin credentials that can be used to bootstrap a real admin user

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -18,8 +18,8 @@
               {put_fsm_buffer_size_max, 10485760},
 
               %% Admin user credentials
-              {admin_key, ""},
-              {admin_secret, ""},
+              {admin_key, "{{admin_key}}"},
+              {admin_secret, "{{admin_secret}}"},
 
               %% Configuration for access to bucket request
               %% serialization service

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -16,9 +16,11 @@
 {riak_ip,           "127.0.0.1"}.
 {riak_pb_port,      8087}.
 {auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
-{stanchion_ssl,     true}.
+{stanchion_ssl,     false}.
 
 %%
 %% etc/vm.args


### PR DESCRIPTION
- Set default admin credentials so that the process of bootstrapping
  an admin user is less of a hassle and so that `riak_cs` and `stanchion`
  will work together with their respective default configurations.
- Set `stanchion_ssl` to `false` as a default to also support the idea
  that `riak_cs` and `stanchion` work together with their default
  configurations.
