### PR TITLE
Use warnings_as_errors directive in rebar.config.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 
 {lib_dirs, ["deps", "apps"]}.
 
-{erl_opts, [debug_info, fail_on_warning, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.
 
 {reset_after_eunit, true}.
 

--- a/src/riak_kv_fs2_backend.erl
+++ b/src/riak_kv_fs2_backend.erl
@@ -23,7 +23,7 @@
 % @doc riak_kv_fs2_backend is filesystem storage system, Mark III
 
 -module(riak_kv_fs2_backend).
--behavior(riak_kv_backend).
+%% -behavior(riak_kv_backend). % Not building within riak_kv
 
 %% KV Backend API
 -export([api_version/0,


### PR DESCRIPTION
- Use `warnings_as_errors` directive in rebar.config.
- Comment out riak_kv_backend behavior declaration in riak_kv_fs2_backend since we are not building under riak_kv and do not wish to have riak_kv as a dependency.
