### PR TITLE
REPL proxy-get

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -72,7 +72,7 @@
                  creation_time=now() :: erlang:timestamp()}).
 -type acl() :: #acl_v1{} | #acl_v2{}.
 
--type cluster_id() :: undefined | term().  % Type still in flux.
+-type cluster_id() :: undefined | binary(). %% flattened string as binary
 
 -type cs_uuid() :: binary().
 
@@ -316,3 +316,4 @@
 -define(DEFAULT_GC_INTERVAL, 900). %% 15 minutes
 -define(DEFAULT_GC_RETRY_INTERVAL, 21600). %% 6 hours
 -define(EPOCH_START, <<"0">>).
+-define(DEFAULT_CLUSTER_ID_TIMEOUT,5000).

--- a/rebar.config
+++ b/rebar.config
@@ -32,5 +32,6 @@
         {stanchion, ".*", {git, "git@github.com:basho/stanchion", {branch, "master"}}},
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},
+				{riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{branch,"master"}}}
        ]}.

--- a/src/riak_moss_put_fsm.erl
+++ b/src/riak_moss_put_fsm.erl
@@ -335,6 +335,9 @@ prepare(State=#state{bucket=Bucket,
     FreeWriters = ordsets:from_list(WriterPids),
     MaxBufferSize = (riak_moss_lfs_utils:put_fsm_buffer_size_factor() * BlockSize),
     UUID = druuid:v4(),
+
+    %% for now, always populate cluster_id
+    ClusterID = riak_moss_utils:get_cluster_id(RiakPid),
     Manifest =
         riak_moss_lfs_utils:new_manifest(Bucket,
                                          Key,
@@ -345,7 +348,9 @@ prepare(State=#state{bucket=Bucket,
                                          undefined,
                                          Metadata,
                                          BlockSize,
-                                         Acl),
+                                         Acl,
+                                         undefined,
+                                         ClusterID),
     NewManifest = Manifest?MANIFEST{write_start_time=os:timestamp()},
 
     %% TODO:


### PR DESCRIPTION
See also:
https://github.com/basho/riak_repl/tree/adt-proxy-get
https://github.com/basho/riak-erlang-client/tree/adt-extra-messages

For testing/setup:
https://github.com/basho/internal_wiki/wiki/Multi-Data-Center-Proxy-Gets

Note: This includes some of Chris Tilt's work as well,
but the squash removed history.
