### PR TITLE
Don't expose tracebacks to users on 500 error

### DIFF
--- a/src/riak_moss_wm_error_handler.erl
+++ b/src/riak_moss_wm_error_handler.erl
@@ -13,11 +13,13 @@ render_error(500, Req, Reason) ->
     {ok, ReqState} = Req:add_response_header("Content-Type", "text/html"),
     {Path,_} = Req:path(),
     error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, Reason]),
-    STString = io_lib:format("~p", [Reason]),
-    ErrorStart = "<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request:<br><pre>",
-    ErrorEnd = "</pre><P><HR><ADDRESS>mochiweb+webmachine web server</ADDRESS></body></html>",
-    ErrorIOList = [ErrorStart,STString,ErrorEnd],
-    {erlang:iolist_to_binary(ErrorIOList), ReqState};
+
+    ErrorOne = <<"<html><head><title>500 Internal Server Error</title>">>,
+    ErrorTwo = <<"</head><body><h1>Internal Server Error</h1>">>,
+    ErrorThree = <<"The server encountered an error while processing ">>,
+    ErrorFour = <<"this request</body></html>">>,
+    IOList = [ErrorOne, ErrorTwo, ErrorThree, ErrorFour],
+    {erlang:iolist_to_binary(IOList), ReqState};
 render_error(_Code, Req, _Reason) ->
     dt_entry(<<"render_error">>),
     Req:response_body().


### PR DESCRIPTION
The error is still logged to error.log, so it is not hidden.
