### PR TITLE
Check for timeout when calling poolboy:checkout

### DIFF
--- a/src/riak_moss_riakc_pool_worker.erl
+++ b/src/riak_moss_riakc_pool_worker.erl
@@ -29,7 +29,7 @@ riak_host_port() ->
 
 start_link(_Args) ->
     {Host, Port} = riak_host_port(),
-    riakc_pb_socket:start_link(Host, Port).
+    riakc_pb_socket:start_link(Host, Port, [{connect_timeout, 10000}]).
 
 stop(Worker) ->
     riakc_pb_socket:stop(Worker).

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -471,9 +471,11 @@ riak_connection() ->
 %% from the specified connection pool.
 -spec riak_connection(atom()) -> {ok, pid()} | {error, term()}.
 riak_connection(Pool) ->
-    case poolboy:checkout(Pool, false) of
+    case catch poolboy:checkout(Pool, false) of
         full ->
             {error, all_workers_busy};
+        {'EXIT', _Error} ->
+            {error, poolboy_error};
         Worker ->
             {ok, Worker}
     end.


### PR DESCRIPTION
If Riak is responding very slowly then the synchronous call `poolboy:checkout` can time out. Poolboy calls `gen_fsm:sync_send_state` with a 5 second timeout and our pool worker function calls `riakc_pb_socket:start_link` with the default timeout of infinity. Check for such a timeout in riak_moss_utils:riak_connection` so the condition can be handled gracefully.

Add a catch in `riak_moss_utils:riak_connection/1` to handle cases where the call to `poolboy:checkout/2` times out or otherwise throws an error. The error is handled gracefully and an error code is returned to the client that indicates the request should be retried, but that the request rate is too high.
