### PR TITLE
Gh147 not-really-gc-related type fixes

### DIFF
--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -64,10 +64,11 @@ service_available(RD, Ctx) ->
 %%      but this is how S3 does things.
 forbidden(RD, #key_context{context=ICtx}=Ctx) ->
     dt_entry(<<"forbidden">>),
-    Next = fun(NewRD, NewCtx) ->
-                   get_access_and_manifest(NewRD, Ctx#key_context{context=NewCtx})
+    Next = fun(NewRD, NewICtx) ->
+                   get_access_and_manifest(NewRD, Ctx#key_context{context=NewICtx})
            end,
-    case riak_moss_wm_utils:find_and_auth_user(RD, ICtx, Next) of
+    Conv2KeyCtx = fun(NewICtx) -> Ctx#key_context{context=NewICtx} end,
+    case riak_moss_wm_utils:find_and_auth_user(RD, ICtx, Next, Conv2KeyCtx) of
         {false, _RD2, Ctx2} = FalseRet ->
             dt_return(<<"forbidden">>, [], [extract_name((Ctx2#key_context.context)#context.user), <<"false">>]),
             FalseRet;

--- a/src/riak_moss_wm_usage.erl
+++ b/src/riak_moss_wm_usage.erl
@@ -218,7 +218,8 @@ forbidden(RD, #ctx{auth_bypass=AuthBypass, riak=Riak}=Ctx) ->
     Next = fun(NewRD, #context{user=User}) ->
                    forbidden(NewRD, Ctx, User)
            end,
-    riak_moss_wm_utils:find_and_auth_user(RD, BogusContext, Next).
+    Conv2Ctx = fun(_) -> Ctx end,
+    riak_moss_wm_utils:find_and_auth_user(RD, BogusContext, Next, Conv2Ctx).
 
 forbidden(RD, Ctx, undefined) ->
     %% anonymous access disallowed


### PR DESCRIPTION
Here are fixes for a couple of type problems that I found while fiddling with Meck evil.  Both are the result of `finish_request()` callbacks being given the wrong context record type.  The result is a `function_clause` error, which then cascades to Poolboy with an error message like this to the console:

```
00:10:56.204 [error] Supervisor poolboy_sup had child riak_moss_riakc_pool_worker started with {riak_moss_riakc_pool_worker,start_link,undefined} at <0.223.0> exit with reason killed in context child_terminated
```
