### PR TITLE
Upgrade clojure tests to leiningen2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-python:
 test-clojure:
 	@command -v lein >/dev/null 2>&1 || { echo >&2 "I require lein but it's not installed. \
 	Please read client_tests/clojure/clj-s3/README."; exit 1; }
-	@cd client_tests/clojure/clj-s3 && lein deps, midje
+	@cd client_tests/clojure/clj-s3 && lein do deps, midje
 
 ##
 ## Release targets

--- a/client_tests/clojure/clj-s3/.gitignore
+++ b/client_tests/clojure/clj-s3/.gitignore
@@ -6,3 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/target

--- a/client_tests/clojure/clj-s3/README
+++ b/client_tests/clojure/clj-s3/README
@@ -4,10 +4,13 @@
 If you don't have a Clojure environment set up, follow these
 steps first.
 
+(Note, if you have leingingen 1.x, you'll need leiningen2, instructions
+for upgrading are [here](https://github.com/technomancy/leiningen/wiki/Upgrading).
+
 ```shell
 # this will in Leiningen (often called lein), this Clojure build tool
 INSTALL_DIR=/usr/local/bin
-curl "https://raw.github.com/technomancy/leiningen/1.x/bin/lein" > $INSTALL_DIR/lein
+curl "https://raw.github.com/technomancy/leiningen/preview/bin/lein" > $INSTALL_DIR/lein
 chmod +x $INSTALL_DIR/lein
 ```
 

--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,10 +1,11 @@
-(defproject java-s3-tests "0.0.1-SNAPSHOT"
-  :description "integration tests for Riak CS using the offical Java SDK"
+(defproject java-s3-tests/java-s3-tests "0.0.1-SNAPSHOT" 
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [com.amazonaws/aws-java-sdk "1.3.11"]
                  [com.reiddraper/clj-aws-s3 "0.4.0-SNAPSHOT"]
                  [commons-codec/commons-codec "1.6"]
                  [clj-http "0.4.3"]
                  [cheshire "4.0.0"]]
-  :dev-dependencies [[midje "1.4.0"]
-                    [lein-midje "1.0.9"]])
+  :profiles {:dev {:dependencies [[midje "1.4.0"]]}}
+  :min-lein-version "2.0.0"
+  :plugins [[lein-midje "2.0.0-SNAPSHOT"]]
+  :description "integration tests for Riak CS using the offical Java SDK")


### PR DESCRIPTION
Instructions for upgrading are here:
https://github.com/technomancy/leiningen/wiki/Upgrading

make everything should remain the same from the perspective
of running the make target, 'make test-clojure'
