### PR TITLE
Monitor webmachine process during file download.

### DIFF
--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -137,7 +137,7 @@ deny_invalid_key(RD, Ctx) ->
 ensure_doc(Ctx=#key_context{get_fsm_pid=undefined, bucket=Bucket, key=Key}) ->
     %% start the get_fsm
     BinKey = list_to_binary(Key),
-    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(node(), [Bucket, BinKey]),
+    {ok, Pid} = riak_moss_get_fsm_sup:start_get_fsm(node(), [Bucket, BinKey, self()]),
     Manifest = riak_moss_get_fsm:get_manifest(Pid),
     Ctx#key_context{get_fsm_pid=Pid, manifest=Manifest};
 ensure_doc(Ctx) -> Ctx.


### PR DESCRIPTION
Monitor the calling webmachine process from the get fsm so that if the
client connection is prematurely terminated then it can be detected by
the get fsm and the retrieval of file blocks can be halted.
## Testing
1. Start `riak_cs` in console mode or attach to the console.
2. Load a large file into `riak_cs`. _i.e._ One that will take at least several seconds to download.
3. Set the lager console backend to debug level: `lager:set_loglevel(lager_console_backend, debug).`
4. Begin to download the file from `riak_cs` using `s3cmd`, but hit `CTRL+C` to terminate the download before it completes. 

On the `master` branch the console output will show that the blocks of the file continue to be fetched from Riak until they have all been retrieved. Using the `s184-wm-monitor-on-download` branch the block retrieval will halt once the webmachine process dies and the notification of its death is received and processed by the get fsm.
