### PR TITLE
Set content-type in context when using the default type.

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -233,7 +233,10 @@ delete_resource(RD, Ctx=#key_context{bucket=Bucket,
 content_types_accepted(RD, Ctx) ->
     case wrq:get_req_header("Content-Type", RD) of
         undefined ->
-            {[{"application/octet-stream", accept_body}], RD, Ctx};
+            DefaultCType = "application/octet-stream",
+            {[{DefaultCType, accept_body}],
+             RD,
+             Ctx#key_context{putctype=DefaultCType}};
         %% This was shamelessly ripped out of
         %% https://github.com/basho/riak_kv/blob/0d91ca641a309f2962a216daa0cee869c82ffe26/src/riak_kv_wm_object.erl#L492
         CType ->


### PR DESCRIPTION
If no content-type header is specified in a request the default header type is not set in the key_context in the `riak_moss_wm_key` webmachine resource. This causes a badarg error when the accept_body function calls `list_to_binary` on the content-type from the context and the value is undefined.
## Testing

Use the following ruby script to reproduce or send a request with the Content-Type header not set: 

https://gist.github.com/db9006729bedd3b92ab7
