### PR TITLE
limit amount of usage stats allowed in one request (fixes #201)

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -55,7 +55,13 @@
               %% chosen such that each storage_schedule entry falls in
               %% a different period; integer number of seconds
               %% (86400 == 1 day)
-              {storage_archive_period, 86400}
+              {storage_archive_period, 86400},
+
+              %% How many archive periods a user can request in one
+              %% usage read, applied independently to access and
+              %% storage; integer number of intervals (744 == 1 month
+              %% @ 1 hour intervals)
+              {usage_request_limit, 744}
              ]},
 
  {webmachine, [

--- a/src/riak_moss.app.src
+++ b/src/riak_moss.app.src
@@ -24,6 +24,7 @@
          {access_archive_period, 3600},
          {access_log_flush_factor, 1},
          {storage_archive_period, 86400},
+         {usage_request_limit, 744},
          %% Size, MaxOverflow
          {riakc_pool, {128, 0}}
         ]}

--- a/src/riak_moss_wm_usage.erl
+++ b/src/riak_moss_wm_usage.erl
@@ -157,9 +157,16 @@ malformed_request(RD, Ctx) ->
         {ok, Start} ->
             case parse_end_time(RD, Start) of
                 {ok, End} ->
-                    {false, RD,
-                     Ctx#ctx{start_time=lists:min([Start, End]),
-                             end_time=lists:max([Start, End])}};
+                    case too_many_periods(Start, End) of
+                        true ->
+                            {true,
+                             error_msg(RD, <<"Too much time requested">>),
+                             Ctx};
+                        false ->
+                            {false, RD,
+                             Ctx#ctx{start_time=lists:min([Start, End]),
+                                     end_time=lists:max([Start, End])}}
+                    end;
                 error ->
                     {true, error_msg(RD, <<"Invalid end-time format">>), Ctx}
             end;
@@ -435,6 +442,19 @@ datetime(String) when is_list(String) ->
         _ ->
             error
     end.
+
+%% @doc Will this request require more reads than the configured limit?
+-spec too_many_periods(calendar:datetime(), calendar:datetime())
+          -> boolean().
+too_many_periods(Start, End) ->
+    Seconds = calendar:datetime_to_gregorian_seconds(End)
+        -calendar:datetime_to_gregorian_seconds(Start),
+    {ok, Limit} = application:get_env(riak_moss, usage_request_limit),
+    
+    {ok, Access} = riak_moss_access:archive_period(),
+    {ok, Storage} = riak_moss_storage:archive_period(),
+    
+    ((Seconds div Access) > Limit) orelse ((Seconds div Storage) > Limit).
 
 -ifdef(TEST).
 -ifdef(EQC).


### PR DESCRIPTION
Set the `riak_moss` application environment variable `usage_request_limit` to the number of archive periods that a user is allowed to request in a single usage read.  Default is 744, which is one month's worth of usage data at the default archive period of one hour.

Should this be expressed as a number of seconds instead of a number of periods?
