### PR TITLE
Improve the performance of object listing

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -272,7 +272,9 @@ map_keys_and_manifests(Object, _, _) ->
             _ ->
                 []
         end
-    catch _:_ ->
+    catch Type:Reason ->
+            lager:warning("Riak CS object list map failed: ~p:~p",
+                          [Type, Reason]),
             []
     end.
 

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -257,7 +257,7 @@ receive_keys_and_manifests(ReqId, Acc) ->
             {error, timeout}
     end.
 
-%% MapReduce function, runs on the Riak nodes, should therefor use
+%% MapReduce function, runs on the Riak nodes, should therefore use
 %% riak_object, not riakc_obj.
 map_keys_and_manifests({error, notfound}, _, _) ->
     [];

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -223,8 +223,13 @@ get_keys_and_manifests(BucketName, Prefix, RiakPid) ->
 active_manifests(ManifestBucket, Prefix, RiakPid) ->
     Input = case Prefix of
                 <<>> -> ManifestBucket;
-                %% TODO: use 2i range query instead?
-                _ -> {ManifestBucket, [[<<"starts_with">>, Prefix]]}
+                _ ->
+                    %% using filtered listkeys instead of 2i here
+                    %% because 2i seems no more than a 10% performance
+                    %% increase, and it requires extra finagling to
+                    %% deal with its range query being inclusive
+                    %% instead of exclusive
+                    {ManifestBucket, [[<<"starts_with">>, Prefix]]}
             end,
     Query = [{map, {modfun, riak_moss_utils, map_keys_and_manifests},
               undefined, true}],


### PR DESCRIPTION
Stream 2I key query results into a mapreduce job to fetch the objects and extract the metadata. This could potentially be cheaper than having all the object fetches done from moss.
