### PR TITLE
Return no_user_key when there is no user for a request.

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -271,6 +271,8 @@ get_object(BucketName, Key, RiakPid) ->
 
 %% @doc Retrieve a MOSS user's information based on their id string.
 -spec get_user(string(), pid()) -> {ok, {term(), term()}} | {error, term()}.
+get_user(undefined, RiakPid) -> 
+    {error, no_user_key};
 get_user(KeyId, RiakPid) ->
     %% @TODO Check for an resolve siblings to get a
     %% coherent view of the bucket ownership.


### PR DESCRIPTION
Ensure that we return no_user_key when the user making the request is unauthenticated.

Fixes the following server error, when accessing a public asset without authentication.

```
{error,badarg,
       [{erlang,list_to_binary,[undefined]},
        {riak_moss_utils,get_user,2},
        {riak_moss_wm_service,forbidden,2},
        {webmachine_resource,resource_call,3},
        {webmachine_resource,do,3},
        {webmachine_decision_core,resource_call,1},
        {webmachine_decision_core,decision,1},
        {webmachine_decision_core,handle_request,2}]}
```

I wasn't sure the correct way to approach the eunit test for this functionality.  Should I just unit test the get_user method, or do we prefer to test this a different way?
