### PR TITLE
Expand User API so admin user can list all users

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -213,3 +213,5 @@
 %% to determine the PUT buffer size.
 %% ex. 2 would mean BlockSize * 2
 -define(DEFAULT_PUT_BUFFER_FACTOR, 1).
+-define(JSON_TYPE, "application/json").
+-define(XML_TYPE, "application/xml").

--- a/src/riak_moss_access_logger.erl
+++ b/src/riak_moss_access_logger.erl
@@ -352,6 +352,8 @@ operation(#wm_log_data{resource_module=riak_moss_wm_usage}) ->
     <<"UsageRead">>;
 operation(#wm_log_data{resource_module=riak_moss_wm_service}) ->
     <<"ListBuckets">>;
+operation(#wm_log_data{resource_module=riak_moss_wm_user}) ->
+    <<"AccountRead">>;
 operation(#wm_log_data{resource_module=riak_moss_wm_bucket,
                        path=Path,
                        method=Method}) ->

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -289,7 +289,7 @@ get_object(BucketName, Key, RiakPid) ->
 
 %% @doc Retrieve a MOSS user's information based on their id string.
 -spec get_user('undefined' | list(), pid()) -> {ok, {moss_user(), riakc_obj:vclock()}} | {error, term()}.
-get_user(undefined, _RiakPid) -> 
+get_user(undefined, _RiakPid) ->
     {error, no_user_key};
 get_user(KeyId, RiakPid) ->
     %% @TODO Check for an resolve siblings to get a

--- a/src/riak_moss_web.erl
+++ b/src/riak_moss_web.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
@@ -23,6 +23,8 @@ dispatch_table() ->
      {[], riak_moss_wm_service, [{auth_bypass, AuthBypass}]},
      {["riak-cs", "stats"], riak_cs_wm_stats, StatsProps},
      {["user"], riak_moss_wm_user, []},
+     {["riak-cs", "users"], riak_moss_wm_users, [{auth_bypass, AuthBypass}]},
+     {["riak-cs", "user", '*'], riak_moss_wm_user, [{auth_bypass, AuthBypass}]},
      {["usage", '*'], riak_moss_wm_usage, [{auth_bypass, AuthBypass}]},
      {[bucket], riak_moss_wm_bucket, [{auth_bypass, AuthBypass}]},
      {[bucket, '*'], riak_moss_wm_key, [{auth_bypass, AuthBypass}]}

--- a/src/riak_moss_wm_usage.erl
+++ b/src/riak_moss_wm_usage.erl
@@ -113,9 +113,6 @@
 -include("rts.hrl").
 -include("riak_moss.hrl").
 
--define(JSON_TYPE, "application/json").
--define(XML_TYPE, "application/xml").
-
 %% Keys used in output - defined here to help keep JSON and XML output
 %% as similar as possible.
 -define(KEY_USAGE, 'Usage').
@@ -353,7 +350,7 @@ xml_storage({Storage, Errors}) ->
                      || S <- Storage]},
      {?KEY_ERRORS, [xml_sample_error(E, ?KEY_BUCKET, ?KEY_NAME)
                     || E <- Errors ]}].
-    
+
 %% Internals %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 user_key(RD) ->
     case path_tokens(RD) of
@@ -470,10 +467,10 @@ too_many_periods(Start, End) ->
     Seconds = calendar:datetime_to_gregorian_seconds(End)
         -calendar:datetime_to_gregorian_seconds(Start),
     {ok, Limit} = application:get_env(riak_moss, usage_request_limit),
-    
+
     {ok, Access} = riak_moss_access:archive_period(),
     {ok, Storage} = riak_moss_storage:archive_period(),
-    
+
     ((Seconds div Access) > Limit) orelse ((Seconds div Storage) > Limit).
 
 -ifdef(TEST).

--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% -------------------------------------------------------------------
 
@@ -8,25 +8,68 @@
 
 -export([init/1,
          service_available/2,
+         forbidden/2,
+         content_types_provided/2,
+         allowed_methods/2,
+         produce_json/2,
+         produce_xml/2,
          process_post/2,
-         allowed_methods/2]).
+         finish_request/2]).
 
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
-init(_Config) ->
-    {ok, #context{}}.
+%% -------------------------------------------------------------------
+%% Webmachine callbacks
+%% -------------------------------------------------------------------
+
+init(Config) ->
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
-    {true, RD, Ctx}.
+    riak_moss_wm_utils:service_available(RD, Ctx).
 
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
 allowed_methods(RD, Ctx) ->
-    {['POST'], RD, Ctx}.
+    {['GET', 'HEAD', 'POST'], RD, Ctx}.
 
+forbidden(RD, Ctx) ->
+    case wrq:method(RD) of
+        'POST' ->
+            {false, RD, Ctx};
+        _ ->
+            Next = fun(NewRD, NewCtx=#context{user=User}) ->
+                           AccessRD = riak_moss_access_logger:set_user(User, NewRD),
+                           forbidden(AccessRD, NewCtx, User)
+                   end,
+            riak_moss_wm_utils:find_and_auth_user(RD, Ctx, Next)
+    end.
 
-%% @doc Create a user from a POST
+content_types_provided(RD, Ctx) ->
+    {[{?XML_TYPE, produce_xml}, {?JSON_TYPE, produce_json}], RD, Ctx}.
+
+produce_json(RD, #context{user=User}=Ctx) ->
+    MJ = {struct, riak_moss_wm_utils:user_record_to_proplist(User)},
+    Body = mochijson2:encode(MJ),
+    Etag = etag(Body),
+    RD2 = wrq:set_resp_header("ETag", Etag, RD),
+    {Body, RD2, Ctx}.
+
+produce_xml(RD, #context{user=User}=Ctx) ->
+    XmlUserRec =
+        [{Key, [binary_to_list(Value)]} ||
+            {Key, Value} <- riak_moss_wm_utils:user_record_to_proplist(User)],
+    Doc = [{'User', XmlUserRec}],
+    Body = riak_moss_s3_response:export_xml(Doc),
+    Etag = etag(Body),
+    RD2 = wrq:set_resp_header("ETag", Etag, RD),
+    {Body, RD2, Ctx}.
+
+%% @doc Create a user from a POST.
 %%      and return the user object
 %%      as JSON
 -spec process_post(term(), term()) -> {true, term(), term}.
@@ -38,11 +81,70 @@ process_post(RD, Ctx) ->
     case riak_moss_utils:create_user(UserName, Email) of
         {ok, UserRecord} ->
             PropListUser = riak_moss_wm_utils:user_record_to_proplist(UserRecord),
-            CTypeWritten = wrq:set_resp_header("Content-Type", "application/json", RD),
+            CTypeWritten = wrq:set_resp_header("Content-Type", ?JSON_TYPE, RD),
             WrittenRD = wrq:set_resp_body(list_to_binary(
                                             mochijson2:encode(PropListUser)),
                                           CTypeWritten),
             {true, WrittenRD, Ctx};
         {error, Reason} ->
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
+    end.
+
+finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
+    {true, RD, Ctx};
+finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    riak_moss_utils:close_riak_connection(RiakPid),
+    {true, RD, Ctx#context{riakc_pid=undefined}}.
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+%% @doc Calculate the etag of a response body
+etag(Body) ->
+    webmachine_util:quoted_string(
+      riak_moss_utils:binary_to_hexlist(
+        crypto:md5(Body))).
+
+forbidden(RD, Ctx, undefined) ->
+    %% anonymous access disallowed
+    riak_moss_wm_utils:deny_access(RD, Ctx);
+forbidden(RD, Ctx, User) ->
+    UserKeyId = User?MOSS_USER.key_id,
+    UserPathKey = user_key(RD),
+    case UserPathKey of
+        [] ->
+            %% user is accessing own account
+            %% @TODO Determine if logging this is appropriate
+            %% and if we need to classify it differently.
+            AccessRD = riak_moss_access_logger:set_user(User, RD),
+            {false, AccessRD, Ctx};
+         UserKeyId ->
+            %% user is accessing own account
+            %% @TODO Determine if logging this is appropriate
+            %% and if we need to classify it differently.
+            AccessRD = riak_moss_access_logger:set_user(User, RD),
+            {false, AccessRD, Ctx};
+        _ ->
+            case riak_moss_utils:get_admin_creds() of
+                {ok, {Admin, _}} when Admin == UserKeyId ->
+                    %% admin can access any account
+                    case riak_moss_utils:get_user(UserPathKey, Ctx#context.riakc_pid) of
+                        {ok, {ReqUser, _}} ->
+                            {false, RD, Ctx#context{user=ReqUser}};
+                        {error, Reason} ->
+                            _ = lager:warning("Failed to fetch user record. KeyId: ~p"
+                                          " Reason: ~p", [UserPathKey, Reason]),
+                            riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
+                    end;
+                _ ->
+                    %% no one else is allowed
+                    riak_moss_wm_utils:deny_access(RD, Ctx)
+            end
+    end.
+
+user_key(RD) ->
+    case wrq:path_tokens(RD) of
+        [KeyId|_] -> mochiweb_util:unquote(KeyId);
+        _         -> []
     end.

--- a/src/riak_moss_wm_users.erl
+++ b/src/riak_moss_wm_users.erl
@@ -1,0 +1,156 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_moss_wm_users).
+
+-export([init/1,
+         service_available/2,
+         forbidden/2,
+         content_types_provided/2,
+         allowed_methods/2,
+         produce_json/2,
+         produce_xml/2,
+         finish_request/2]).
+
+-include("riak_moss.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+%% -------------------------------------------------------------------
+%% Webmachine callbacks
+%% -------------------------------------------------------------------
+
+init(Config) ->
+    %% Check if authentication is disabled and
+    %% set that in the context.
+    AuthBypass = proplists:get_value(auth_bypass, Config),
+    {ok, #context{auth_bypass=AuthBypass}}.
+
+-spec service_available(term(), term()) -> {true, term(), term()}.
+service_available(RD, Ctx) ->
+    riak_moss_wm_utils:service_available(RD, Ctx).
+
+-spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
+allowed_methods(RD, Ctx) ->
+    {['GET', 'HEAD'], RD, Ctx}.
+
+forbidden(RD, Ctx) ->
+    Next = fun(NewRD, NewCtx=#context{user=User}) ->
+                   forbidden(NewRD, NewCtx, User)
+           end,
+    riak_moss_wm_utils:find_and_auth_user(RD, Ctx, Next).
+
+content_types_provided(RD, Ctx) ->
+    {[{?XML_TYPE, produce_xml}, {?JSON_TYPE, produce_json}], RD, Ctx}.
+
+produce_json(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    Boundary = unique_id(),
+    UpdRD = wrq:set_resp_header("Content-Type",
+                                "multipart/mixed; boundary="++Boundary,
+                                RD),
+    {{stream, {<<>>, fun() -> stream_users(json, RiakPid, Boundary) end}}, UpdRD, Ctx}.
+
+produce_xml(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    Boundary = unique_id(),
+    UpdRD = wrq:set_resp_header("Content-Type",
+                                "multipart/mixed; boundary="++Boundary,
+                                RD),
+    {{stream, {<<>>, fun() -> stream_users(xml, RiakPid, Boundary) end}}, UpdRD, Ctx}.
+
+finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
+    {true, RD, Ctx};
+finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    riak_moss_utils:close_riak_connection(RiakPid),
+    {true, RD, Ctx#context{riakc_pid=undefined}}.
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+forbidden(RD, Ctx, undefined) ->
+    %% anonymous access disallowed
+    riak_moss_wm_utils:deny_access(RD, Ctx);
+forbidden(RD, Ctx, User) ->
+    UserKeyId = User?MOSS_USER.key_id,
+    case riak_moss_utils:get_admin_creds() of
+        {ok, {Admin, _}} when Admin == UserKeyId ->
+            %% admin account is allowed
+            {false, RD, Ctx};
+        _ ->
+            %% no one else is allowed
+            riak_moss_wm_utils:deny_access(RD, Ctx)
+    end.
+
+stream_users(Format, RiakPid, Boundary) ->
+    case riakc_pb_socket:stream_list_keys(RiakPid, ?USER_BUCKET) of
+        {ok, ReqId} ->
+            case riak_moss_utils:riak_connection() of
+                {ok, RiakPid2} ->
+                    Res = wait_for_users(Format, RiakPid2, ReqId, Boundary),
+                    riak_moss_utils:close_riak_connection(RiakPid2),
+                    Res;
+                {error, _Reason} ->
+                    wait_for_users(Format, RiakPid, ReqId, Boundary)
+            end;
+        {error, _Reason} ->
+            {<<>>, done}
+    end.
+
+wait_for_users(Format, RiakPid, ReqId, Boundary) ->
+    receive
+        {ReqId, {keys, UserIds}} ->
+            UserDocs = [user_doc(Format, RiakPid, binary_to_list(UserId)) ||
+                           UserId <- UserIds],
+            Doc = users_doc(UserDocs, Format, Boundary),
+            {Doc, fun() -> wait_for_users(Format, RiakPid, ReqId, Boundary) end};
+        {ReqId, done} ->
+            {list_to_binary(["\r\n--", Boundary, "--"]), done};
+        _ ->
+            wait_for_users(Format, RiakPid, ReqId, Boundary)
+    end.
+
+%% @doc Compile a multipart entity for a set of user documents.
+users_doc(UserDocs, xml, Boundary) ->
+    XmlDoc = riak_moss_s3_response:export_xml([{'Users', UserDocs}]),
+    ["\r\n--",
+     Boundary,
+     "\r\nContent-Type: ", ?XML_TYPE, "\r\n\r\n",
+     XmlDoc];
+users_doc(UserDocs, json, Boundary) ->
+    ["\r\n--",
+     Boundary,
+     "\r\nContent-Type: ", ?JSON_TYPE, "\r\n\r\n",
+     mochijson2:encode(UserDocs)].
+
+%% @doc Generate xml or json terms representing
+%% the information for a given user.
+user_doc(Format, RiakPid, UserId) ->
+    case riak_moss_utils:get_user(UserId, RiakPid) of
+        {ok, {User, _}} ->
+            case Format of
+                xml ->
+                    produce_user_xml(User);
+                json ->
+                    produce_user_json(User)
+            end;
+        {error, Reason} ->
+            _ = lager:warning("Failed to fetch user record. KeyId: ~p"
+                          " Reason: ~p", [UserId, Reason]),
+            []
+    end.
+
+produce_user_json(User) ->
+      {struct, riak_moss_wm_utils:user_record_to_proplist(User)}.
+
+produce_user_xml(User) ->
+    XmlUserRec =
+        [{Key, [binary_to_list(Value)]} ||
+            {Key, Value} <- riak_moss_wm_utils:user_record_to_proplist(User)],
+    {'User', XmlUserRec}.
+
+unique_id() ->
+    Rand = crypto:sha(term_to_binary({make_ref(), now()})),
+    <<I:160/integer>> = Rand,
+    integer_to_list(I, 36).

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -109,7 +109,8 @@ validate_auth_header(RD, AuthBypass, RiakPid) ->
             case AuthMod:authenticate(RD, Secret, Signature) of
                 ok ->
                     {ok, User, UserVclock};
-                {error, _Reason} ->
+                {error, Reason} ->
+                    lager:info("Reason: ~p", [Reason]),
                     %% TODO: are the errors here of small enough
                     %% number that we could just handle them in
                     %% forbidden/2?
@@ -172,20 +173,20 @@ user_record_to_proplist(?MOSS_USER{email=Email,
                                    key_id=KeyID,
                                    key_secret=KeySecret,
                                    canonical_id=CanonicalID}) ->
-    [{<<"email">>, list_to_binary(Email)},
-     {<<"display_name">>, list_to_binary(DisplayName)},
-     {<<"name">>, list_to_binary(Name)},
-     {<<"key_id">>, list_to_binary(KeyID)},
-     {<<"key_secret">>, list_to_binary(KeySecret)},
-     {<<"id">>, list_to_binary(CanonicalID)}];
+    [{'Email', list_to_binary(Email)},
+     {'DisplayName', list_to_binary(DisplayName)},
+     {'Name', list_to_binary(Name)},
+     {'KeyId', list_to_binary(KeyID)},
+     {'KeySecret', list_to_binary(KeySecret)},
+     {'Id', list_to_binary(CanonicalID)}];
 user_record_to_proplist(#moss_user{name=Name,
                                    key_id=KeyID,
                                    key_secret=KeySecret,
                                    buckets = Buckets}) ->
-    [{<<"name">>, list_to_binary(Name)},
-     {<<"key_id">>, list_to_binary(KeyID)},
-     {<<"key_secret">>, list_to_binary(KeySecret)},
-     {<<"buckets">>, Buckets}].
+    [{'Name', list_to_binary(Name)},
+     {'KeyId', list_to_binary(KeyID)},
+     {'KeySecret', list_to_binary(KeySecret)},
+     {'Buckets', Buckets}].
 
 %% @doc Get an ISO 8601 formatted timestamp representing
 %% current time.

--- a/test/riak_moss_put_fsm_test.erl
+++ b/test/riak_moss_put_fsm_test.erl
@@ -10,7 +10,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 setup() ->
-    application:start(lager).
+    application:start(lager),
+    {ok, _} = riak_cs_stats:start_link().
 
 %% TODO:
 %% Implement this

--- a/test/s3api_verification_test.py
+++ b/test/s3api_verification_test.py
@@ -62,7 +62,7 @@ class S3ApiVerificationTest(unittest.TestCase):
 
 
     def make_connection(self, user):
-        return S3Connection(user['key_id'], user['key_secret'], is_secure=False,
+        return S3Connection(user['KeyId'], user['KeySecret'], is_secure=False,
                             host=self.host, port=self.port, debug=True,
                             calling_format=OrdinaryCallingFormat() )
 
@@ -80,16 +80,16 @@ class S3ApiVerificationTest(unittest.TestCase):
         self.data = file("/dev/random").read(1024)
 
     def defaultAcl(self, user):
-        return self.SimpleAcl % (user['id'], user['display_name'], user['id'], user['display_name'], 'FULL_CONTROL')
+        return self.SimpleAcl % (user['Id'], user['DisplayName'], user['Id'], user['DisplayName'], 'FULL_CONTROL')
 
     def prAcl(self, user):
-        return self.PublicReadAcl % (user['id'], user['display_name'], user['id'], user['display_name'], 'FULL_CONTROL')
+        return self.PublicReadAcl % (user['Id'], user['DisplayName'], user['Id'], user['DisplayName'], 'FULL_CONTROL')
 
     def setUp(self):
         self.conn = self.make_connection(self.user1)
 
     def test_auth(self):
-        bad_user = json.loads('{"email":"baduser@example.me","display_name":"baduser","name":"user1","key_id":"bad_key","key_secret":"bad_secret","id":"bad_canonical_id"}')
+        bad_user = json.loads('{"Email":"baduser@example.me","DisplayName":"baduser","Name":"user1","KeyId":"bad_key","KeySecret":"BadSecret","Id":"bad_canonical_id"}')
         conn = self.make_connection(bad_user)
         self.assertRaises(S3ResponseError, conn.get_canonical_user_id)
 


### PR DESCRIPTION
These changes adds one webmachine resource, `riak_moss_wm_users` and updates another, `riak_moss_wm_user`.

The changes to `riak_moss_wm_user` to allow a user to list their own account information or the admin user to list the user information of any individual user.

`riak_moss_wm_users` allows the admin user to get a list of all users on the system. This information is gathered from riak using a streaming list keys and is streamed back to the requesting client using a multipart response. This is to avoid having to accumulate all of the user records in memory when the number of users could potentially be very large.
## Testing

I recommend the [s3-curl](http://aws.amazon.com/code/128) tool for these tests and that's what I'll use to show testing examples with. [Here's](https://gist.github.com/23cda6221da4995c15be) a sample s3-curl config file. The following testing suggestions assume that the admin user credentials are associated with the admin id in the `.s3curl` file.
1. List the cs user's information. All of the following should yield the same document containing the user account info for the user associated with the `cs` id in the `.s3curl` file.
   
   ```
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/user/TMEQSQBMR59IZCTYRXQY
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/user
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/user/TMEQSQBMR59IZCTYRXQY
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/user
   ```
2. List another user using the admin credentials. Both of the following should yield the same results and that result should be a document containing the cs user's record.
   
   ```
   ./s3curl.pl --id admin -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/user/TMEQSQBMR59IZCTYRXQY
   ./s3curl.pl --id admin -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/user/TMEQSQBMR59IZCTYRXQY
   ```
3. Fail to list another user using non-admin credentials. This assumes that the user credentials represented by the `test` id in the `.s3curl` file is distinct from the `cs` user and also not the admin for the system.
   
   ```
   ./s3curl.pl --id test -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/user/TMEQSQBMR59IZCTYRXQY
    ./s3curl.pl --id test -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/user/TMEQSQBMR59IZCTYRXQY
   ```
4. List all users using the admin credentials. Both of the following should yield the same results and that result should be a list of all user records.
   
   ```
   ./s3curl.pl --id admin -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/users
   ./s3curl.pl --id admin -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/users
   ```
5. Fail to list all users using non-admin credentials
   
   ```
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://s3.amazonaws.com/riak-cs/users
   ./s3curl.pl --id cs -- --proxy1.0 "localhost:8080" -v -H "Accept: application/json"  http://riak-cs.s3.amazonaws.com/users
   ```

Also repeat all of the above steps using `application/xml` as the `Accept` header value and verify that the xml results are correct as well.
