### PR TITLE
Add compatibility tests of Java S3 sdk, through Clojure

### DIFF
--- a/client_tests/clojure/clj-s3/.gitignore
+++ b/client_tests/clojure/clj-s3/.gitignore
@@ -1,0 +1,8 @@
+/pom.xml
+*jar
+/lib
+/classes
+/native
+/.lein-failures
+/checkouts
+/.lein-deps-sum

--- a/client_tests/clojure/clj-s3/README
+++ b/client_tests/clojure/clj-s3/README
@@ -1,0 +1,46 @@
+# clj-s3
+
+
+If you don't have a Clojure environment set up, follow these
+steps first.
+
+```shell
+# this will in Leiningen (often called lein), this Clojure build tool
+INSTALL_DIR=/usr/local/bin
+curl "https://raw.github.com/technomancy/leiningen/1.x/bin/lein" > $INSTALL_DIR/lein
+chmod +x $INSTALL_DIR/lein
+```
+
+To run the tests, run:
+
+```shell
+# if you've never run the tests before,
+# you'll need to run this command first
+lein deps
+
+# run the tests.
+# (midje is a testing
+# library for Clojure
+#
+# Riak CS should be running on http://localhost:8080 (note http
+# not https)
+#
+# # we can add support for configurable host/ports in the future
+# as needed
+lein midje
+```
+
+## About
+
+These tests are written using [Reid's fork](https://github.com/reiddraper/clj-aws-s3)
+of [clj-aws-s3](https://github.com/weavejester/clj-aws-s3). The fork adds things
+such as proxy configuration, needed to test Riak CS (instead of the real
+s3. You can see that, and the other dependencies in `project.clj`. There is
+code for creating Riak CS users in `src/java_s3_tests/user_creation.clj`.
+New tests cases are added to `test/java_s3_tests/test/client.clj`. The tests
+are written using the Clojure testing library [midje](https://github.com/marick/Midje),
+[which has great documentation](https://github.com/marick/Midje/wiki).
+
+## License
+
+Copyright (C) 2012 Basho Technologies

--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,0 +1,10 @@
+(defproject java-s3-tests "0.0.1-SNAPSHOT"
+  :description "integration tests for Riak CS using the offical Java SDK"
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [com.amazonaws/aws-java-sdk "1.3.11"]
+                 [com.reiddraper/clj-aws-s3 "0.4.0-SNAPSHOT"]
+                 [commons-codec/commons-codec "1.6"]
+                 [clj-http "0.4.3"]
+                 [cheshire "4.0.0"]]
+  :dev-dependencies [[midje "1.4.0"]
+                    [lein-midje "1.0.9"]])

--- a/client_tests/clojure/clj-s3/src/java_s3_tests/core.clj
+++ b/client_tests/clojure/clj-s3/src/java_s3_tests/core.clj
@@ -1,0 +1,1 @@
+(ns java-s3-tests.core)

--- a/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
+++ b/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
@@ -1,0 +1,43 @@
+(ns java-s3-tests.user-creation
+  (:require [cheshire.core :as cheshire])
+  (:require [clj-http.client :as http]))
+
+(defn ^:internal make-host-port-string [host port]
+  (str host ":" port))
+
+(defn ^:internal make-url-with-resource [host-port-string resource]
+  (str host-port-string "/" resource))
+
+(defn ^:internal make-body [user-name email]
+  (cheshire/generate-string
+    {"email" email "name" user-name}))
+
+(defn ^:internal make-user-url [host port]
+  (let [location (make-host-port-string host port)]
+    (make-url-with-resource location "user")))
+
+(defn ^:internal parse-response-body [string]
+  (let [data (cheshire/parse-string string true)]
+    (select-keys data [:key_id :key_secret])))
+
+(defn ^:internal parse-response [response]
+  (parse-response-body (:body response)))
+
+(defn ^:internal string-uuid []
+  (str (java.util.UUID/randomUUID)))
+
+(defn create-user
+  "create a new user from the /user
+  resource. Returns a map with keys
+  :key_id and :key_secret"
+  [host port user-name email]
+  (let [url (make-user-url host port)
+        body (make-body user-name email)
+        headers {"Content-Type" "application/json"}]
+    (parse-response (http/post url {:body body :headers headers}))))
+
+(defn create-random-user [host port]
+  (let [random-token (string-uuid)
+        user-name random-token
+        email (str random-token "@example.com")]
+    (create-user host port user-name email)))

--- a/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
+++ b/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
@@ -1,0 +1,101 @@
+(ns java-s3-tests.test.client
+  (:import java.security.MessageDigest
+           org.apache.commons.codec.binary.Hex
+           com.amazonaws.services.s3.model.AmazonS3Exception
+           com.amazonaws.services.s3.model.ObjectMetadata)
+  (:require [aws.sdk.s3 :as s3])
+  (:require [java-s3-tests.user-creation :as user-creation])
+  (:use midje.sweet))
+
+(def ^:internal riak-cs-host-with-protocol "http://localhost")
+(def ^:internal riak-cs-host "localhost")
+(def ^:internal riak-cs-port 8080)
+
+(defn md5-byte-array [input-byte-array]
+  (let [instance (MessageDigest/getInstance "MD5")]
+    (.digest instance input-byte-array)))
+
+(defn md5-string
+  [input-byte-array]
+  (let [b (md5-byte-array input-byte-array)]
+    (String. (Hex/encodeHex b))))
+
+(defn random-client
+  []
+  (let [new-creds (user-creation/create-random-user
+                    riak-cs-host-with-protocol
+                    riak-cs-port)]
+    (s3/client (:key_id new-creds)
+               (:key_secret new-creds)
+               {:proxy-host riak-cs-host
+                :proxy-port riak-cs-port
+                :protocol :http})))
+
+(defmacro with-random-client
+  "Execute `form` with a random-client
+  bound to `var-name`"
+  [var-name form]
+  `(let [~var-name (random-client)]
+     ~form))
+
+(defn random-string []
+  (str (java.util.UUID/randomUUID)))
+
+(fact "bogus creds raises an exception"
+      (let [bogus-client
+            (s3/client "foo"
+                       "bar"
+                       {:endpoint "http://localhost:8080"})]
+        (s3/list-buckets bogus-client))
+      => (throws AmazonS3Exception))
+
+(fact "new users have no buckets"
+        (with-random-client c
+          (s3/list-buckets c))
+        => [])
+
+(let [bucket-name (random-string)]
+  (fact "creating a bucket should list
+        one bucket in list buckets"
+        (with-random-client c
+          (do (s3/create-bucket c bucket-name)
+            ((comp :name first) (s3/list-buckets c))))
+        => bucket-name))
+
+(let [bucket-name (random-string)
+      object-name (random-string)]
+  (fact "simple put works"
+        (with-random-client c
+          (do (s3/create-bucket c bucket-name)
+            (s3/put-object c bucket-name object-name
+                           "contents")))
+        => truthy))
+
+(let [bucket-name (random-string)
+      object-name (random-string)
+      value "this is the value!"]
+  (fact "the value received during GET is the same
+        as the object that was PUT"
+        (with-random-client c
+          (do (s3/create-bucket c bucket-name)
+            (s3/put-object c bucket-name object-name
+                           value)
+            ((comp slurp :content) (s3/get-object c bucket-name object-name))))
+        => value))
+
+(let [bucket-name (random-string)
+      object-name (random-string)
+      value "this is the value!"
+      as-bytes (.getBytes value "UTF-8")
+      md5-sum (md5-string as-bytes)]
+  (fact "check that the etag of the response
+        is the same as the md5 of the original
+        object"
+        (with-random-client c
+          (do (s3/create-bucket c bucket-name)
+            (s3/put-object c bucket-name object-name
+                           value)
+            ((comp :etag :metadata)
+               (s3/get-object
+                 c bucket-name object-name))))
+        => md5-sum))

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 {deps, [
         {node_package, ".*", {git, "git://github.com/basho/node_package", {branch, "master"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "wrd-content-length-with-streaming"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.2.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},
         {sext, ".*", {git, "git://github.com/esl/sext", "master"}},


### PR DESCRIPTION
I've found Clojure to be a better Java, so it was easy
enough to write compatibility tests of the official
Java S3 SDK through a [clojure
wrapper](https://github.com/reiddraper/clj-aws-s3). The
README has details about getting Clojure set up and how to
run the tests. I've also written some macros to make adding
new test cases have a bit less boilerplate. Despite being
written in Clojure, the tests should exercise the Java SDK
as well as anything written in Java.
