### PR TITLE
Support user-specified metadata headers

### DIFF
--- a/src/riak_moss_s3_auth.erl
+++ b/src/riak_moss_s3_auth.erl
@@ -142,7 +142,8 @@ extract_amazon_headers(Headers) ->
         fun({K, V}, Acc) ->
                 case lists:prefix("x-amz-", K) of
                     true ->
-                        [[K, ":", V, "\n"] | Acc];
+                        V2 = unicode:characters_to_binary(V, utf8),
+                        [[K, ":", V2, "\n"] | Acc];
                     false ->
                         Acc
                 end

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -240,7 +240,7 @@ produce_body(RD, #key_context{get_fsm_pid=GetFsmPid, manifest=Mfst,
                         RD,
                         [{"ETag",  ETag},
                          {"Last-Modified", LastModified}
-                        ]),
+                        ] ++  Mfst#lfs_manifest_v2.metadata),
     Method = wrq:method(RD),
     case Method == 'HEAD'
         orelse
@@ -386,11 +386,7 @@ accept_body(RD, Ctx=#key_context{bucket=Bucket,
     dt_entry(<<"accept_body">>, [], [UserName, BFile_str]),
     dt_entry_object(<<"file_put">>, [], [UserName, BFile_str]),
     riak_moss_get_fsm:stop(GetFsmPid),
-    %% TODO:
-    %% the Metadata
-    %% should be pulled out of the
-    %% headers
-    Metadata = orddict:new(),
+    Metadata = riak_moss_wm_utils:extract_user_metadata(RD),
     BlockSize = riak_moss_lfs_utils:block_size(),
     %% Check for `x-amz-acl' header to support
     %% non-default ACL at bucket creation time.

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -286,6 +286,8 @@ extract_amazon_headers(Headers) ->
         fun({K, V}, Acc) ->
                 case lists:prefix("x-amz-", K) of
                     true ->
+                        %% HTTP headers aren't supposed to support
+                        %% anything but US-ASCII, but AWS does :(
                         V2 = unicode:characters_to_binary(V, utf8),
                         [[K, ":", V2, "\n"] | Acc];
                     false ->
@@ -316,6 +318,8 @@ extract_metadata(Headers) ->
         fun({K, V}, Acc) ->
                 case lists:prefix("x-amz-meta-", K) of
                     true ->
+                        %% HTTP headers aren't supposed to support
+                        %% anything but US-ASCII, but AWS does :(
                         V2 = unicode:characters_to_list(V, utf8),
                         [{K, V2} | Acc];
                     false ->


### PR DESCRIPTION
Allow users to associate arbitrary metadata headers with objects using `x-amz-meta-` headers.

I cherry-picked Marcel's original commit and made a few changes and did some refactoring to reduce code duplication.

The original branch Marcel created is [here](https://github.com/basho/riak_moss/tree/user-metadata-handling). 
## Testing

Headers can be specified with `s3cmd` using the `--add-header=NAME:VALUE` option. 

_e.g._ `--add-header=x-amz-meta-cheese=feta` 

Using the `-d` option when fetching a file dumps the headers so the presence of the metadata can be verified.
