### PR TITLE
The user resource does not need a riak connection.

### DIFF
--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -19,7 +19,7 @@ init(_Config) ->
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
-    riak_moss_wm_utils:service_available(RD, Ctx).
+    {true, RD, Ctx}.
 
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
 allowed_methods(RD, Ctx) ->


### PR DESCRIPTION
Do not need to call `riak_moss_wm_utils:service_available` because that nows reserves a pool connection and the user resource does not need a riak connection because the work is done by stanchion. Also since we aren't releasing the pool connection in the user resource it causes an error when the webmachine process dies and takes the pool worker with it.
## Testing

Using master create a user and you should see output like this on the console:

```
(riak-cs@127.0.0.1)1> 16:58:49.424 [error] Supervisor poolboy_sup had child riak_moss_riakc_pool_worker started with {riak_moss_riakc_pool_worker,start_link,undefined} at <0.259.0> exit with reason killed in context child_terminated
16:58:49.424 [info] Starting worker
```

This error should not happen when creating a user using the `klm-no-riakc-for-wm-user` branch.
