### PR TITLE
ACL ownership information update

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -42,7 +42,7 @@
                       putctype :: string(),
                       bucket :: binary(),
                       key :: list(),
-                      owner :: moss_user(),
+                      owner :: string(),
                       size :: non_neg_integer()}).
 
 -type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
@@ -50,10 +50,14 @@
 -type group_grant() :: 'AllUsers' | 'AuthUsers'.
 -type acl_grantee() :: {string(), string()} | group_grant().
 -type acl_grant() :: {acl_grantee(), acl_perms()}.
--record(acl_v1, {owner={"", ""} :: {string(), string()},
+-type acl_owner() :: {string(), string()} | {string(), string(), string()}.
+-record(acl_v1, {owner={"", ""} :: acl_owner(),
                  grants=[] :: [acl_grant()],
                  creation_time=now() :: erlang:timestamp()}).
--type acl() :: #acl_v1{}.
+-record(acl_v2, {owner={"", "", ""} :: acl_owner(),
+                 grants=[] :: [acl_grant()],
+                 creation_time=now() :: erlang:timestamp()}).
+-type acl() :: #acl_v1{} | #acl_v2{}.
 
 -type cluster_id() :: undefined | term().  % Type still in flux.
 
@@ -181,7 +185,7 @@
     }).
 -type lfs_manifest() :: #lfs_manifest_v2{}.
 
--define(ACL, #acl_v1).
+-define(ACL, #acl_v2).
 -define(MOSS_BUCKET, #moss_bucket_v1).
 -define(MOSS_USER, #moss_user_v1).
 -define(USER_BUCKET, <<"moss.users">>).

--- a/src/riak_moss_access_logger.erl
+++ b/src/riak_moss_access_logger.erl
@@ -54,7 +54,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--define(SERVER, ?MODULE). 
+-define(SERVER, ?MODULE).
 
 -record(state, {
           period :: integer(),         %% time between aggregation archivals
@@ -76,6 +76,8 @@
 
 %% @doc Set the MOSS user for this request.  Stats are not recorded if
 %% the user is not set.
+set_user(KeyID, RD) when is_list(KeyID) ->
+    wrq:add_note(?STAT(user), KeyID, RD);
 set_user(?MOSS_USER{key_id=KeyID}, RD) ->
     wrq:add_note(?STAT(user), KeyID, RD);
 set_user(unknown, RD) ->
@@ -280,7 +282,7 @@ code_change(_OldVsn, State, _Extra) ->
 %% @doc Create a new ets table to accumulate accesses in.
 -spec fresh_table() -> ets:tid().
 fresh_table() ->
-    ets:new(?SERVER, [private, duplicate_bag, {keypos, 1}]).    
+    ets:new(?SERVER, [private, duplicate_bag, {keypos, 1}]).
 
 %% @doc Schedule a message to be sent when it's time to archive this
 %% slice's accumulated accesses.

--- a/test/riak_moss_dummy_reader.erl
+++ b/test/riak_moss_dummy_reader.erl
@@ -85,7 +85,7 @@ handle_call(get_manifest, _From, #state{bucket=Bucket,
                                                 <<"md5">>,
                                                 orddict:new(),
                                                 riak_moss_lfs_utils:block_size(),
-                                                riak_moss_acl_utils:default_acl("tester", "id123")),
+                                                riak_moss_acl_utils:default_acl("tester", "id123", "keyid123")),
     {reply, {ok, Manifest}, State};
 handle_call(_Msg, _From, State) ->
     {reply, ok, State}.

--- a/test/riak_moss_lfs_utils_eqc.erl
+++ b/test/riak_moss_lfs_utils_eqc.erl
@@ -78,7 +78,9 @@ prop_manifest_manipulation() ->
                                                         Md5,
                                                         MD,
                                                         riak_moss_lfs_utils:block_size(),
-                                                        riak_moss_acl_utils:default_acl("tester", "tester_id")),
+                                                        riak_moss_acl_utils:default_acl("tester",
+                                                                                        "tester_id",
+                                                                                        "tester_key_id")),
 
             Blocks = riak_moss_lfs_utils:initial_blocks(CLength, riak_moss_lfs_utils:block_size()),
             %% TODO: maybe we should shuffle blocks?

--- a/test/riak_moss_lfs_utils_test.erl
+++ b/test/riak_moss_lfs_utils_test.erl
@@ -42,7 +42,9 @@ test_is_manifest() ->
                                          <<"2522ccc1ca2a458eca94a9576d4b71c2">>,
                                          orddict:new(),
                                          riak_moss_lfs_utils:block_size(),
-                                         riak_moss_acl_utils:default_acl("tester", "tester_id")),
+                                         riak_moss_acl_utils:default_acl("tester",
+                                                                         "tester_id",
+                                                                         "tester_key_id")),
     ?assert(riak_moss_lfs_utils:is_manifest(term_to_binary(Manifest))).
 
 test_block_count_1() ->

--- a/test/riak_moss_put_fsm_test.erl
+++ b/test/riak_moss_put_fsm_test.erl
@@ -26,7 +26,7 @@ put_fsm_test_() ->
 small_put() ->
     {ok, Pid} =
     riak_moss_put_fsm:start_link(<<"bucket">>, <<"key">>, 10, <<"ctype">>,
-        orddict:new(), 2, riak_moss_acl_utils:default_acl("display", "canonical_id"),
+        orddict:new(), 2, riak_moss_acl_utils:default_acl("display", "canonical_id", "key_id"),
         60000, self()),
     Data = <<"0123456789">>,
     Md5 = make_md5(Data),


### PR DESCRIPTION
These changes add an `acl_v2` record and make the changes necessary to include the user's `key_id` as part of the acl ownership information. The reason behind this is to eliminate the need for an expensive 2I query on each object put request and to only use the secondary index to look up user by `canonical_id` when absolutely necessary. These changes are backward compatible so existing buckets and objects with `acl_v1` ACLs will continue to work. 

These changes also rely on [this](https://github.com/basho/stanchion/pull/10) stanchion pr. When testing be sure to use the `s209-acl-owner-update` branch of stanchion both to run stanchion and checked out in the deps of riak_moss.
