### PR TITLE
Monitor delete fsm from gc daemon

### DIFF
--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -194,6 +194,11 @@ initiating_file_delete(continue, #state{current_files=[Manifest | _RestManifests
     %% name upon terminate(), so we do not have to pass our pid to it
     %% in order to get a reply.
     {ok, Pid} = riak_cs_delete_fsm_sup:start_delete_fsm(node(), Args),
+
+    %% Link to the delete fsm, so that if it dies,
+    %% we go down too. If the link fails, we should
+    %% also receive an 'EXIT' message.
+    catch link(Pid),
     {next_state, waiting_file_delete, State#state{delete_fsm_pid = Pid}};
 initiating_file_delete(_, State) ->
     {next_state, initiating_file_delete, State}.

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -196,9 +196,13 @@ initiating_file_delete(continue, #state{current_files=[Manifest | _RestManifests
     {ok, Pid} = riak_cs_delete_fsm_sup:start_delete_fsm(node(), Args),
 
     %% Link to the delete fsm, so that if it dies,
-    %% we go down too. If the link fails, we should
-    %% also receive an 'EXIT' message.
-    catch link(Pid),
+    %% we go down too. In the future we might want to do
+    %% something more complicated like retry
+    %% a particular key N times before moving on, but for
+    %% now this is the easiest thing to do. If we need to manually
+    %% skip an object to GC, we can change the epoch start
+    %% time in app.config
+    link(Pid),
     {next_state, waiting_file_delete, State#state{delete_fsm_pid = Pid}};
 initiating_file_delete(_, State) ->
     {next_state, initiating_file_delete, State}.


### PR DESCRIPTION
We need to monitor the delete FSMs the GC daemon starts, because if they crash we get stuck forever in the `waiting_file_delete` state, waiting for a response from the FSM. I believe we should treat this case exactly the same as if the delete_fsm replies back to the gc daemon with an error.

In the particular case I found, the delete fsm is dying because (actually in the manifest fsm):

```
(riak-cs@127.0.0.1)36> 17:41:04.327 [error] gen_fsm <0.17924.129> in state waiting_command terminated with reason: bad argument in call to erlang:binary_to_term(<<>>) in lists:map/2 line 1173
```
