### PR TITLE
Fix bucket naming to work with multi-backend scheme.

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -455,7 +455,8 @@ to_bucket_name(Type, Bucket) ->
         blocks ->
             Prefix = ?BLOCK_BUCKET_PREFIX
     end,
-    crypto:md5(<<Prefix/binary, Bucket/binary>>).
+    BucketHash = crypto:md5(Bucket),
+    <<Prefix/binary, BucketHash/binary>>.
 
 %% ===================================================================
 %% Internal functions


### PR DESCRIPTION
Do not hash the prefix as part of the bucket name for objects and blocks buckets. The multi-backend scheme expects to find the `b:` or `o:` part of the bucket name as plain text.
