### PR TITLE
Issue with Updates on User Objects

### DIFF
--- a/include/riak_moss.hrl
+++ b/include/riak_moss.hrl
@@ -43,7 +43,7 @@
 -record(context, {start_time :: erlang:timestamp(),
                   auth_bypass :: atom(),
                   user :: moss_user(),
-                  user_vclock :: term(),
+                  user_object :: riakc_obj:riakc_obj(),
                   bucket :: binary(),
                   requested_perm :: acl_perm(),
                   riakc_pid :: pid()

--- a/src/riak_cs_wm_stats.erl
+++ b/src/riak_cs_wm_stats.erl
@@ -100,7 +100,7 @@ produce_body(RD, Ctx) ->
 forbidden(RD, #ctx{auth_bypass = AuthBypass, riakc_pid = RiakPid} = Ctx) ->
     dt_entry(<<"forbidden">>, [], []),
     case riak_moss_wm_utils:validate_auth_header(RD, AuthBypass, RiakPid) of
-        {ok, User, _UserVclock} ->
+        {ok, User, _UserObj} ->
             UserKeyId = User?MOSS_USER.key_id,
             case riak_moss_utils:get_admin_creds() of
                 {ok, {Admin, _}} when Admin == UserKeyId ->

--- a/src/riak_moss_storage.erl
+++ b/src/riak_moss_storage.erl
@@ -31,7 +31,7 @@ sum_user(Riak, User) when is_binary(User) ->
     sum_user(Riak, binary_to_list(User));
 sum_user(Riak, User) when is_list(User) ->
     case riak_moss_utils:get_user(User, Riak) of
-        {ok, {?MOSS_USER{buckets=Buckets}, _VClock}} ->
+        {ok, {?MOSS_USER{buckets=Buckets}, _UserObj}} ->
             {ok, [ {B, sum_bucket(Riak, B)}
                    || ?MOSS_BUCKET{name=B} <- Buckets ]};
         {error, Error} ->

--- a/src/riak_moss_wm_usage.erl
+++ b/src/riak_moss_wm_usage.erl
@@ -179,7 +179,7 @@ malformed_request(RD, Ctx) ->
 
 resource_exists(RD, #ctx{riak=Riak}=Ctx) ->
     case riak_moss_utils:get_user(user_key(RD), Riak) of
-        {ok, {User, _UserVclock}} ->
+        {ok, {User, _UserObj}} ->
             {true, RD, Ctx#ctx{user=User}};
         {error, _} ->
             {false, error_msg(RD, <<"Unknown user">>), Ctx}

--- a/src/riak_moss_wm_user.erl
+++ b/src/riak_moss_wm_user.erl
@@ -241,8 +241,8 @@ get_user(AdminCheckResult, _) ->
                              term()) ->
                                     {boolean() | {halt, term()}, term(), term()}.
 
-handle_get_user_result({ok, {User, _}}, RD, Ctx) ->
-    {false, RD, Ctx#context{user=User}};
+handle_get_user_result({ok, {User, UserObj}}, RD, Ctx) ->
+    {false, RD, Ctx#context{user=User, user_object=UserObj}};
 handle_get_user_result({error, Reason}, RD, Ctx) ->
     _ = lager:warning("Failed to fetch user record. KeyId: ~p"
                       " Reason: ~p", [user_key(RD), Reason]),
@@ -276,10 +276,10 @@ handle_update_result({false, _User}, RD, Ctx) ->
     ContentType = wrq:get_resp_header("Content-Type", RD),
     {{halt, 200}, set_resp_data(ContentType, RD, Ctx), Ctx};
 handle_update_result({true, User}, RD, Ctx) ->
-    #context{user_vclock=VClock,
+    #context{user_object=UserObj,
              riakc_pid=RiakPid} = Ctx,
     handle_save_user_result(
-      riak_moss_utils:save_user(User, VClock, RiakPid), User, RD, Ctx).
+      riak_moss_utils:save_user(User, UserObj, RiakPid), User, RD, Ctx).
 
 -spec handle_save_user_result(ok | {error, term()}, rcs_user(), term(), term()) ->
     {boolean() | {halt, term()}, term(), term()}.

--- a/src/riak_moss_wm_utils.erl
+++ b/src/riak_moss_wm_utils.erl
@@ -102,7 +102,7 @@ parse_auth_params(KeyId, Signature, _) ->
 %% @doc Lookup the user specified by the access headers, and call
 %% `Next(RD, NewCtx)' if there is no auth error.
 %%
-%% If a user was successfully authed, the `user' and `user_vclock'
+%% If a user was successfully authed, the `user' and `user_object'
 %% fields in the `#context' record passed to `Next' will be filled.
 %% If the access is instead anonymous, those fields will be left as
 %% they were passed to this function.
@@ -117,10 +117,10 @@ find_and_auth_user(Rd, ICtx, Next) ->
 find_and_auth_user(RD, #context{auth_bypass=AuthBypass,
                                 riakc_pid=RiakPid}=ICtx, Next, Conv2KeyCtx) ->
     case validate_auth_header(RD, AuthBypass, RiakPid) of
-        {ok, User, UserVclock} ->
+        {ok, User, UserObj} ->
             %% given keyid and signature matched, proceed
             NewICtx = ICtx#context{user=User,
-                                   user_vclock=UserVclock},
+                                   user_object=UserObj},
             Next(RD, NewICtx);
         {error, no_user_key} ->
             %% no keyid was given, proceed anonymously
@@ -134,10 +134,10 @@ find_and_auth_user(RD, #context{auth_bypass=AuthBypass,
     end.
 
 %% @doc Look for an Authorization header in the request, and validate
-%% it if it exists.  Returns `{ok, User, UserVclock}' if validation
+%% it if it exists.  Returns `{ok, User, UserObj}' if validation
 %% succeeds, or `{error, KeyId, Reason}' if any step fails.
 -spec validate_auth_header(#wm_reqdata{}, term(), pid()) ->
-                                  {ok, moss_user(), riakc_obj:vclock()} |
+                                  {ok, moss_user(), riakc_obj:riakc_obj()} |
                                   {error, bad_auth | notfound | no_user_key | term()}.
 validate_auth_header(RD, AuthBypass, RiakPid) ->
     AuthHeader = wrq:get_req_header("authorization", RD),
@@ -153,11 +153,11 @@ validate_auth_header(RD, AuthBypass, RiakPid) ->
             {AuthMod, KeyId, Signature} = parse_auth_header(AuthHeader, AuthBypass)
     end,
     case riak_moss_utils:get_user(KeyId, RiakPid) of
-        {ok, {User, UserVclock}} when User?MOSS_USER.status =:= enabled ->
+        {ok, {User, UserObj}} when User?MOSS_USER.status =:= enabled ->
             Secret = User?MOSS_USER.key_secret,
             case AuthMod:authenticate(RD, Secret, Signature) of
                 ok ->
-                    {ok, User, UserVclock};
+                    {ok, User, UserObj};
                 {error, _Reason} ->
                     %% TODO: are the errors here of small enough
                     %% number that we could just handle them in


### PR DESCRIPTION
From a client perspective: Updates on user objects (like changing status) don't work consistently.
From an internal perspective: It looks like siblings get created which then don't get merged/resolved correctly.

Vector clocks were not being used for user account updates and this resulted in sibling creation and unexpected behavior from the user perspective. This change reworks how user record updates are handled so that now instead of storing only the vector clock in the webmachine resource context and having to reconstruct an entire new object for an update, we store the entire object in the context and make the appropriate updates to that object prior to saving.

There is still a chance that even with these changes that a user object could have siblings, but this would require multiple admin users modifying the same account at the same time. Currently, the code to retrieve and update the user records can handle the siblings, but there is no meaningful semantic I can think of with the current user record to intelligently pick which sibling should _win_. In the future we may want to add a modified timestamp to the user record as a means to make this decision a little more intelligently. For now I think the likelihood of this happening is minimal enough to wait on that. 
