### PR TITLE
Don't crash in terminate if State isn't fully populated

### DIFF
--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -555,12 +555,12 @@ handle_receiving_last_chunk(NewData, State=#state{buffer_queue=BufferQueue,
 maybe_stop_manifest_fsm(undefined) ->
     ok;
 maybe_stop_manifest_fsm(ManiPid) ->
-    riak_moss_manifest_fsm:stop(ManiPid),
+    riak_cs_manifest_fsm:stop(ManiPid),
     ok.
 
 -spec maybe_stop_block_servers(undefined | pid()) -> ok.
 maybe_stop_block_servers(undefined) ->
     ok;
 maybe_stop_block_servers(BlockServerPids) ->
-    _ = [riak_moss_block_server:stop(P) || P <- BlockServerPids],
+    _ = [riak_cs_block_server:stop(P) || P <- BlockServerPids],
     ok.


### PR DESCRIPTION
Check to make sure that the pids we stop
in terminate/3 are actually pids before stopping them.
This was masking errors earlier in the FSM because crashes
in the terminate function were causing the previous error
to not be logged. Tested by adding some bugs calls to
foo:foo() in the various `prepare` function clauses.
