### PR TITLE
Existing buckets can be duplicated after upgrade from 1.0->1.1

### DIFF
--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -1036,6 +1036,14 @@ xml_error_code(Xml) ->
     {ParsedData, _Rest} = xmerl_scan:string(Xml, []),
     process_xml_error(ParsedData#xmlElement.content).
 
+%% @doc Update a bucket record to convert the name from binary
+%% to string if necessary.
+-spec update_bucket_record(term()) -> moss_bucket().
+update_bucket_record(Bucket=?MOSS_BUCKET{name=Name}) when is_binary(Name) ->
+    Bucket?MOSS_BUCKET{name=binary_to_list(Name)};
+update_bucket_record(Bucket) ->
+    Bucket.
+
 %% @doc Check if a user already has an ownership of
 %% a bucket and update the bucket list if needed.
 -spec update_user_buckets(moss_user(), moss_bucket()) ->
@@ -1075,7 +1083,8 @@ update_user_record(User=#moss_user_v1{}) ->
               key_id=User#moss_user_v1.key_id,
               key_secret=User#moss_user_v1.key_secret,
               canonical_id=User#moss_user_v1.canonical_id,
-              buckets=User#moss_user_v1.buckets}.
+              buckets=[update_bucket_record(Bucket) ||
+                          Bucket <- User#moss_user_v1.buckets]}.
 
 %% @doc Return a user record for the specified user name and
 %% email address.


### PR DESCRIPTION
Examining an afflicted user record reveals why this happens:

```
{rcs_user_v2,"test","test","test@test.com",
             "W8PBALCLT7GQAJSFP1KM",
             "c5W-HAYAMFJSGJX6Sx0mzTHpwGmQCA3yFnD3cA==",
             "e39e3296dde28b04d29ba82a578cabc240374e0fa1b1890c3a6617484c108686",
             [{moss_bucket_v1,"test",undefined,
                              "2012-08-08T23:15:25.000Z",
                              {1344,467725,672623},
                              undefined},
              {moss_bucket_v1,<<"test">>,created,
                              "2012-08-08T21:56:55.000Z",
                              {1344,463015,301318},
                              undefined}],
             enabled}
```
## Testing

An easy way to induce the problem is by changing the ACL on a bucket.

For example:

```
s3cmd setacl -P s3://test
```

or

```
s3cmd setacl --acl-private s3://test
```

Then doing `s3cmd ls` should show the `test` bucket listed twice when using the `master` branch, but using `moss263-duplicate-bucket-fix` the bucket should only be listed once after changing the ACL.

_Note:_ This branch does not correct the problem once duplicate bucket names have been created, it just prevents it from happening in the first place. Just keep that in mind when testing if not wiping out all Riak data when changing branches.
