### PR TITLE
Update required VSN to version with hmac_init.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R14B0[234]|R15"}.
+{require_otp_vsn, "R14B0[34]|R15"}.
 
 {cover_enabled, true}.
 


### PR DESCRIPTION
Update OTP VSN to R14B03 as a minimum, as it's the first release to support crypto:hmac_init.

@kellymclaughlin 
