### PR TITLE
Slf dtrace round1

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -253,5 +253,5 @@
 -define(DT_SERVICE_OP,      701).
 -define(DT_BUCKET_OP,       702).
 -define(DT_OBJECT_OP,       703).
--define(DT_AUTH_OP,         704).
+%%-define(DT_AUTH_OP,         704).
 -define(DT_WM_OP,           705).

--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -213,3 +213,11 @@
 %% to determine the PUT buffer size.
 %% ex. 2 would mean BlockSize * 2
 -define(DEFAULT_PUT_BUFFER_FACTOR, 1).
+
+%% Major categories of Erlang-triggered DTrace probes
+-define(DT_BLOCK_OP,        1).
+-define(DT_SERVICE_OP,      2).
+-define(DT_BUCKET_OP,       3).
+-define(DT_OBJECT_OP,       4).
+-define(DT_AUTH_OP,         5).
+-define(DT_WM_OP,           6).

--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -215,9 +215,43 @@
 -define(DEFAULT_PUT_BUFFER_FACTOR, 1).
 
 %% Major categories of Erlang-triggered DTrace probes
--define(DT_BLOCK_OP,        1).
--define(DT_SERVICE_OP,      2).
--define(DT_BUCKET_OP,       3).
--define(DT_OBJECT_OP,       4).
--define(DT_AUTH_OP,         5).
--define(DT_WM_OP,           6).
+%%
+%% The main R15B01 USDT probe that can be triggered by Erlang code is defined
+%% like this:
+%%
+%% /**
+%%  * Multi-purpose probe: up to 4 NUL-terminated strings and 4
+%%  * 64-bit integer arguments.
+%%  *
+%%  * @param proc, the PID (string form) of the sending process
+%%  * @param user_tag, the user tag of the sender
+%%  * @param i1, integer
+%%  * @param i2, integer
+%%  * @param i3, integer
+%%  * @param i4, integer
+%%  * @param s1, string/iolist. D's arg6 is NULL if not given by Erlang
+%%  * @param s2, string/iolist. D's arg7 is NULL if not given by Erlang
+%%  * @param s3, string/iolist. D's arg8 is NULL if not given by Erlang
+%%  * @param s4, string/iolist. D's arg9 is NULL if not given by Erlang
+%%  */
+%% probe user_trace__i4s4(char *proc, char *user_tag,
+%%                        int i1, int i2, int i3, int i4,
+%%                        char *s1, char *s2, char *s3, char *s4);
+%%
+%% The convention that we'll use of these probes is:
+%%   param  D arg name  use
+%%   -----  ----------  ---
+%%   i1     arg2        Application category (see below)
+%%   i2     arg3        1 = function entry, 2 = function return
+%%                      NOTE! Not all function entry probes have a return probe
+%%   i3-i4  arg4-arg5   Varies, zero usually means unused (but not always!)
+%%   s1     arg6        Module name
+%%   s2     arg7        Function name
+%%   s3-4   arg8-arg9   Varies, NULL means unused
+%%
+-define(DT_BLOCK_OP,        700).
+-define(DT_SERVICE_OP,      701).
+-define(DT_BUCKET_OP,       702).
+-define(DT_OBJECT_OP,       703).
+-define(DT_AUTH_OP,         704).
+-define(DT_WM_OP,           705).

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -76,7 +76,14 @@
               %% == Riak CS stats HTTP API ==
 
               %% true = enable the stats HTTP API, false = disable it
-              {riak_cs_stat, true}
+              {riak_cs_stat, true},
+
+              %% == DTrace ==
+
+              %% If your Erlang virtual machine supports DTrace (or
+              %% user-space SystemTap), set dtrace_support to true.
+              {dtrace_support, true}
+
              ]},
 
  {webmachine, [

--- a/src/riak_cs_dtrace.erl
+++ b/src/riak_cs_dtrace.erl
@@ -5,7 +5,9 @@
 %% -------------------------------------------------------------------
 -module(riak_cs_dtrace).
 
--export([dtrace/1]).
+-export([dtrace/1, dtrace/3, dtrace/4, dtrace/6]).
+-include("riak_moss.hrl").
+-export([t/1, t/2, tt/3]).                      % debugging use only
 
 -define(MAGIC, '**DTRACE*SUPPORT**').
 
@@ -36,6 +38,51 @@ dtrace(ArgList) ->
             erlang:apply(dyntrace, p, ArgList);
         dtrace ->
             erlang:apply(dtrace, p, ArgList);
+        _ ->
+            false
+    end.
+
+dtrace(Int0, Ints, Strings) when is_integer(Int0) ->
+    case get(?MAGIC) of
+        unsupported ->
+            false;
+        _ ->
+            dtrace([Int0] ++ Ints ++ Strings)
+    end.
+
+dtrace(Int0, Ints, String0, Strings) when is_integer(Int0) ->
+    case get(?MAGIC) of
+        unsupported ->
+            false;
+        _ ->
+            dtrace([Int0] ++ Ints ++ [String0] ++ Strings)
+    end.
+
+%% NOTE: Due to use of ?MODULE, we may have cases where the type
+%%       of String0 is an atom and not a string/iodata.
+
+dtrace(Int0, Int1, Ints, String0, String1, Strings)
+  when is_integer(Int0), is_integer(Int1) ->
+    case get(?MAGIC) of
+        unsupported ->
+            false;
+        _ ->
+            S0 = if is_atom(String0) -> erlang:atom_to_binary(String0, latin1);
+                    true             -> String0
+                 end,
+            dtrace([Int0, Int1] ++ Ints ++ [S0, String1] ++ Strings)
+    end.
+
+t(L) ->                                  % debugging/micro-performance
+    dtrace(L).
+
+t(Ints, Strings) ->                      % debugging/micro-performance
+    dtrace([77] ++ Ints ++ ["entry"] ++ Strings).
+
+tt(Int0, Ints, Strings) ->                     % debugging/micro-performance
+    case get(?MAGIC) of
+        X when X == dyntrace; X == dtrace ->
+            dtrace([Int0] ++ Ints ++ Strings);
         _ ->
             false
     end.

--- a/src/riak_cs_dtrace.erl
+++ b/src/riak_cs_dtrace.erl
@@ -1,0 +1,46 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+-module(riak_cs_dtrace).
+
+-export([dtrace/1]).
+
+-define(MAGIC, '**DTRACE*SUPPORT**').
+
+%% timing:
+%%
+%% f(Xs), begin [_|Xs] = [begin put('**DYNTRACE', undefined), timer:tc(riak_cs_dtrace, dtrace, [[42]]) end || _ <- lists:seq(1,10000)], lists:sum([X || {X, _} <- Xs]) / (length(Xs)-1) end.
+%% -> 0.21024204840968194
+
+dtrace(ArgList) ->
+    case get(?MAGIC) of
+        undefined ->
+            case application:get_env(riak_moss, dtrace_support) of
+                {ok, true} ->
+                    case string:to_float(erlang:system_info(version)) of
+                        {5.8, _} ->
+                            %% R14B04
+                            put(?MAGIC, dtrace),
+                            dtrace(ArgList);
+                        {Num, _} when Num > 5.8 ->
+                            %% R15B or higher, though dyntrace option
+                            %% was first available in R15B01.
+                            put(?MAGIC, dyntrace),
+                            dtrace(ArgList);
+                        _ ->
+                            put(?MAGIC, unsupported),
+                            false
+                    end;
+                _ ->
+                    put(?MAGIC, unsupported),
+                    false
+            end;
+        dyntrace ->
+            erlang:apply(dyntrace, p, ArgList);
+        dtrace ->
+            erlang:apply(dtrace, p, ArgList);
+        _ ->
+            false
+    end.

--- a/src/riak_cs_dtrace.erl
+++ b/src/riak_cs_dtrace.erl
@@ -9,11 +9,6 @@
 
 -define(MAGIC, '**DTRACE*SUPPORT**').
 
-%% timing:
-%%
-%% f(Xs), begin [_|Xs] = [begin put('**DYNTRACE', undefined), timer:tc(riak_cs_dtrace, dtrace, [[42]]) end || _ <- lists:seq(1,10000)], lists:sum([X || {X, _} <- Xs]) / (length(Xs)-1) end.
-%% -> 0.21024204840968194
-
 dtrace(ArgList) ->
     case get(?MAGIC) of
         undefined ->

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -7,8 +7,6 @@
 
 -behaviour(gen_server).
 
--compile(export_all).
-
 %% API
 -export([start_link/0,
          update/2,
@@ -158,62 +156,4 @@ raw_report_item(BaseId) ->
              Latency95, Latency99]};
         undefined ->
             {BaseId, -1, -1, -1, -1, -1, -1}
-    end.
-
--define(MAGIC, '**DYNTRACE').
-
-dyntrace(ArgList) ->
-    case application:get_env(riak_moss, dyntrace) of
-        undefined ->
-            false;
-        dyntrace ->
-            erlang:apply(dyntrace, p, ArgList);
-        dtrace ->
-            erlang:apply(dtrace, p, ArgList)
-    end.
-
-%% On an unloaded/idle MacBook Pro:
-%% 
-%% dyntrace0:
-%%
-%% f(Xs), begin [_|Xs] = [begin put('**DYNTRACE', undefined), timer:tc(riak_cs_stats, dyntrace0, [[42]]) end || _ <- lists:seq(1,500)], lists:sum([X || {X, _} <- Xs]) / (length(Xs)-1) end.  
-%% -> 5013.883534136547
-%%
-%% dyntrace2:
-%%
-%% riak_cs_stats:dyntrace2_setup(undefined).
-%% f(Xs), begin [_|Xs] = [begin put('**DYNTRACE', undefined), timer:tc(riak_cs_stats, dyntrace2, [[42]]) end || _ <- lists:seq(1,10000)], lists:sum([X || {X, _} <- Xs]) / (length(Xs)-1) end.
-%% -> 1.0608121624324864
-%%
-%% dyntrace:
-%%
-%% f(Xs), begin [_|Xs] = [begin put('**DYNTRACE', undefined), timer:tc(riak_cs_stats, dyntrace, [[42]]) end || _ <- lists:seq(1,10000)], lists:sum([X || {X, _} <- Xs]) / (length(Xs)-1) end. 
-%% -> 0.5754150830166033
-
-dyntrace0(ArgList) ->
-    try
-        erlang:apply(dyntrace, p, ArgList)
-    catch
-        error:undef ->
-            try
-                erlang:apply(dtrace, p, ArgList)
-            catch
-                error:undef ->
-                    false
-            end
-    end.
-
-dyntrace2_setup(Val)
-  when Val == undefined; Val == dyntrace; Val == dtrace ->
-    code:add_pathz("/Users/fritchie/b/src/riak/deps/mochiweb/ebin"),
-    mochiglobal:put(?MAGIC, Val).
-
-dyntrace2(ArgList) ->
-    case mochiglobal:get(?MAGIC) of
-        undefined ->
-            false;
-        dyntrace ->
-            erlang:apply(dyntrace, p, ArgList);
-        dtrace ->
-            erlang:apply(dtrace, p, ArgList)
     end.

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -5,6 +5,7 @@
 %% -------------------------------------------------------------------
 -module(riak_moss_s3_response).
 -export([api_error/3,
+         status_code/1,
          respond/4,
          export_xml/1,
          error_response/5,

--- a/src/riak_moss_sup.erl
+++ b/src/riak_moss_sup.erl
@@ -34,6 +34,7 @@ start_link() ->
                          integer()},
                         [supervisor:child_spec()]}}.
 init([]) ->
+    catch dtrace:init(),                        % NIF load trigger (R14B04)
     case application:get_env(riak_moss, moss_ip) of
         {ok, Ip} ->
             ok;

--- a/src/riak_moss_sup.erl
+++ b/src/riak_moss_sup.erl
@@ -34,7 +34,8 @@ start_link() ->
                          integer()},
                         [supervisor:child_spec()]}}.
 init([]) ->
-    catch dtrace:init(),                        % NIF load trigger (R14B04)
+    catch dtrace:init(),                   % NIF load trigger (R14B04)
+    catch dyntrace:p(),                    % NIF load trigger (R15B01+)
     case application:get_env(riak_moss, moss_ip) of
         {ok, Ip} ->
             ok;

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -293,8 +293,8 @@ map_keys_and_manifests(Object, _, _) ->
                 []
         end
     catch Type:Reason ->
-            lager:warning("Riak CS object list map failed: ~p:~p",
-                          [Type, Reason]),
+            _ = lager:warning("Riak CS object list map failed: ~p:~p",
+                              [Type, Reason]),
             []
     end.
 

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -326,12 +326,8 @@ finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
     dt_return(<<"finish_request">>, [1], []),
     {true, RD, Ctx#context{riakc_pid=undefined}}.
 
-extract_name(User) when is_list(User) ->
-    User;
-extract_name(?MOSS_USER{name=Name}) ->
-    Name;
-extract_name(_) ->
-    "-unknown-".
+extract_name(X) ->
+    riak_moss_wm_utils:extract_name(X).
 
 dt_entry(Func) ->
     dt_entry(Func, [], []).

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -23,6 +23,7 @@
 
 
 init(Config) ->
+    dt_entry(<<"init">>),
     %% Check if authentication is disabled and
     %% set that in the context.
     AuthBypass = proplists:get_value(auth_bypass, Config),
@@ -30,10 +31,14 @@ init(Config) ->
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
-    riak_moss_wm_utils:service_available(RD, Ctx).
+    dt_entry(<<"service_available">>),
+    Res = riak_moss_wm_utils:service_available(RD, Ctx),
+    dt_return(<<"service_available">>),
+    Res.
 
 -spec malformed_request(term(), term()) -> {false, term(), term()}.
 malformed_request(RD, Ctx) ->
+    dt_entry(<<"malformed_request">>),
     {false, RD, Ctx}.
 
 %% @doc Check to see if the user is
@@ -41,7 +46,19 @@ malformed_request(RD, Ctx) ->
 %%      we'd use the `authorized` callback,
 %%      but this is how S3 does things.
 forbidden(RD, Ctx) ->
-    riak_moss_wm_utils:find_and_auth_user(RD, Ctx, fun check_permission/2).
+    dt_entry(<<"forbidden">>),
+    case riak_moss_wm_utils:find_and_auth_user(RD, Ctx, fun check_permission/2) of
+        {false, _RD2, Ctx2} = FalseRet ->
+            dt_return(<<"forbidden">>, [], [extract_name(Ctx2#context.user), <<"false">>]),
+            FalseRet;
+        {Rsn, _RD2, Ctx2} = Ret ->
+            Reason = case Rsn of
+                         {halt, Code} -> Code;
+                         _            -> -1
+                     end,
+            dt_return(<<"forbidden">>, [Reason], [extract_name(Ctx2#context.user), <<"true">>]),
+            Ret
+    end.
 
 check_permission(RD, #context{user=User,
                               riakc_pid=RiakPid}=Ctx) ->
@@ -129,6 +146,7 @@ shift_to_owner(RD, Ctx, OwnerId, RiakPid) when RiakPid /= undefined ->
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
 allowed_methods(RD, Ctx) ->
+    dt_entry(<<"allowed_methods">>),
     %% TODO: add POST
     %% TODO: make this list conditional on Ctx
     {['HEAD', 'GET', 'PUT', 'DELETE'], RD, Ctx}.
@@ -136,6 +154,7 @@ allowed_methods(RD, Ctx) ->
 -spec content_types_provided(term(), term()) ->
                                     {[{string(), atom()}], term(), term()}.
 content_types_provided(RD, Ctx) ->
+    dt_entry(<<"content_types_provided">>),
     %% TODO:
     %% Add xml support later
 
@@ -149,6 +168,7 @@ content_types_provided(RD, Ctx) ->
 %%          {[{ContentType::string(), Acceptor::atom()}],
 %%           reqdata(), context()}
 content_types_accepted(RD, Ctx) ->
+    dt_entry(<<"content_types_accepted">>),
     case wrq:get_req_header("content-type", RD) of
         undefined ->
             {[{"application/octet-stream", accept_body}], RD, Ctx};
@@ -164,11 +184,15 @@ to_xml(RD, Ctx=#context{start_time=StartTime,
                         bucket=Bucket,
                         requested_perm='READ',
                         riakc_pid=RiakPid}) ->
+    dt_entry(<<"to_xml">>, [], [extract_name(User), Bucket]),
     StrBucket = binary_to_list(Bucket),
     case [B || B <- riak_moss_utils:get_buckets(User),
                B?MOSS_BUCKET.name =:= StrBucket] of
         [] ->
-            riak_moss_s3_response:api_error(no_such_bucket, RD, Ctx);
+            CodeName = no_such_bucket,
+            Res = riak_moss_s3_response:api_error(CodeName, RD, Ctx),
+            dt_return(<<"to_xml">>, [riak_moss_s3_response:status_code(CodeName)], [extract_name(User), Bucket]),
+            Res;
         [BucketRecord] ->
             Prefix = list_to_binary(wrq:get_qs_value("prefix", "", RD)),
             case riak_moss_utils:get_keys_and_manifests(Bucket, Prefix, RiakPid) of
@@ -180,22 +204,32 @@ to_xml(RD, Ctx=#context{start_time=StartTime,
                                                                    Ctx),
                     ok = riak_cs_stats:update_with_start(bucket_list_keys,
                                                          StartTime),
+                    dt_return(<<"to_xml">>, [200], [extract_name(User), Bucket]),
                     X;
                 {error, Reason} ->
-                    riak_moss_s3_response:api_error(Reason, RD, Ctx)
+                    Code = riak_moss_s3_response:status_code(Reason),
+                    X = riak_moss_s3_response:api_error(Reason, RD, Ctx),
+                    dt_return(<<"to_xml">>, [Code], [extract_name(User), Bucket]),
+                    X
             end
     end;
 to_xml(RD, Ctx=#context{start_time=StartTime,
+                        user=User,
                         bucket=Bucket,
                         requested_perm='READ_ACP',
                         riakc_pid=RiakPid}) ->
+    dt_entry(<<"to_xml">>, [], [extract_name(User), Bucket]),
     case riak_moss_acl:bucket_acl(Bucket, RiakPid) of
         {ok, Acl} ->
             X = {riak_moss_acl_utils:acl_to_xml(Acl), RD, Ctx},
             ok = riak_cs_stats:update_with_start(bucket_get_acl, StartTime),
+            dt_return(<<"to_xml">>, [200], [extract_name(User), Bucket]),
             X;
         {error, Reason} ->
-            riak_moss_s3_response:api_error(Reason, RD, Ctx)
+            Code = riak_moss_s3_response:status_code(Reason),
+            X = riak_moss_s3_response:api_error(Reason, RD, Ctx),
+            dt_return(<<"to_xml">>, [Code], [extract_name(User), Bucket]),
+            X
     end.
 
 %% @doc Process request body on `PUT' request.
@@ -204,6 +238,7 @@ accept_body(RD, Ctx=#context{user=User,
                              bucket=Bucket,
                              requested_perm='WRITE_ACP',
                              riakc_pid=RiakPid}) ->
+    dt_entry(<<"accept_body">>, [], [extract_name(User), Bucket]),
     Body = binary_to_list(wrq:req_body(RD)),
     case Body of
         [] ->
@@ -227,14 +262,18 @@ accept_body(RD, Ctx=#context{user=User,
                                         ACL,
                                         RiakPid) of
         ok ->
+            dt_return(<<"accept_body">>, [200, size(Body)], [extract_name(User)]),
             {{halt, 200}, RD, Ctx};
         {error, Reason} ->
+            Code = riak_moss_s3_response:status_code(Reason),
+            dt_return(<<"accept_body">>, [Code], [extract_name(User)]),
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
     end;
 accept_body(RD, Ctx=#context{user=User,
                              user_vclock=VClock,
                              bucket=Bucket,
                              riakc_pid=RiakPid}) ->
+    dt_entry(<<"accept_body">>, [], [extract_name(User), Bucket]),
     %% Check for `x-amz-acl' header to support
     %% non-default ACL at bucket creation time.
     ACL = riak_moss_acl_utils:canned_acl(
@@ -250,8 +289,11 @@ accept_body(RD, Ctx=#context{user=User,
                                        ACL,
                                        RiakPid) of
         ok ->
+            dt_return(<<"accept_body">>, [200], [extract_name(User), Bucket]),
             {{halt, 200}, RD, Ctx};
         {error, Reason} ->
+            Code = riak_moss_s3_response:status_code(Reason),
+            dt_return(<<"accept_body">>, [Code], [extract_name(User)]),
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
     end.
 
@@ -261,18 +303,44 @@ delete_resource(RD, Ctx=#context{user=User,
                                  user_vclock=VClock,
                                  bucket=Bucket,
                                  riakc_pid=RiakPid}) ->
+    dt_entry(<<"delete_resource">>, [], [extract_name(User), Bucket]),
     case riak_moss_utils:delete_bucket(User,
                                        VClock,
                                        Bucket,
                                        RiakPid) of
         ok ->
+            dt_return(<<"delete_resource">>, [200], [extract_name(User), Bucket]),
             {true, RD, Ctx};
         {error, Reason} ->
+            Code = riak_moss_s3_response:status_code(Reason),
+            dt_return(<<"delete_resource">>, [Code], [extract_name(User), Bucket]),
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
     end.
 
 finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
+    dt_entry(<<"finish_request">>, [0], []),
     {true, RD, Ctx};
 finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    dt_entry(<<"finish_request">>, [1], []),
     riak_moss_utils:close_riak_connection(RiakPid),
+    dt_return(<<"finish_request">>, [1], []),
     {true, RD, Ctx#context{riakc_pid=undefined}}.
+
+extract_name(User) when is_list(User) ->
+    User;
+extract_name(?MOSS_USER{name=Name}) ->
+    Name;
+extract_name(_) ->
+    "-unknown-".
+
+dt_entry(Func) ->
+    dt_entry(Func, [], []).
+
+dt_entry(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
+
+dt_return(Func) ->
+    dt_return(Func, [], []).
+
+dt_return(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -262,7 +262,7 @@ accept_body(RD, Ctx=#context{user=User,
                                         ACL,
                                         RiakPid) of
         ok ->
-            dt_return(<<"accept_body">>, [200, size(Body)], [extract_name(User)]),
+            dt_return(<<"accept_body">>, [200], [extract_name(User)]),
             {{halt, 200}, RD, Ctx};
         {error, Reason} ->
             Code = riak_moss_s3_response:status_code(Reason),

--- a/src/riak_moss_wm_error_handler.erl
+++ b/src/riak_moss_wm_error_handler.erl
@@ -6,7 +6,10 @@
 -module(riak_moss_wm_error_handler).
 -export([render_error/3]).
 
+-include("riak_moss.hrl").
+
 render_error(500, Req, Reason) ->
+    dt_entry(<<"render_error">>),
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
     {Path,_} = Req:path(),
     error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, Reason]),
@@ -16,4 +19,9 @@ render_error(500, Req, Reason) ->
     ErrorIOList = [ErrorStart,STString,ErrorEnd],
     {erlang:iolist_to_binary(ErrorIOList), ReqState};
 render_error(_Code, Req, _Reason) ->
+    dt_entry(<<"render_error">>),
     Req:response_body().
+
+dt_entry(Name) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, [], ?MODULE, Name, []).
+    

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -458,8 +458,5 @@ dt_entry(Func) ->
 dt_entry(Func, Ints, Strings) ->
     riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
 
-%% dt_return(Func) ->
-%%     dt_return(Func, [], []).
-
 dt_return(Func, Ints, Strings) ->
     riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).

--- a/src/riak_moss_wm_rewrite.erl
+++ b/src/riak_moss_wm_rewrite.erl
@@ -6,9 +6,13 @@
 -module(riak_moss_wm_rewrite).
 -export([rewrite/2]).
 
+-include("riak_moss.hrl").
+
 bucket_from_host(undefined) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, [], ?MODULE, <<"bucket_from_host">>, []),
     undefined;
 bucket_from_host(HostHeader) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, [], ?MODULE, <<"bucket_from_host">>, []),
     HostNoPort = hd(string:tokens(HostHeader, ":")),
     {ok, RootHost} = application:get_env(riak_moss, moss_root_host),
     case HostNoPort of
@@ -24,6 +28,7 @@ bucket_from_host(HostHeader) ->
     end.
 
 rewrite(Headers, Path) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, [], ?MODULE, <<"bucket_from_host">>, []),
     HostHeader = mochiweb_headers:get_value("host", Headers),
     case bucket_from_host(HostHeader) of
         undefined ->

--- a/src/riak_moss_wm_service.erl
+++ b/src/riak_moss_wm_service.erl
@@ -19,6 +19,7 @@
 -include_lib("webmachine/include/webmachine.hrl").
 
 init(Config) ->
+    dt_entry(<<"init">>),
     %% Check if authentication is disabled and
     %% set that in the context.
     AuthBypass = proplists:get_value(auth_bypass, Config),
@@ -26,10 +27,12 @@ init(Config) ->
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
+    dt_entry(<<"service_available">>),
     riak_moss_wm_utils:service_available(RD, Ctx).
 
 -spec malformed_request(term(), term()) -> {false, term(), term()}.
 malformed_request(RD, Ctx) ->
+    dt_entry(<<"malformed_request">>),
     {false, RD, Ctx}.
 
 %% @doc Check to see if the user is
@@ -38,6 +41,7 @@ malformed_request(RD, Ctx) ->
 %%      but this is how S3 does things.
 forbidden(RD, Ctx=#context{auth_bypass=AuthBypass,
                            riakc_pid=RiakPid}) ->
+    dt_entry(<<"forbidden">>),
     AuthHeader = wrq:get_req_header("authorization", RD),
     {AuthMod, KeyId, Signature} =
         riak_moss_wm_utils:parse_auth_header(AuthHeader, AuthBypass),
@@ -47,26 +51,33 @@ forbidden(RD, Ctx=#context{auth_bypass=AuthBypass,
                 ok ->
                     %% Authentication succeeded
                     AccessRD = riak_moss_access_logger:set_user(User, RD),
+                    dt_return(<<"forbidden">>, [], [extract_name(User), <<"false">>]),
                     {false, AccessRD, Ctx#context{user=User}};
                 {error, _Reason} ->
                     %% Authentication failed, deny access
+                    dt_return(<<"forbidden">>, [403], [extract_name(User), <<"true">>]),
                     riak_moss_s3_response:api_error(access_denied, RD, Ctx)
             end;
         {error, no_user_key} ->
             %% Anonymous access not allowed, deny access
+            dt_return(<<"forbidden">>, [403], [extract_name(KeyId), <<"true">>]),
             riak_moss_s3_response:api_error(access_denied, RD, Ctx);
         {error, notfound} ->
             %% Access not allowed, deny access
+            dt_return(<<"forbidden">>, [403], [extract_name(KeyId), <<"true">>]),
             riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx);
         {error, Reason} ->
             %% Access not allowed, deny access and log the reason
             _ = lager:error("Retrieval of user record for ~p failed. Reason: ~p", [KeyId, Reason]),
+            Code = riak_moss_s3_response:status_code(Reason),
+            dt_return(<<"forbidden">>, [Code], [extract_name(KeyId), <<"true">>]),
             riak_moss_s3_response:api_error(invalid_access_key_id, RD, Ctx)
     end.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
 allowed_methods(RD, Ctx) ->
+    dt_entry(<<"allowed_methods">>),
     %% TODO:
     %% The docs seem to suggest GET is the only
     %% allowed method. It's worth checking to see
@@ -76,6 +87,7 @@ allowed_methods(RD, Ctx) ->
 -spec content_types_provided(term(), term()) ->
     {[{string(), atom()}], term(), term()}.
 content_types_provided(RD, Ctx) ->
+    dt_entry(<<"content_types_provided">>),
     %% TODO:
     %% This needs to be xml soon, but for now
     %% let's do json.
@@ -89,12 +101,29 @@ content_types_provided(RD, Ctx) ->
 -spec to_xml(term(), term()) ->
     {{'halt', term()}, term(), #context{}}.
 to_xml(RD, Ctx=#context{start_time=StartTime,user=User}) ->
+    dt_entry(<<"to_xml">>),
     Res = riak_moss_s3_response:list_all_my_buckets_response(User, RD, Ctx),
     ok = riak_cs_stats:update_with_start(service_get_buckets, StartTime),
+    dt_entry(<<"to_xml">>, [], [extract_name(User), <<"service_get_buckets">>]),
     Res.
 
 finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
+    dt_entry(<<"finish_request">>, [0], []),
     {true, RD, Ctx};
 finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
+    dt_entry(<<"finish_request">>, [1], []),
     riak_moss_utils:close_riak_connection(RiakPid),
+    dt_return(<<"finish_request">>, [1], []),
     {true, RD, Ctx#context{riakc_pid=undefined}}.
+
+extract_name(X) ->
+    riak_moss_wm_utils:extract_name(X).
+
+dt_entry(Func) ->
+    dt_entry(Func, [], []).
+
+dt_entry(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
+
+dt_return(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).

--- a/src/riak_moss_wm_service.erl
+++ b/src/riak_moss_wm_service.erl
@@ -102,9 +102,11 @@ content_types_provided(RD, Ctx) ->
     {{'halt', term()}, term(), #context{}}.
 to_xml(RD, Ctx=#context{start_time=StartTime,user=User}) ->
     dt_entry(<<"to_xml">>),
+    dt_entry_service(<<"to_xml">>),
     Res = riak_moss_s3_response:list_all_my_buckets_response(User, RD, Ctx),
     ok = riak_cs_stats:update_with_start(service_get_buckets, StartTime),
-    dt_entry(<<"to_xml">>, [], [extract_name(User), <<"service_get_buckets">>]),
+    dt_return(<<"to_xml">>, [], [extract_name(User), <<"service_get_buckets">>]),
+    dt_return_service(<<"service_get_buckets">>, [], [extract_name(User)]),
     Res.
 
 finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
@@ -125,5 +127,14 @@ dt_entry(Func) ->
 dt_entry(Func, Ints, Strings) ->
     riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
 
+dt_entry_service(Func) ->
+    dt_entry_service(Func, [], []).
+
+dt_entry_service(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_SERVICE_OP, 1, Ints, ?MODULE, Func, Strings).
+
 dt_return(Func, Ints, Strings) ->
     riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).
+
+dt_return_service(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_SERVICE_OP, 2, Ints, ?MODULE, Func, Strings).

--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -15,14 +15,17 @@
 -include_lib("webmachine/include/webmachine.hrl").
 
 init(_Config) ->
+    dt_entry(<<"init">>),
     {ok, #context{}}.
 
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
+    dt_entry(<<"service_available">>),
     {true, RD, Ctx}.
 
 -spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
 allowed_methods(RD, Ctx) ->
+    dt_entry(<<"allowed_methods">>),
     {['POST'], RD, Ctx}.
 
 
@@ -31,6 +34,7 @@ allowed_methods(RD, Ctx) ->
 %%      as JSON
 -spec process_post(term(), term()) -> {true, term(), term}.
 process_post(RD, Ctx) ->
+    dt_entry(<<"process_post">>),
     Body = wrq:req_body(RD),
     ParsedBody = mochiweb_util:parse_qs(binary_to_list(Body)),
     UserName = proplists:get_value("name", ParsedBody, ""),
@@ -42,7 +46,19 @@ process_post(RD, Ctx) ->
             WrittenRD = wrq:set_resp_body(list_to_binary(
                                             mochijson2:encode(PropListUser)),
                                           CTypeWritten),
+            dt_return(<<"process_post">>, [200], [UserName]),
             {true, WrittenRD, Ctx};
         {error, Reason} ->
+            Code = riak_moss_s3_response:status_code(Reason),
+            dt_return(<<"process_post">>, [Code], [UserName]),
             riak_moss_s3_response:api_error(Reason, RD, Ctx)
     end.
+
+dt_entry(Func) ->
+    dt_entry(Func, [], []).
+
+dt_entry(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
+
+dt_return(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -17,7 +17,8 @@
          user_record_to_proplist/1,
          find_and_auth_user/3,
          validate_auth_header/3,
-         deny_access/2]).
+         deny_access/2,
+         extract_name/1]).
 
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
@@ -227,6 +228,13 @@ iso_8601_to_rfc_1123(Date) when is_binary(Date) ->
       _/binary>> = Date,
     httpd_util:rfc1123_date({{b2i(Yr), b2i(Mo), b2i(Da)},
                              {b2i(Hr), b2i(Mn), b2i(Sc)}}).
+
+extract_name(User) when is_list(User) ->
+    User;
+extract_name(?MOSS_USER{name=Name}) ->
+    Name;
+extract_name(_) ->
+    "-unknown-".
 
 %% ===================================================================
 %% Internal functions

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -13,7 +13,7 @@
          to_iso_8601/1,
          iso_8601_to_rfc_1123/1,
          to_rfc_1123/1,
-         streaming_get/2,
+         streaming_get/4,
          user_record_to_proplist/1,
          find_and_auth_user/3,
          validate_auth_header/3,
@@ -154,13 +154,15 @@ ensure_doc(Ctx=#key_context{get_fsm_pid=undefined,
     Ctx#key_context{get_fsm_pid=Pid, manifest=Manifest};
 ensure_doc(Ctx) -> Ctx.
 
-streaming_get(FsmPid, StartTime) ->
+streaming_get(FsmPid, StartTime, UserName, BFile_str) ->
     case riak_moss_get_fsm:get_next_chunk(FsmPid) of
         {done, Chunk} ->
             ok = riak_cs_stats:update_with_start(object_get, StartTime),
+            riak_moss_wm_key:dt_return_object(<<"file_get">>, [],
+                                              [UserName, BFile_str]),
             {Chunk, done};
         {chunk, Chunk} ->
-            {Chunk, fun() -> streaming_get(FsmPid, StartTime) end}
+            {Chunk, fun() -> streaming_get(FsmPid, StartTime, UserName, BFile_str) end}
     end.
 
 %% @doc Convert a moss_user record


### PR DESCRIPTION
Add USDT DTrace probes to RiakCS.

```
%% The convention that we'll use of these probes is:
%%   param  D arg name  use
%%   -----  ----------  ---
%%   --     arg0         Erlang PID
%%   --     arg1         PID's user-defined tag (if any)
%%   i1     arg2        Application category (see below)
%%   i2     arg3        1 = function entry, 2 = function return
%%                      NOTE! Not all function entry probes have a return probe
%%   i3-i4  arg4-arg5   Varies, zero usually means unused (but not always!)
%%   s1     arg6        Module name
%%   s2     arg7        Function name
%%   s3-4   arg8-arg9   Varies, NULL means unused
```

Here's an example, using R14B04:
For example, running a D script such as this (as the superuser):

```
dtrace -qn 'erlang*:::user_trace* /arg2 == 703/ {printf("pid %s: mod %s op %s: user %s bucket/file %s\n", copyinstr(arg0), copyinstr(arg6), copyinstr(arg7), copyinstr(arg8), copyinstr(arg9));}'
```

... yields this output when using `s3cmd get s3://decision/foo`:

```
pid <0.790.0>: mod riak_moss_wm_key op file_get: user foo bar bucket/file decision,foo
pid <0.790.0>: mod riak_moss_wm_key op file_get: user foo bar bucket/file decision,foo
```
