### PR TITLE
Add ping resource for Riak CS.

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -225,7 +225,7 @@
 %% to determine the PUT buffer size.
 %% ex. 2 would mean BlockSize * 2
 -define(DEFAULT_PUT_BUFFER_FACTOR, 1).
-
+-define(DEFAULT_PING_TIMEOUT, 5000).
 -define(JSON_TYPE, "application/json").
 -define(XML_TYPE, "application/xml").
 

--- a/src/riak_cs_wm_ping.erl
+++ b/src/riak_cs_wm_ping.erl
@@ -1,0 +1,105 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_cs_wm_ping).
+
+-export([init/1,
+         service_available/2,
+         allowed_methods/2,
+         to_html/2,
+         finish_request/2]).
+
+-include("riak_moss.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-record(ping_context, {pool_pid=true :: boolean(),
+                  riakc_pid :: pid()}).
+
+%% -------------------------------------------------------------------
+%% Webmachine callbacks
+%% -------------------------------------------------------------------
+
+init(_Config) ->
+    dt_entry(<<"init">>),
+    {ok, #ping_context{}}.
+
+-spec service_available(term(), term()) -> {true, term(), term()}.
+service_available(RD, Ctx) ->
+    dt_entry(<<"service_available">>),
+    case poolboy:checkout(request_pool, true, ping_timeout()) of
+        full ->
+            case riak_moss_riakc_pool_worker:start_link([]) of
+                {ok, Pid} ->
+                    UpdCtx = Ctx#ping_context{riakc_pid=Pid,
+                                         pool_pid=false};
+                {error, _} ->
+                    Pid = undefined,
+                    UpdCtx = Ctx
+            end;
+        Pid ->
+            UpdCtx = Ctx#ping_context{riakc_pid=Pid}
+    end,
+    case Pid of
+        undefined ->
+            Available = false;
+        _ ->
+            case riakc_pb_socket:ping(Pid, ping_timeout()) of
+                pong ->
+                    Available = true;
+                 _ ->
+                    Available = false
+            end
+    end,
+    {Available, RD, UpdCtx}.
+
+-spec allowed_methods(term(), term()) -> {[atom()], term(), term()}.
+allowed_methods(RD, Ctx) ->
+    dt_entry(<<"allowed_methods">>),
+    {['GET', 'HEAD'], RD, Ctx}.
+
+to_html(ReqData, Ctx) ->
+    {"OK", ReqData, Ctx}.
+
+finish_request(RD, Ctx=#ping_context{riakc_pid=undefined}) ->
+    dt_entry(<<"finish_request">>, [0], []),
+    {true, RD, Ctx};
+finish_request(RD, Ctx=#ping_context{riakc_pid=RiakPid,
+                                pool_pid=PoolPid}) ->
+    dt_entry(<<"finish_request">>, [1], []),
+    case PoolPid of
+        true ->
+            riak_moss_utils:close_riak_connection(RiakPid);
+        false ->
+            riak_moss_riakc_pool_worker:stop(RiakPid)
+    end,
+    dt_return(<<"finish_request">>, [1], []),
+    {true, RD, Ctx#ping_context{riakc_pid=undefined}}.
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+dt_entry(Func) ->
+    dt_entry(Func, [], []).
+
+dt_entry(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 1, Ints, ?MODULE, Func, Strings).
+
+dt_return(Func, Ints, Strings) ->
+    riak_cs_dtrace:dtrace(?DT_WM_OP, 2, Ints, ?MODULE, Func, Strings).
+
+%% @doc Return the configured ping timeout. Default is 5 seconds.  The
+%% timeout is used in call to `poolboy:checkout' and if that fails in
+%% the call to `riakc_pb_socket:ping' so the effective cumulative
+%% timeout could be up to 2 * `ping_timeout()'.
+-spec ping_timeout() -> pos_integer().
+ping_timeout() ->
+    case application:get_env(riak_moss, ping_timeout) of
+        undefined ->
+            ?DEFAULT_PING_TIMEOUT;
+        {ok, Timeout} ->
+            Timeout
+    end.

--- a/src/riak_moss_web.erl
+++ b/src/riak_moss_web.erl
@@ -22,6 +22,7 @@ dispatch_table() ->
     [
      {[], riak_moss_wm_service, [{auth_bypass, AuthBypass}]},
      {["riak-cs", "stats"], riak_cs_wm_stats, StatsProps},
+     {["riak-cs", "ping"], riak_cs_wm_ping, []},
      {["user"], riak_moss_wm_user, []},
      {["riak-cs", "users"], riak_moss_wm_users, [{auth_bypass, AuthBypass}]},
      {["riak-cs", "user", '*'], riak_moss_wm_user, [{auth_bypass, AuthBypass}]},


### PR DESCRIPTION
Add a webmachine resource for health checks of Riak CS. The resource determines success of the ping request by attempting to acquire a Riak protocol buffers connection and then calling the `riakc_pb_socket:ping/2` function via that connection. If the Riak ping is successful a `200` is returned with 'OK' as the response body; otherwise, a `503` error response code is returned.

The resource first attempts to obtain a connection from the normal request pool and if that request times out then a new connection to Riak is tried outside of the connection pool. Failure to make that connection results in an error response from the ping request. The reason for the two step process is to balance between having the result of the ping be meaningful (_i.e._ A failure really does indicate something is wrong) and being wise with system resource usage in the face of many concurrent or frequent ping requests (_e.g._ Exhausting all available sockets on a machine.).

The resource resides at `/riak-cs/ping` and can be tested on a local setup using curl as follows:

```
curl localhost:8080/riak-cs/ping -v
```
