### PR TITLE
Extra resource canonicalization

### DIFF
--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -170,6 +170,7 @@ canonicalize_resource(RD) ->
     case {bucket_from_host(wrq:get_req_header("host", RD), RD),
           wrq:path_tokens(RD)} of
         {undefined, []} -> ["/"];
+        {undefined, _} -> [wrq:path(RD)];
         {Bucket, []} -> ["/", Bucket, "/"];
         {Bucket, KeyTokens} ->
             ["/", Bucket, "/", string:join(KeyTokens, "/")]


### PR DESCRIPTION
Trying to write Python demo code to fetch usage statistics, I came up with:

``` python
from boto.s3.connection import S3Connection
from boto.s3.connection import OrdinaryCallingFormat
from boto.s3.key import Key
c = S3Connection('PK1PPLB0MAY8NHCCR9SA', 'E5dkHSGINbutC8KuZG0cfd8xkUKf1NpjtWMVDQ==', is_secure=False, host='localhost', port=8080, calling_format=OrdinaryCallingFormat())
b = c.get_bucket('usage', validate=False)
k = Key(b, 'PK1PPLB0MAY8NHCCR9SA')
k.get_contents_as_string()
```

but I received errors in the riak-cs console:

```
20:25:13.518 [error] webmachine error: path="/usage/PK1PPLB0MAY8NHCCR9SA"
{error,badarg,[{crypto,sha_mac_n,["E5dkHSGINbutC8KuZG0cfd8xkUKf1NpjtWMVDQ==",["GET","\n",[],"\n",[],"\n",["Wed, 28 Mar 2012 00:24:27 GMT","\n"],[],[["/",undefined,"/","PK1PPLB0MAY8NHCCR9SA"],[]]],20]},{riak_moss_s3_auth,calculate_signature,2},{riak_moss_s3_auth,authenticate,3},{riak_moss_wm_utils,find_and_auth_user,2},{riak_moss_wm_utils,find_and_auth_user,3},{webmachine_resource,resource_call,3},{webmachine_resource,do,3},{webmachine_decision_core,resource_call,1}]}
```

Adding some debugging statements makes it look like boto set these headers:

```
Accept-Encoding: identity
Authorization: AWS PK1PPLB0MAY8NHCCR9SA:6+1S1EgGtGLmVwmNKTZSv533Rrg=
Content-Length: 0
Date: Wed, 28 Mar 2012 00:36:05 GMT
Host: localhost:8080
User-Agent: Boto/2.3.0 (darwin)
```

This leads `riak_moss_s3_auth:bucket_from_host` to return `undefined`, because there is no bucket subdomain on the host, _and_ the usage resource's dispatch does not define a `bucket` path component.  Unfortunately, there are still path tokens, so the case clause of `canonicalize_resource` ends up confused.

This patch adds a clause to that case in `canonicalize_resource` to handle the `{undefined, NonEmptyList}` case, and then use the entire path for auth hashing.
