### PR TITLE
Trigger access archive on log size (helps fix #220)

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -38,6 +38,11 @@
               %% twice per period, etc.)
               {access_log_flush_factor, 1},
               
+              %% Additional access log flush trigger - flush after
+              %% this many accesses are recorded, even if the flush
+              %% interval has not expired; integer number of accesses
+              {access_log_flush_size, 1000000},
+
               %% How large each access archive object is. Should be a
               %% multiple of access_log_flush_interval; integer number
               %% of seconds (3600 == 1 hour)

--- a/src/riak_moss.app.src
+++ b/src/riak_moss.app.src
@@ -23,6 +23,7 @@
          {put_fsm_buffer_size_max, 10485760},
          {access_archive_period, 3600},
          {access_log_flush_factor, 1},
+         {access_log_flush_size, 1000000},
          {storage_archive_period, 86400},
          %% Size, MaxOverflow
          {riakc_pool, {128, 0}}

--- a/src/riak_moss_access.erl
+++ b/src/riak_moss_access.erl
@@ -11,6 +11,7 @@
 -export([
          archive_period/0,
          log_flush_interval/0,
+         max_flush_size/0,
          make_object/3,
          get_usage/4
         ]).
@@ -68,6 +69,19 @@ log_flush_interval() ->
             end;
         _ ->
             {error, "riak_moss:access_log_flush_interval was not an integer"}
+    end.
+
+%% @doc Retreive the number of seconds that should elapse between
+%% archivings of access stats.  This setting is controlled by the
+%% `access_archive_period' environment variable of the `riak_moss'
+%% application.
+-spec max_flush_size() -> {ok, integer()}|{error, term()}.
+max_flush_size() ->
+    case application:get_env(riak_moss, access_log_flush_size) of
+        {ok, AP} when is_integer(AP), AP > 0 ->
+            {ok, AP};
+        _ ->
+            {error, "riak_moss:access_log_flush_size was not a positive integer"}
     end.
 
 %% @doc Create a Riak object for storing a user/slice's access data.

--- a/src/riak_moss_access.erl
+++ b/src/riak_moss_access.erl
@@ -33,7 +33,7 @@
 
 -define(NODEKEY, <<"MossNode">>).
 
-%% @doc Retreive the number of seconds that should elapse between
+%% @doc Retrieve the number of seconds that should elapse between
 %% archivings of access stats.  This setting is controlled by the
 %% `access_archive_period' environment variable of the `riak_moss'
 %% application.
@@ -46,7 +46,7 @@ archive_period() ->
             {error, "riak_moss:access_archive_period was not an integer"}
     end.
 
-%% @doc Retreive the number of seconds that should elapse between
+%% @doc Retrieve the number of seconds that should elapse between
 %% flushes of access stats.  This setting is controlled by the
 %% `access_log_flush_interval' environment variable of the `riak_moss'
 %% application.
@@ -71,10 +71,10 @@ log_flush_interval() ->
             {error, "riak_moss:access_log_flush_interval was not an integer"}
     end.
 
-%% @doc Retreive the number of seconds that should elapse between
-%% archivings of access stats.  This setting is controlled by the
-%% `access_archive_period' environment variable of the `riak_moss'
-%% application.
+%% @doc Retrieve the maximum number of records that should be added to
+%% the log before the log is automatically archived.  This setting is
+%% controlled by the `access_log_flush_size' environment variable of
+%% the `riak_moss' application.
 -spec max_flush_size() -> {ok, integer()}|{error, term()}.
 max_flush_size() ->
     case application:get_env(riak_moss, access_log_flush_size) of


### PR DESCRIPTION
This is an attempt to avoid the situation where a single user with _many_ accesses takes a _long_ time to archive.  I've set the default trigger for one million accesses.  That's probably high for an underpowered cluster, and low for beefy hardware.  I'm open to suggestion for a better default.

To test:

Set `{access_log_flush_size, 10}` in your app.config.  Start riak-cs.  Run:

```
s3cmd get s3://usage/YOUR_KEY/abj/20120304T000000Z/20120304235959Z
```

ten times.  Pause for a breath, then run it an eleventh time.  On the eleventh, you should see a new access sample in the result.  (be sure you modify the dates in that example to cover the time you're experimenting)
