### PR TITLE
Default dtrace_support to false.

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -87,7 +87,7 @@
 
               %% If your Erlang virtual machine supports DTrace (or
               %% user-space SystemTap), set dtrace_support to true.
-              {dtrace_support, true}
+              {dtrace_support, false}
 
              ]},
 


### PR DESCRIPTION
Sadly most of our installs will probably be without dtrace support so default this to `false` to be safe.
