### PR TITLE
Fix PUTs for zero-byte files

### DIFF
--- a/src/riak_moss_put_fsm.erl
+++ b/src/riak_moss_put_fsm.erl
@@ -130,23 +130,6 @@ init([Bucket, Key, ContentLength, ContentType,
                          riakc_pid=RiakPid,
                          timeout=Timeout},
                      0}.
-%% init([test, Bucket, Key, ContentLength, BlockSize]) ->
-%%     {ok, prepare, State1, 0} = init([Bucket, Key, self(), pid]),
-
-%%     %% %% purposely have the timeout happen
-%%     %% %% so that we get called in the prepare
-%%     %% %% state
-%%     %% {ok, ReaderPid} =
-%%     %%     riak_moss_dummy_reader:start_link([self(),
-%%     %%                                        Bucket,
-%%     %%                                        Key,
-%%     %%                                        ContentLength,
-%%     %%                                        BlockSize]),
-%%     %% link(ReaderPid),
-%%     {ok, Manifest} = riak_moss_dummy_reader:get_manifest(ReaderPid),
-%%     {ok, waiting_value, State1#state{free_readers=[ReaderPid],
-%%                                      manifest=Manifest,
-%%                                      test=true}}.
 
 %%--------------------------------------------------------------------
 %%

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -323,6 +323,8 @@ accept_body(RD, Ctx=#key_context{bucket=Bucket,
     {ok, Pid} = riak_moss_put_fsm_sup:start_put_fsm(node(), Args),
     accept_streambody(RD, Ctx, Pid, wrq:stream_req_body(RD, riak_moss_lfs_utils:block_size())).
 
+accept_streambody(RD, Ctx=#key_context{size=0}, Pid, {_Data, _Next}) ->
+    finalize_request(RD, Ctx, Pid);
 accept_streambody(RD, Ctx=#key_context{}, Pid, {Data, Next}) ->
     riak_moss_put_fsm:augment_data(Pid, Data),
     if is_function(Next) ->


### PR DESCRIPTION
S212

Skip all of the block writing
state if the content length
of the file is 0.
