### PR TITLE
Slf basho bench big files

### DIFF
--- a/bench/basho_bench_driver_moss.erl
+++ b/bench/basho_bench_driver_moss.erl
@@ -101,8 +101,6 @@ new(ID) ->
 
 run(get, KeyGen, _ValueGen, #state{working_op = undefined,
                                    bucket = Bucket} = State) ->
-    case get(qwerty) of undefined -> timer:sleep(State#state.client_id * 25), io:format("x"); _ -> ok end,
-    put(qwerty, yo_keep_going),
     {NextHost, S2} = next_host(State),
     {Host, Port} = NextHost,
     Key = KeyGen(),

--- a/bench/basho_bench_driver_moss.erl
+++ b/bench/basho_bench_driver_moss.erl
@@ -71,7 +71,7 @@ new(ID) ->
     end,
     %% For ops other than get, basho_bench doesn't give us an explicit
     %% way to pass ReportFun to the necessary place in a purely
-    %% functional way.  Alas, this function isn't executed by the same
+    %% functional way.
     application:set_env(?MODULE, ?REPORTFUN_APPKEY, ReportFun),
 
     OpsList = basho_bench_config:get(operations, []),
@@ -97,7 +97,7 @@ new(ID) ->
 %% This module does some crazy stuff, but it's there for a reason.
 %% The reason is that basho_bench is expecting the run() function to
 %% do something that takes a few/several seconds at most.  It is not
-%% expeciting run() to finish after minutes/hours/days of runtime,
+%% expecting run() to finish after minutes/hours/days of runtime,
 %% which is quite possible when testing 5GB files or larger.
 %%
 %% So, we adopt a strategy where run() will return after ?BLOCK of

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -5,8 +5,8 @@
 %% The `mode` rate does *not* apply to `insert` operations.
 %% The driver does *not* support `update` operations
 
-%{mode, max}.
-{mode, {rate,4}}.
+{mode, max}.
+%{mode, {rate,4}}.
 {duration, 1}.
 {concurrent, 1}.
 
@@ -34,8 +34,8 @@
 % "make kbyte_sec-results"
 %{moss_measurement_units, kbyte_sec}.
 
-%{key_generator, {int_to_str, {uniform_int, 500}}}.
-{key_generator, {int_to_str, {uniform_int, 5}}}.
+{key_generator, {int_to_str, {partitioned_sequential_int, 1000, 100}}}.
+%{key_generator, {int_to_str, {uniform_int, 1000}}}.
 %% See comments in source code for bigfile_valgen() function for full
 %% explanation of the proplist below.
 {value_generator, {function, basho_bench_driver_moss, bigfile_valgen,

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -31,8 +31,8 @@
 {moss_request_timeout, 999999000}.
 % If using the moss_measurement_units option, you need to change
 % any R graph's labels of the Y axis, e.g. basho_bench's Makefile target
-% "make kbyte_sec-results"
-%{moss_measurement_units, kbyte_sec}.
+% "make mbyte_sec-results"
+{moss_measurement_units, mbyte_sec}.
 
 {key_generator, {int_to_str, {partitioned_sequential_int, 1000, 100}}}.
 %{key_generator, {int_to_str, {uniform_int, 1000}}}.

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -29,7 +29,7 @@
 % "make kbyte_sec-results"
 %{moss_measurement_units, kbyte_sec}.
 
-%{key_generator, {int_to_bin, {uniform_int, 500}}}.
+%{key_generator, {uniform_int, 500}}.
 {key_generator, {uniform_int, 5}}.
 %{value_generator_source_size, 12100105}. %% Must be larger than val gen max size.
 %{value_generator, {fixed_bin, 12100100}}.

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -1,5 +1,10 @@
 %% Sample config file for Riak CS basho_bench benchmarking
 
+%% About rate limiting via the `mode` setting: the `mode` rate is
+%% valid for the basho_bench_driver_moss plugin for `get` operations.
+%% The `mode` rate does *not* apply to `insert` operations.
+%% The driver does *not* support `update` operations
+
 %{mode, max}.
 {mode, {rate,4}}.
 {duration, 1}.
@@ -29,11 +34,16 @@
 % "make kbyte_sec-results"
 %{moss_measurement_units, kbyte_sec}.
 
-%{key_generator, {uniform_int, 500}}.
-{key_generator, {uniform_int, 5}}.
-%{value_generator_source_size, 12100105}. %% Must be larger than val gen max size.
-%{value_generator, {fixed_bin, 12100100}}.
-{value_generator, {fixed_bin, 1024}}.
+%{key_generator, {int_to_str, {uniform_int, 500}}}.
+{key_generator, {int_to_str, {uniform_int, 5}}}.
+%% See comments in source code for bigfile_valgen() function for full
+%% explanation of the proplist below.
+{value_generator, {function, basho_bench_driver_moss, bigfile_valgen,
+                  [[{file_size, 8001001},
+                    {ibrowse_block_size, 1000000},
+                    {max_rate_per_chunk, 50}]]}}.
 
-{operations, [{insert, 1}, {delete, 1}, {get, 1}]}.
-
+%% NOTE: It's not a good idea to mix insert & get ops in a single
+%%       basho_bench instance.  Use separate ones instead!
+%% bad idea: {operations, [{insert, 1}, {delete, 1}, {get, 1}]}.
+{operations, [{insert, 1}]}.

--- a/bench/moss.config.sample
+++ b/bench/moss.config.sample
@@ -35,5 +35,5 @@
 %{value_generator, {fixed_bin, 12100100}}.
 {value_generator, {fixed_bin, 1024}}.
 
-{operations, [{insert, 1}, {update, 1}, {delete, 1}, {get, 1}]}.
+{operations, [{insert, 1}, {delete, 1}, {get, 1}]}.
 

--- a/src/riak_moss_wm_key.erl
+++ b/src/riak_moss_wm_key.erl
@@ -241,7 +241,7 @@ produce_body(RD, #key_context{get_fsm_pid=GetFsmPid, manifest=Mfst,
                         RD,
                         [{"ETag",  ETag},
                          {"Last-Modified", LastModified}
-                        ] ++  Mfst#lfs_manifest_v2.metadata),
+                        ] ++  Mfst?MANIFEST.metadata),
     Method = wrq:method(RD),
     case Method == 'HEAD'
         orelse


### PR DESCRIPTION
Allow basho_bench to insert & get very big files, hundreds & thousands of megabytes.

Requires the use of the `slf-silent-run-return-stats` branch of basho_bench ... until that branch is merged into master.
