### PR TITLE
Account for change in return type from riakc_pb_socket:get_index

### DIFF
--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -360,8 +360,8 @@ fetch_eligible_manifest_keys(RiakPid, IntervalStart) ->
     EndTime = list_to_binary(integer_to_list(IntervalStart)),
     eligible_manifest_keys(gc_index_query(RiakPid, EndTime)).
 
-eligible_manifest_keys({{ok, BKeys}, _}) ->
-    [Key || [_, Key] <- BKeys];
+eligible_manifest_keys({{ok, Keys}, _}) ->
+    Keys;
 eligible_manifest_keys({{error, Reason}, EndTime}) ->
     _ = lager:warning("Error occurred trying to query from time 0 to ~p"
                       "in gc key index. Reason: ~p",

--- a/src/riak_moss_utils.erl
+++ b/src/riak_moss_utils.erl
@@ -432,7 +432,7 @@ get_user_index(Index, Value, RiakPid) ->
     case riakc_pb_socket:get_index(RiakPid, ?USER_BUCKET, Index, Value) of
         {ok, []} ->
             {error, notfound};
-        {ok, [[_, Key]]} ->
+        {ok, [Key | _]} ->
             {ok, binary_to_list(Key)};
         {error, Reason}=Error ->
             _ = lager:warning("Error occurred trying to query ~p in user index ~p. Reason: ~p", [Value,


### PR DESCRIPTION
The return type of `riakc_pb_socket:get_index` recently changed from `[{Bucket, Key}]` to `[Key]`. This pr updates our expectations for that return type so that our uses of `get_index` work properly.
## Testing

There are two places where this problem affects system operations.
1. When updating an ACL `riak_moss_utils:get_user_by_index` gets called so updating an ACL for a user's bucket or object should expose the problem.
1. The garbage collection daemon calls `get_index` to determine eligible keys for garbage collection. In this case, there is no error reported, but the daemon will report that it processed 0 manifests even if it should have found some. I recommend setting `leeway_seconds` to `0` and `gc_interval` to `infinity`, overwrite one or more objects, and then initiate a garbage collection batch with `riak-cs-gc batch`. With `master` it should show 0 manifests, but with `moss261-index-return-change` it should report the expected count of manifests cleaned up.

_Note:_ Make sure the `riakc` and `riak_pb` deps are up-to-date with the latest changes.
