### PR TITLE
Expand User API to be able to issue new credentials to a user

### DIFF
--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -78,7 +78,11 @@ status_code(_) -> 503.
 
 
 respond(StatusCode, Body, ReqData, Ctx) ->
-    {{halt, StatusCode}, wrq:set_resp_body(Body, ReqData), Ctx}.
+     UpdReqData = wrq:set_resp_body(Body,
+                                    wrq:set_resp_header("Content-Type",
+                                                        ?XML_TYPE,
+                                                        ReqData)),
+    {{halt, StatusCode}, UpdReqData, Ctx}.
 
 api_error(Error, ReqData, Ctx) when is_atom(Error); is_tuple(Error) ->
     error_response(status_code(Error), error_code(Error), error_message(Error),


### PR DESCRIPTION
Changes to allow users to change generate a new `key_secret` for their account.  Return updated user document in the response body. Also allow admin users to generate a new `key_secret` for a specified user account.
## Testing

The `key_secret` for a user account can be reissued by a `PUT` to `/riak-cs/user` with the appropriate JSON or XML document. For admin users the `PUT` would be to `/riak-cs/user/<key-id>`. The documents should look as follows:

JSON

```
{"new_key_secret":true}
```

XML

```
<?xml version="1.0" encoding="UTF-8"?>
<UserUpdate>
  <NewKeySecret>true</NewKeySecret>
</UserUpdate>
```

**NOTE** The `new_key_secret` field may be combined with other user update fields in the same request. Currently, the only other supported field is `status`, but more may be added in the future. Unsupported fields are simply ignored.
