### PR TITLE
key_context record referenced in dt_return call in riak_moss_wm_user

### DIFF
--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -53,7 +53,7 @@ forbidden(RD, Ctx) ->
                    end,
             case riak_moss_wm_utils:find_and_auth_user(RD, Ctx, Next) of
                 {false, _RD2, Ctx2} = FalseRet ->
-                    dt_return(<<"forbidden">>, [], [extract_name((Ctx2#key_context.context)#context.user), <<"false">>]),
+                    dt_return(<<"forbidden">>, [], [extract_name(Ctx2#context.user), <<"false">>]),
                     FalseRet;
                 {Rsn, _RD2, Ctx2} = Ret ->
                     Reason = case Rsn of


### PR DESCRIPTION
Remove an inappropriate reference to the `key_context` record in forbidden function in the `riak_moss_wm_user` module.
