### PR TITLE
Fetching info on a bucket fails.

### DIFF
--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -163,8 +163,9 @@ to_xml(RD, Ctx=#context{user=User,
                         bucket=Bucket,
                         requested_perm='READ',
                         riakc_pid=RiakPid}) ->
+    StrBucket = binary_to_list(Bucket),
     case [B || B <- riak_moss_utils:get_buckets(User),
-               B?MOSS_BUCKET.name =:= Bucket] of
+               B?MOSS_BUCKET.name =:= StrBucket] of
         [] ->
             riak_moss_s3_response:api_error(no_such_bucket, RD, Ctx);
         [BucketRecord] ->


### PR DESCRIPTION
Doing a GET on a bucket resource fails because we compare the bucket name in binary form against the string representation.
