### PR TITLE
Overhaul basho_bench plugin to use S3 auth

### DIFF
--- a/bench/basho_bench_driver_moss.erl
+++ b/bench/basho_bench_driver_moss.erl
@@ -198,9 +198,9 @@ send_request(_Host, _Url, _Headers, _Method, _Body, _Options, 0) ->
     {error, max_retries};
 send_request(Host, Url, Headers0, Method, Body, Options, Count) ->
     Pid = connect(Host),
-    ContentTypeStr = atom_to_list(proplists:get_value(
-                                    'Content-Type', Headers0,
-                                    'application/octet-stream')),
+    ContentTypeStr = to_list(proplists:get_value(
+                               'Content-Type', Headers0,
+                               'application/octet-stream')),
     Date = httpd_util:rfc1123_date(),
     Headers = [{'Content-Type', ContentTypeStr},
                {'Date', Date}|lists:keydelete('Content-Type', 1, Headers0)],
@@ -287,3 +287,8 @@ uppercase_verb(get) ->
     'GET';
 uppercase_verb(delete) ->
     'DELETE'.
+
+to_list(A) when is_atom(A) ->
+    atom_to_list(A);
+to_list(L) when is_list(L) ->
+    L.

--- a/bench/basho_bench_driver_moss.erl
+++ b/bench/basho_bench_driver_moss.erl
@@ -35,6 +35,8 @@ new(ID) ->
     %% IP for now
     Ip  = basho_bench_config:get(moss_raw_ip, "127.0.0.1"),
     Port = basho_bench_config:get(moss_raw_port, 8080),
+    Disconnect = basho_bench_config:get(moss_disconnect_frequency, infinity),
+    erlang:put(disconnect_freq, Disconnect),
 
     Hosts = [{Ip, Port}],
 

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -16,6 +16,7 @@
 %% https://github.com/basho/riak_moss/wiki/Creating-a-User
 {moss_access_key, "ZG7SS3ZPECF-8LZOEBMA"}.
 {moss_secret_key, "21HoIRdeO617nJrIbam9mKH2MBxmcsMEwESvmQ=="}.
+{moss_bucket, "test"}.
 {moss_raw_ip, "s3.amazonaws.com"}. % DO NOT CHANGE
 {moss_raw_port, 80}.               % DO NOT CHANGE
 %% Replace these with your HTTP proxy's location (i.e. Riak CS)

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -17,6 +17,7 @@
 {moss_access_key, "ZG7SS3ZPECF-8LZOEBMA"}.
 {moss_secret_key, "21HoIRdeO617nJrIbam9mKH2MBxmcsMEwESvmQ=="}.
 {moss_bucket, "test"}.
+{moss_disconnect_frequency, 5}.    % # ops before disconnecting HTTP socket
 {moss_raw_ip, "s3.amazonaws.com"}. % DO NOT CHANGE
 {moss_raw_port, 80}.               % DO NOT CHANGE
 %% Replace these with your HTTP proxy's location (i.e. Riak CS)

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -1,26 +1,33 @@
-%% Sample config file for riak_moss
-%% basho benchmarking
+%% Sample config file for Riak CS basho_bench benchmarking
 
-{mode, max}.
-
+%{mode, max}.
+{mode, {rate,4}}.
 {duration, 1}.
-
 {concurrent, 1}.
 
+%% Replace these with your own paths
+{source_dir, "/Users/fritchie/b/src/riak_moss/bench"}.
+{code_paths, ["deps/ibrowse", "/Users/fritchie/b/src/riak_moss",
+              "/Users/fritchie/b/src/riak_moss/deps/stanchion"]}.
 {driver, basho_bench_driver_moss}.
 
 %% Replace this with a user you have created.
 %% Instructions to create a user are here:
 %% https://github.com/basho/riak_moss/wiki/Creating-a-User
-{moss_authorization, "4844552620141D3E1EA71090A9D27F363F9CFA25"}.
+{moss_access_key, "ZG7SS3ZPECF-8LZOEBMA"}.
+{moss_secret_key, "21HoIRdeO617nJrIbam9mKH2MBxmcsMEwESvmQ=="}.
+{moss_raw_ip, "s3.amazonaws.com"}. % DO NOT CHANGE
+{moss_raw_port, 80}.               % DO NOT CHANGE
+%% Replace these with your HTTP proxy's location (i.e. Riak CS)
+{moss_http_proxy_host, "localhost"}.
+{moss_http_proxy_port, 8080}.
+{moss_request_timeout, 999999000}.
 
-{code_paths, ["deps/ibrowse"]}.
-
-{value_generator, {fixed_bin, 1000}}.
-
-{http_raw_port, 8080}.
+%{key_generator, {int_to_bin, {uniform_int, 500}}}.
+{key_generator, {uniform_int, 5}}.
+%{value_generator_source_size, 12100105}. %% Must be larger than val gen max size.
+%{value_generator, {fixed_bin, 12100100}}.
+{value_generator, {fixed_bin, 1024}}.
 
 {operations, [{insert, 1}, {update, 1}, {delete, 1}, {get, 1}]}.
 
-%% replace this with your own path
-{source_dir, "/Users/reid/Documents/repos/basho/riak_moss/bench"}.


### PR DESCRIPTION
When using the new basho_bench config items as shown in the sample
config file, the RCS server's `auth_bypass` config knob can keep its
default `false` value.
