### PR TITLE
don't bomb if the object being deleted doesn't exist

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -224,7 +224,15 @@ delete_resource(RD, Ctx=#key_context{bucket=Bucket,
     riak_moss_get_fsm:stop(GetFsmPid),
     BinKey = list_to_binary(Key),
     #context{riakc_pid=RiakPid} = InnerCtx,
-    ok = riak_moss_delete_marker:delete(Bucket, BinKey, RiakPid),
+    case riak_moss_delete_marker:delete(Bucket, BinKey, RiakPid) of
+        ok ->
+            %% successfully marked for deletion
+            ok;
+        {error, notfound} ->
+            %% it's not there; consider the delete successful
+            ok
+%%% other errors: bomb for now, handle better later?
+    end,
     {true, RD, Ctx}.
 
 -spec content_types_accepted(term(), term()) ->


### PR DESCRIPTION
This case was making `s3api_verification_test.py` barf when the tests ran in a
different order than expected (because one of the tests attempted to
clean up something that shouldn't have been there).  Beyond the test
case, though, I think we don't want RCS to log an error when a user
attempts to delete something that doesn't exist.

Simple test:

```
s3cmd mb s3://deltest
s3cmd del s3://deltest/nonexistent
```

Without this patch, you'll see a parse error from s3cmd, and `{error,{badmatch,{error,notfound}},[{riak_moss_wm_key,delete_resource,2}…` in the RCS console.  With the patch, you'll just see s3cmd report `File s3://deltest/nonexistent deleted`

The `s3api_verification_test.py` script also passes once again after this patch is applied.
