### PR TITLE
Short-circuit WM with {halt, 200} on sucessful PUT

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -349,7 +349,7 @@ finalize_request(RD, #key_context{size=S}=Ctx, Pid) ->
 
     {ok, Manifest} = riak_moss_put_fsm:finalize(Pid),
     ETag = "\"" ++ riak_moss_utils:binary_to_hexlist(Manifest#lfs_manifest_v2.content_md5) ++ "\"",
-    {true, wrq:set_resp_header("ETag",  ETag, AccessRD), Ctx}.
+    {{halt, 200}, wrq:set_resp_header("ETag",  ETag, AccessRD), Ctx}.
 
 finish_request(RD, KeyCtx=#key_context{context=InnerCtx}) ->
     #context{riakc_pid=RiakPid} = InnerCtx,


### PR DESCRIPTION
Use "s3cmd -d put /local/path/file s3://bucket/some-name" to look at HTTP response code for a successful file upload:

before: 204
after: 200
