### PR TITLE
Bad owner element in response from GET Bucket request

### DIFF
--- a/src/riak_moss_s3_response.erl
+++ b/src/riak_moss_s3_response.erl
@@ -134,7 +134,7 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
                                           {'Size', [Size]},
                                           {'LastModified', [LastModified]},
                                           {'ETag', [ETag]},
-                                          {'Owner', [user_to_xml_owner(User)]}]};
+                                          user_to_xml_owner(User)]};
                         {error, Reason} ->
                             _ = lager:debug("Unable to fetch manifest for ~p. Reason: ~p",
                                             [Key, Reason]),


### PR DESCRIPTION
```
<?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Name>bucket1</Name><Prefix/><Marker/><MaxKeys>1000</MaxKeys><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated><Contents><Key>a</Key><Size>110</Size><LastModified>2012-06-28T14:56:21.000Z</LastModified><ETag>"15a856e22be94e87419e0719ff014a1c"</ETag><Owner><Owner><ID>9561934eeada29448c58efc9b281c656179695aff36f7297d501a0ee511cb125</ID><DisplayName>admin</DisplayName></Owner></Owner></Contents></ListBucketResult>
```
