### PR TITLE
gen_server & related call timeout review

### DIFF
--- a/src/riak_moss_block_server.erl
+++ b/src/riak_moss_block_server.erl
@@ -56,7 +56,7 @@ delete_block(Pid, Bucket, Key, UUID, BlockNumber) ->
     gen_server:cast(Pid, {delete_block, self(), Bucket, Key, UUID, BlockNumber}).
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:call(Pid, stop, infinity).
 
 %%%===================================================================
 %%% gen_server callbacks

--- a/src/riak_moss_delete_fsm.erl
+++ b/src/riak_moss_delete_fsm.erl
@@ -276,6 +276,6 @@ test_link(StateProps, Bucket, Name, Timeout) ->
 %% @doc Get the current state of the fsm for testing inspection
 -spec current_state(pid()) -> atom() | {error, term()}.
 current_state(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, current_state).
+    gen_fsm:sync_send_all_state_event(Pid, current_state, infinity).
 
 -endif.

--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -74,10 +74,10 @@ continue(Pid) ->
     gen_fsm:send_event(Pid, continue).
 
 get_manifest(Pid) ->
-    gen_fsm:sync_send_event(Pid, get_manifest, 60000).
+    gen_fsm:sync_send_event(Pid, get_manifest, infinity).
 
 get_next_chunk(Pid) ->
-    gen_fsm:sync_send_event(Pid, get_next_chunk, 60000).
+    gen_fsm:sync_send_event(Pid, get_next_chunk, infinity).
 
 manifest(Pid, ManifestValue) ->
     gen_fsm:send_event(Pid, {object, self(), ManifestValue}).

--- a/src/riak_moss_manifest_fsm.erl
+++ b/src/riak_moss_manifest_fsm.erl
@@ -80,22 +80,23 @@ start_link(Bucket, Key) ->
     gen_fsm:start_link(?MODULE, [Bucket, Key], []).
 
 get_active_manifest(Pid) ->
-    gen_fsm:sync_send_event(Pid, get_active_manifest).
+    gen_fsm:sync_send_event(Pid, get_active_manifest, infinity).
 
 add_new_manifest(Pid, Manifest) ->
     gen_fsm:send_event(Pid, {add_new_manifest, Manifest}).
 
 mark_active_as_pending_delete(Pid) ->
-    gen_fsm:sync_send_event(Pid, mark_active_as_pending_delete).
+    gen_fsm:sync_send_event(Pid, mark_active_as_pending_delete, infinity).
 
 update_manifest(Pid, Manifest) ->
     gen_fsm:send_event(Pid, {update_manifest, Manifest}).
 
 update_manifest_with_confirmation(Pid, Manifest) ->
-    gen_fsm:sync_send_event(Pid, {update_manifest_with_confirmation, Manifest}).
+    gen_fsm:sync_send_event(Pid, {update_manifest_with_confirmation, Manifest},
+                           infinity).
 
 stop(Pid) ->
-    gen_fsm:sync_send_all_state_event(Pid, stop).
+    gen_fsm:sync_send_all_state_event(Pid, stop, infinity).
 
 %%%===================================================================
 %%% gen_fsm callbacks

--- a/src/riak_moss_put_fsm.erl
+++ b/src/riak_moss_put_fsm.erl
@@ -73,10 +73,10 @@ start_link(Bucket, Key, ContentLength, ContentType, Metadata, BlockSize, Acl, Ti
     gen_fsm:start_link(?MODULE, Args, []).
 
 augment_data(Pid, Data) ->
-    gen_fsm:sync_send_event(Pid, {augment_data, Data}).
+    gen_fsm:sync_send_event(Pid, {augment_data, Data}, infinity).
 
 finalize(Pid) ->
-    gen_fsm:sync_send_event(Pid, finalize).
+    gen_fsm:sync_send_event(Pid, finalize, infinity).
 
 block_written(Pid, BlockID) ->
     gen_fsm:send_event(Pid, {block_written, BlockID, self()}).

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -49,7 +49,7 @@ start_link(Args) ->
     gen_server:start_link(?MODULE, Args, []).
 
 get_manifest(Pid) ->
-    gen_server:call(Pid, get_manifest).
+    gen_server:call(Pid, get_manifest, infinity).
 
 get_chunk(Pid, Bucket, Key, UUID, ChunkSeq) ->
     gen_server:cast(Pid, {get_chunk, Bucket, Key, UUID, ChunkSeq}).


### PR DESCRIPTION
Fixes #191

Most of the calls are gen_fsm sync event calls.  For both gen_server
and gen_fsm servers, all procs are intra-VM and therefore there's no
reason that I know of why we shouldn't be using an infinity timeout.

I know that these changes fix at least one bug: the gen_fsm sync call
to fetch manifests for all objects in a bucket (triggered by `s3cmd ls`
of a bucket with many thousands of files can take more than 5 seconds
on a slow machine.
