### PR TITLE
Separate connection pool for bucket listings

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -17,9 +17,14 @@
               {moss_root_host, "s3.amazonaws.com"},
               {put_fsm_buffer_size_max, 10485760},
 
-              %% Connection pool
-              %% {FixedSize, OverflowSize}
-              {riakc_pool, {{riakc_pool_tuple}} },
+              %% Connection pools
+              %% Each pool is specified as a nested
+              %% tuple of {Name, {FixedSize, OverflowSize}}
+              {connection_pools,
+               [
+                {request_pool, {{request_pool_tuple}} },
+                {bucket_list_pool, {{bucket_list_pool_tuple}} }
+               ]},
 
               %% Admin user credentials
               {admin_key, "{{admin_key}}"},
@@ -32,12 +37,12 @@
               {stanchion_ssl, {{stanchion_ssl}} },
 
               %% == Usage recording ==
-              
+
               %% How often to flush the access log; integer factor of
               %% access_archive_period (1 == once per period; 2 ==
               %% twice per period, etc.)
               {access_log_flush_factor, 1},
-              
+
               %% Additional access log flush trigger - flush after
               %% this many accesses are recorded, even if the flush
               %% interval has not expired; integer number of accesses

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -21,7 +21,8 @@
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
 {stanchion_ssl,     false}.
-{riakc_pool_tuple, "{128, 0}"}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev_vars.config
+++ b/rel/vars/dev_vars.config
@@ -19,6 +19,8 @@
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
 {stanchion_ssl,     true}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
 
 %%
 %% etc/vm.args

--- a/src/riak_moss_wm_bucket.erl
+++ b/src/riak_moss_wm_bucket.erl
@@ -21,6 +21,7 @@
 -include("riak_moss.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
+-define(RIAKCPOOL, bucket_list_pool).
 
 init(Config) ->
     dt_entry(<<"init">>),
@@ -32,7 +33,7 @@ init(Config) ->
 -spec service_available(term(), term()) -> {true, term(), term()}.
 service_available(RD, Ctx) ->
     dt_entry(<<"service_available">>),
-    Res = riak_moss_wm_utils:service_available(RD, Ctx),
+    Res = riak_moss_wm_utils:service_available(?RIAKCPOOL, RD, Ctx),
     dt_return(<<"service_available">>),
     Res.
 
@@ -339,7 +340,7 @@ finish_request(RD, Ctx=#context{riakc_pid=undefined}) ->
     {true, RD, Ctx};
 finish_request(RD, Ctx=#context{riakc_pid=RiakPid}) ->
     dt_entry(<<"finish_request">>, [1], []),
-    riak_moss_utils:close_riak_connection(RiakPid),
+    riak_moss_utils:close_riak_connection(?RIAKCPOOL, RiakPid),
     dt_return(<<"finish_request">>, [1], []),
     {true, RD, Ctx#context{riakc_pid=undefined}}.
 


### PR DESCRIPTION
- Add an independent connection pool only for bucket listings and limit it by default to 5.
- Update `riak_moss_wm_bucket` to use this new pool.
- Add functions so that a pool may be specified when requesting a connection or returning one to a pool.
- Update supervisor to create specifications for any connection pool specified in the application environment.
