### PR TITLE
Use {notfound_ok, false} for r=1 block requests

### DIFF
--- a/src/riak_moss_block_server.erl
+++ b/src/riak_moss_block_server.erl
@@ -122,7 +122,8 @@ handle_call(stop, _From, State) ->
 %%--------------------------------------------------------------------
 handle_cast({get_block, ReplyPid, Bucket, Key, UUID, BlockNumber}, State=#state{riakc_pid=RiakcPid}) ->
     {FullBucket, FullKey} = full_bkey(Bucket, Key, UUID, BlockNumber),
-    ChunkValue = case riakc_pb_socket:get(RiakcPid, FullBucket, FullKey, [{r, 1}]) of
+    GetOptions = [{r, 1}, {notfound_ok, false}, {basic_quorum, false}],
+    ChunkValue = case riakc_pb_socket:get(RiakcPid, FullBucket, FullKey, GetOptions) of
         {ok, RiakObject} ->
             {ok, riakc_obj:get_value(RiakObject)};
         {error, notfound}=NotFound ->


### PR DESCRIPTION
Fixes #170

Without this patch, requests for
sufficiently large files will
fail when a single Riak node is
down. This happens (presumably) because
the fallback node is the quickest to
respond, and thus the block request
gets a 404. This commit adds
{notfound_ok, false} and {basic_quorum, false}
to the request so that the request
will only return 404 is N (3) vnodes
return 404.
