### PR TITLE
Stop the manifest fsm on list keys

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -230,6 +230,7 @@ get_keys_and_manifests(BucketName, Prefix) ->
                         [begin
                              {ok, ManiPid} = riak_moss_manifest_fsm:start_link(BucketName, Key),
                              Manifest = riak_moss_manifest_fsm:get_active_manifest(ManiPid),
+                             riak_moss_manifest_fsm:stop(ManiPid),
                              {Key, Manifest}
                          end
                          || Key <- prefix_filter(Keys, Prefix)],


### PR DESCRIPTION
Fixes #[192](https://sprint.ly/#!/product/969/item/192)

Previously we left the manifest
fsm running for each object in a
list keys. This shuts the
fsm down after each object.
