### PR TITLE
Expand User API to be able to disable a user

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -12,7 +12,18 @@
           key_secret :: string(),
           canonical_id :: string(),
           buckets=[] :: [moss_bucket()]}).
--type moss_user() :: #moss_user_v1{}.
+
+-record(rcs_user_v2, {
+          name :: string(),
+          display_name :: string(),
+          email :: string(),
+          key_id :: string(),
+          key_secret :: string(),
+          canonical_id :: string(),
+          buckets=[] :: [moss_bucket()],
+          status=enabled :: enabled | disabled}).
+-type moss_user() :: #rcs_user_v2{} | #moss_user_v1{}.
+-type rcs_user() :: #rcs_user_v2{} | #moss_user_v1{}.
 
 -record(moss_bucket, {
           name :: string(),
@@ -189,7 +200,8 @@
 
 -define(ACL, #acl_v2).
 -define(MOSS_BUCKET, #moss_bucket_v1).
--define(MOSS_USER, #moss_user_v1).
+-define(MOSS_USER, #rcs_user_v2).
+-define(RCS_USER, #rcs_user_v2).
 -define(USER_BUCKET, <<"moss.users">>).
 -define(ACCESS_BUCKET, <<"moss.access">>).
 -define(STORAGE_BUCKET, <<"moss.storage">>).

--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -33,6 +33,8 @@ error_message(user_already_exists) ->
     "The specified email address has already been registered. Email addresses must be unique among all users of the system. Please try again with a different email address.";
 error_message(entity_too_large) ->
     "Your proposed upload exceeds the maximum allowed object size.";
+error_message(invalid_user_update) ->
+    "The user update you request was invalid.";
 error_message(no_such_bucket) ->
     "The specified bucket does not exist.";
 error_message({riak_connect_failed, Reason}) ->
@@ -49,6 +51,7 @@ error_code(bucket_not_empty) -> "BucketNotEmpty";
 error_code(bucket_already_exists) -> "BucketAlreadyExists";
 error_code(user_already_exists) -> "UserAlreadyExists";
 error_code(entity_too_large) -> "EntityTooLarge";
+error_code(invalid_user_update) -> "InvalidUserUpdate";
 error_code(no_such_bucket) -> "NoSuchBucket";
 error_code({riak_connect_failed, _}) -> "RiakConnectFailed";
 error_code(admin_key_undefined) -> "ServiceUnavailable";
@@ -64,6 +67,7 @@ status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;
 status_code(user_already_exists) -> 409;
 status_code(entity_too_large) -> 400;
+status_code(invalid_user_update) -> 400;
 status_code(no_such_bucket) -> 404;
 status_code({riak_connect_failed, _}) -> 503;
 status_code(admin_key_undefined) -> 503;


### PR DESCRIPTION
Update `riak-cs` and `stanchion` to allow users to be disabled.

With this change a user may use a `PUT` to `/riak-cs/user` to disabled their account. The put must include a document indicating a status of _disabled_. JSON or XML formats are supported for this document. Samples of each are shown below. The `Content-Type` header should also be set appropriately. The admin user may also disable or reenable a user's account via a `PUT` to `/riak-cs/user/<user-key-id>`. Users may not reenable their own account once it is disabled.
### Sample JSON status update document

```
{
  "status" : "enabled"
}
```

The `users` resource for admin users to list all users has also been updated to list only enabled accounts by default. Disabled account can be included in the results by using a query parameter of `?disabled=yes` or `?disabled=true`. 
### Sample XML status update document

```
<?xml version="1.0" encoding="UTF-8"?>
<UserUpdate>
  <Status>disabled</Status>
</UserUpdate>
```

**NOTE:** This change also includes [this stanchion pr](https://github.com/basho/stanchion/pull/15). The two should be reviewed and tested together.
### Testing

I suggest creating three user account and setting up one as admin. Save update documents as `user.json` and `user.xml` respectively. Set up a _.s3curl_ file with the credentials for the three users. Create a bucket and place some objects in it with one of the non-admin users. Then disable the user. An example of doing this with s3curl is as follows:
`s3curl --id cs --put=user.json --contentType=application/json -- -v --proxy1.0 "localhost:8080" http://s3.amazonaws.com/riak-cs/user`

At this point access to the bucket and objects in that bucket should be disallowed for the user. The next step is to reenable the user using the admin account.
`s3curl --id admin --put=user.json --contentType=application/json -- -v --proxy1.0 "localhost:8080" http://s3.amazonaws.com/riak-cs/user/NO-YQPYEKKUN-KJNPIGO`

Next disable the non-admin user account again and list all users and verify that the disabled user does not show up.
`s3curl --id admin -- --proxy1.0 "localhost:8080" -v http://s3.amazonaws.com/riak-cs/users`

Then use the `disabled` query parameter to display the user accounts including the disabled user.
`s3curl --id admin -- --proxy1.0 "localhost:8080" -v http://s3.amazonaws.com/riak-cs/users?disabled=true`

Next reenable the user and use ACL manipulation to grant access to the some buckets or objects to the third and so far unused user account. Verify the third user can appropriately access said buckets or objects and then disable the user that owns them. The third user should now also be denied access to the disabled user's buckets and objects.
