### PR TITLE
Create 3-node devrel command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,11 @@ stage : rel
 	$(foreach dep,$(wildcard deps/*), rm -rf rel/riak-cs/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) rel/riak-cs/lib;)
 	$(foreach app,$(wildcard apps/*), rm -rf rel/riak-cs/lib/$(shell basename $(app))-* && ln -sf $(abspath $(app)) rel/riak-cs/lib;)
 
-devrel:
+devrel: dev1 dev2 dev3
+
+dev1 dev2 dev3:
 	mkdir -p dev
-	(cd rel && ../rebar generate skip_deps=true target_dir=../dev/$(PKG_NAME) overlay_vars=vars/dev_vars.config)
+	(cd rel && ../rebar generate skip_deps=true target_dir=../dev/$@ overlay_vars=vars/$@_vars.config)
 
 devclean: clean
 	rm -rf dev

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ERLANG_BIN       = $(shell dirname $(shell which erl))
 REBAR           ?= $(BASE_DIR)/rebar
 OVERLAY_VARS    ?=
 
-.PHONY: rel deps test
+.PHONY: rel stagedevrel deps test
 
 all: deps compile
 
@@ -36,7 +36,7 @@ parity-test:
 ## Release targets
 ##
 rel: deps compile
-	@./rebar skip_deps=true generate  $(OVERLAY_VARS)
+	@./rebar generate skip_deps=true $(OVERLAY_VARS)
 
 relclean:
 	rm -rf rel/riak-cs
@@ -48,11 +48,16 @@ stage : rel
 	$(foreach dep,$(wildcard deps/*), rm -rf rel/riak-cs/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) rel/riak-cs/lib;)
 	$(foreach app,$(wildcard apps/*), rm -rf rel/riak-cs/lib/$(shell basename $(app))-* && ln -sf $(abspath $(app)) rel/riak-cs/lib;)
 
-devrel: dev1 dev2 dev3
+devrel: dev1 dev2 dev3 dev4
 
-dev1 dev2 dev3:
+dev1 dev2 dev3 dev4:
 	mkdir -p dev
 	(cd rel && ../rebar generate skip_deps=true target_dir=../dev/$@ overlay_vars=vars/$@_vars.config)
+
+stagedevrel: dev1 dev2 dev3 dev4
+	$(foreach dev,$^, \
+	  $(foreach app,$(wildcard apps/*), rm -rf dev/$(dev)/lib/$(shell basename $(app))-* && ln -sf $(abspath $(app)) dev/$(dev)/lib;) \
+	  $(foreach dep,$(wildcard deps/*), rm -rf dev/$(dev)/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) dev/$(dev)/lib;))
 
 devclean: clean
 	rm -rf dev

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -33,6 +33,7 @@
        {app, lager, [{incl_cond, include}]},
        {app, poolboy, [{incl_cond, include}]},
        {app, folsom, [{incl_cond, include}]},
+       {app, eper, [{incl_cond, include}]},
        {app, riak_moss, [{incl_cond, include}]}
       ]}.
 

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{moss_ip,           "127.0.0.1"}.
+{moss_port,         8071}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8081}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev1@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_moss
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -12,28 +12,32 @@
 %% etc/app.config
 %%
 {moss_ip,           "127.0.0.1"}.
-{moss_port,         8080}.
+{moss_port,         8072}.
 {riak_ip,           "127.0.0.1"}.
-{riak_pb_port,      8087}.
-{auth_bypass,       true}.
+{riak_pb_port,      8082}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
-{stanchion_ssl,     true}.
+{stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 
 %%
 %% etc/vm.args
 %%
-{node,         "riak_moss_dev@127.0.0.1"}.
+{node,         "rcs-dev2@127.0.0.1"}.
 {crash_dump,   "log/erl_crash.dump"}.
 
 %%
 %% bin/riak_moss
 %%
-{runner_script_dir,  "{{target_dir}}/bin"}.
-{runner_base_dir,    "${RUNNER_SCRIPT_DIR%/*}"}.
-{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
-{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{moss_ip,           "127.0.0.1"}.
+{moss_port,         8073}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8083}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev3@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_moss
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{moss_ip,           "127.0.0.1"}.
+{moss_port,         8074}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8084}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev4@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_moss
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.


### PR DESCRIPTION
Change devrel command to create 3
Riak CS nodes that are meant to talk
to (one-to-one relationship) with a
Riak devrel cluster. The HTTP ports for
Riak CS change to 807[1-3].
