### PR TITLE
Fix error conditions with riak-cs-gc status and pause commands

### DIFF
--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -135,10 +135,18 @@ print_details(Details) ->
       end
       || {K, V} <- Details ].
 
-human_detail(interval, Interval) ->
+human_detail(interval, infinity) ->
+    {"The current garbage collection interval is", "infinity (i.e. gc is disabled)"};
+human_detail(interval, Interval) when is_integer(Interval) ->
     {"The current garbage collection interval is", integer_to_list(Interval)};
+human_detail(interval, _) ->
+    {"The current garbage collection interval is", "undefined"};
+human_detail(next, undefined) ->
+    {"Next run scheduled for", "undefined"};
 human_detail(next, Time) ->
     {"Next run scheduled for", human_time(Time)};
+human_detail(last, undefined) ->
+    {"Last run started at", "undefined"};
 human_detail(last, Time) ->
     {"Last run started at", human_time(Time)};
 human_detail(current, Time) ->


### PR DESCRIPTION
Issuing the status or pause command to the `riak-cs-gc` script while the gc daemon is in the `idle` state can result in errors. This can happen if the daemon is in the `idle` state and a gc batch has never been run or if the interval is set to `inifinity`.
## Testing

I updated the manual command property in `riak_cs_gc_d_eqc` to catch the error with the `pause` command. To verify this, comment out lines [432](https://github.com/basho/riak_moss/pull/264/files#L1R432) and [433](https://github.com/basho/riak_moss/pull/264/files#L1R433) of `riak_cs_gc_d` which reverts to the `master` state for this particular issue (or feel free to checkout master and otherwise make adjustments to the test). 

To test the `status` command start `riak-cs` with `gc_interval` set to `infinity` in the `app.config` and run `riak-cs-gc status`. With `master` the output should be this:

```
There is no garbage collection in progress
Checking garbage collection status failed:
  error:badarg
```

With `moss264-fix-gc-commands` the output should be this:

```
There is no garbage collection in progress
  The current garbage collection interval is: infinity (i.e. gc is disabled)
  Last run started at: undefined
  Next run scheduled for: undefined
```
