### PR TITLE
Bucket listing incompatability between 1.0 and master

### DIFF
--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -100,6 +100,8 @@ list_all_my_buckets_response(User, RD, Ctx) ->
     BucketsDoc =
         [begin
              case is_binary(B?MOSS_BUCKET.name) of
+                 true ->
+                     Name = binary_to_list(B?MOSS_BUCKET.name);
                  false ->
                      Name = B?MOSS_BUCKET.name
              end,


### PR DESCRIPTION
Bucket names were stored as binaries in the bucket records in 1.0, but we have since changed them to be strings. Need to account for this when listing a user's buckets.
