### PR TITLE
Handle tombstones in manifest fsm

### DIFF
--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -181,13 +181,9 @@ generate_key() ->
 -spec decode_and_merge_siblings(riakc_obj:riakc_obj(), twop_set:twop_set()) ->
       twop_set:twop_set().
 decode_and_merge_siblings(Obj, OtherManifestSets) ->
-    Some = [binary_to_term(V) || {MD, V} <- riakc_obj:get_contents(Obj),
-                                 not has_tombstone(MD),
-                                 V /= <<>>],
+    Some = [binary_to_term(V) || {_, V}=Content <- riakc_obj:get_contents(Obj),
+                                 not riak_moss_utils:has_tombstone(Content)],
     twop_set:resolve([OtherManifestSets | Some]).
-
-has_tombstone(MD) ->
-    dict:is_key(<<"X-Riak-Deleted">>, MD) =:= true.
 
 %% ===================================================================
 %% EUnit tests


### PR DESCRIPTION
```
(riak-cs@127.0.0.1)36> 17:41:04.327 [error] gen_fsm <0.17924.129> in state waiting_command terminated with reason: bad argument in call to erlang:binary_to_term(<<>>) in lists:map/2 line 1173
```
