### PR TITLE
Delay starting the block_server processes until after the continue event is received.

### DIFF
--- a/src/riak_moss_get_fsm.erl
+++ b/src/riak_moss_get_fsm.erl
@@ -350,7 +350,12 @@ terminate(_Reason, _StateName, #state{test=false,
                                       mani_fsm_pid=ManiPid}) ->
 
     riak_moss_manifest_fsm:stop(ManiPid),
-    [riak_moss_block_server:stop(P) || P <- BlockServerPids],
+    case BlockServerPids of
+        undefined ->
+            ok;
+        _ ->
+            [riak_moss_block_server:stop(P) || P <- BlockServerPids]
+    end,
     ok;
 terminate(_Reason, _StateName, #state{test=true,
                                       free_readers=[ReaderPid | _]}) ->


### PR DESCRIPTION
This is to avoid wasting time and consuming connections unnecessarily when the only goal is to fetch the file manifest. This effect of this change becomes even more profound as the number of concurrent block fetches is increased and in turn the number of connections consumed is increased.
