### PR TITLE
Fetching own user info fails if the key_id is not specified.

### DIFF
--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -217,7 +217,8 @@ forbidden('POST', RD, Ctx, User, [], _) ->
 forbidden('PUT', RD, Ctx, User, [], _) ->
     admin_check(riak_moss_utils:is_admin(User), RD, Ctx);
 forbidden(_Method, RD, Ctx, User, UserPathKey, _) when
-      UserPathKey =:= User?RCS_USER.key_id ->
+      UserPathKey =:= User?RCS_USER.key_id;
+      UserPathKey =:= [] ->
     %% User is accessing own account
     AccessRD = riak_moss_access_logger:set_user(User, RD),
     {false, AccessRD, Ctx};


### PR DESCRIPTION
Marcel reported that doing s3cmd get s3://riak-cs/user returns the error: "Failed to fetch user record. KeyId: []" instead of the user information.
