### PR TITLE
Add basic support for riak-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,13 @@ stagedevrel: dev1 dev2 dev3 dev4
 	  $(foreach app,$(wildcard apps/*), rm -rf dev/$(dev)/lib/$(shell basename $(app))-* && ln -sf $(abspath $(app)) dev/$(dev)/lib;) \
 	  $(foreach dep,$(wildcard deps/*), rm -rf dev/$(dev)/lib/$(shell basename $(dep))-* && ln -sf $(abspath $(dep)) dev/$(dev)/lib;))
 
+rtdevrel: rtdev1 rtdev2 rtdev3 rtdev4 rtdev5 rtdev6
+
+rtdev1 rtdev2 rtdev3 rtdev4 rtdev5 rtdev6:
+	mkdir -p $(RT_TARGET_CS)/$@
+	 (cd rel && ../rebar generate skip_deps=true target_dir=$(RT_TARGET_CS)/$@ overlay_vars=vars/$@_vars.config)
+
+
 devclean: clean
 	rm -rf dev
 

--- a/rebar.config
+++ b/rebar.config
@@ -33,5 +33,12 @@
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},
-				{riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{branch,"master"}}}
+        {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{branch,"master"}}},
+        {riak_test, ".*", {git, "git@github.com:/basho/riak_test", {branch, "master"}}}
        ]}.
+
+{plugins, [rebar_riak_test_plugin]}.
+{riak_test, [
+    {test_paths, ["riak_test/tests", "riak_test/src"]},
+      {test_output, "riak_test/ebin"}
+]}.

--- a/rel/vars/rtdev1_vars.config
+++ b/rel/vars/rtdev1_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8371}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8081}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev1@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/rtdev2_vars.config
+++ b/rel/vars/rtdev2_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8372}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8082}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev2@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/rtdev3_vars.config
+++ b/rel/vars/rtdev3_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8373}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8083}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev3@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/rtdev4_vars.config
+++ b/rel/vars/rtdev4_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8374}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8084}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev4@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/rtdev5_vars.config
+++ b/rel/vars/rtdev5_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8375}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8085}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev5@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/rel/vars/rtdev6_vars.config
+++ b/rel/vars/rtdev6_vars.config
@@ -1,0 +1,43 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%% Platform-specific installation paths
+{platform_bin_dir,  "./bin"}.
+{platform_data_dir, "./data"}.
+{platform_etc_dir,  "./etc"}.
+{platform_lib_dir,  "./lib"}.
+{platform_log_dir,  "./log"}.
+
+%%
+%% etc/app.config
+%%
+{cs_ip,           "127.0.0.1"}.
+{cs_port,         8376}.
+{riak_ip,           "127.0.0.1"}.
+{riak_pb_port,      8086}.
+{auth_bypass,       false}.
+{admin_key,         "admin-key"}.
+{admin_secret,      "admin-secret"}.
+{stanchion_ip,      "127.0.0.1"}.
+{stanchion_port,    8085}.
+{stanchion_ssl,     false}.
+{request_pool_tuple, "{128, 0}"}.
+{bucket_list_pool_tuple, "{5, 0}"}.
+
+%%
+%% etc/vm.args
+%%
+{node,         "rcs-dev6@127.0.0.1"}.
+{crash_dump,   "log/erl_crash.dump"}.
+
+%%
+%% bin/riak_cs
+%%
+{data_dir,           "{{target_dir}}/data"}.
+{runner_script_dir,  "{{target_dir}}/sbin"}.
+{runner_bin_dir,     "{{target_dir}}"}.
+{runner_run_dir,     "{{target_dir}}"}.
+{runner_etc_dir,     "{{target_dir}}/etc"}.
+{runner_log_dir,     "{{target_dir}}/log"}.
+{pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
+{runner_user,        ""}.

--- a/riak_test/bin/README
+++ b/riak_test/bin/README
@@ -1,0 +1,22 @@
+0) setup a ~/.riak_test.config file like this:
+(Note the extra riak_cs/deps and stanchion/deps)
+{rtdev, [
+    {rt_deps, ["/Users/dparfitt/test-releases/riak_ee/deps",
+	"/Users/dparfitt/test-releases/riak_cs/deps",
+	"/Users/dparfitt/test-releases/stanchion/deps"]},
+    {rt_max_wait_time, 180000},
+    {rt_retry_delay, 500},
+    {rt_harness, rtdev},
+	  
+    {rtdev_path, [{root, "/tmp/rt"},
+                  {current, "/tmp/rt/current"},
+                  {"1.2.0", "/tmp/rt/riak-1.2.0"},
+                  {"1.1.4", "/tmp/rt/riak-1.1.4"},
+                  {"1.0.3", "/tmp/rt/riak-1.0.3"}]}
+]}.
+
+1) export RT_TARGET_CURRENT=/tmp/rt/current
+2) read through setup.sh to see what it's doing
+3) add the following to /etc/hosts:
+127.0.0.1 riak_test_bucket.localhost
+4) run setup.sh

--- a/riak_test/bin/buildcs.sh
+++ b/riak_test/bin/buildcs.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# This script will build a Riak CS instance from source
+basho_checkout_source() {
+    git clone git@github.com:basho/riak_ee.git
+    git clone git@github.com:basho/riak_cs.git
+    git clone git@github.com:basho/stanchion.git
+}
+
+basho_make_all() {
+
+	mkdir -p $RT_TARGET_CURRENT
+
+	# build Riak EE
+	cd riak_ee
+	make devclean
+	make
+	make stagedevrel
+	cd ..
+
+	cp -a riak_ee/dev /tmp/rt/current
+
+	# build stanchion
+	cd stanchion
+	make devclean
+	make
+	make devrel
+	cp -R ./dev/stanchion /tmp/rt/current
+	cd ..
+
+	# build CS
+	cd riak_cs
+	make devclean
+	make
+	make rtdevrel
+	#cp -R ./dev/riak_cs  /tmp/rt/current
+	cd ..
+	mkdir -p $RT_TARGET_CURRENT/stanchion/log
+	for i in `seq 1 6`
+	do
+		mkdir -p $RT_TARGET_CURRENT/cs/rtdev$i/log
+	done
+	touch $RT_TARGET_CURRENT/stanchion/log/.keep
+	for i in `seq 1 6`
+	do
+		touch $RT_TARGET_CURRENT/cs/rtdev$i/log/.keep
+	done
+
+	cwd=$(pwd) 
+	cd $RT_TARGET_CURRENT
+	git init
+	git add .
+	git commit -a -m "riak_test cs init"
+	cd $cwd
+}
+
+basho_buildriakcs_proxyget() {
+  basho_checkout_source
+  basho_make_all
+}
+
+export RT_TARGET_CURRENT=/tmp/rt/current
+export RT_TARGET_STANCHION=$RT_TARGET_CURRENT/stanchion
+export RT_TARGET_CS=$RT_TARGET_CURRENT/cs
+
+basho_buildriakcs_proxyget

--- a/riak_test/bin/setup.sh
+++ b/riak_test/bin/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+mkdir ~/test-releases
+cd ~/test-releases
+git clone git@github.com:basho/riak_cs.git
+cp ./riak_cs/riak_test/bin/buildcs.sh ./
+chmod 700 buildcs.sh
+./buildcs.sh
+export RT_TARGET_CURRENT=/tmp/rt/current
+cd riak_cs
+make && ./rebar rt_run config=rtdev test=repl_test

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -1,0 +1,249 @@
+-module(rtcs).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEVS(N), lists:concat(["dev", N, "@127.0.0.1"])).
+-define(DEV(N), list_to_atom(?DEVS(N))).
+-define(CSDEVS(N), lists:concat(["rcs-dev", N, "@127.0.0.1"])).
+-define(CSDEV(N), list_to_atom(?CSDEVS(N))).
+
+riakcs_binpath(Prefix, N) ->
+    io_lib:format("~s/cs/rtdev~b/sbin/riak-cs", [Prefix, N]).
+
+riakcs_etcpath(Prefix, N) ->
+    io_lib:format("~s/cs/rtdev~b/etc", [Prefix, N]).
+
+riakcscmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
+
+stanchion_binpath(Path, _N) ->
+    io_lib:format("~s/stanchion/sbin/stanchion", [Path]).
+
+stanchion_etcpath(Path) ->
+    io_lib:format("~s/stanchion/etc", [Path]).
+
+stanchioncmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [stanchion_binpath(Path, N), Cmd])).
+
+deploy_nodes(NumNodes, InitialConfig) ->
+    NodeConfig = [{current, InitialConfig} || _ <- lists:seq(1,NumNodes)],
+    RiakNodes = [?DEV(N) || N <- lists:seq(1, NumNodes)],
+    CSNodes = [?CSDEV(N) || N <- lists:seq(1, NumNodes)],
+    StanchionNode = 'stanchion@127.0.0.1',
+
+    NodeMap = orddict:from_list(lists:zip(RiakNodes, lists:seq(1, NumNodes))),
+    rt:set_config(rt_nodes, NodeMap),
+
+    VersionMap = lists:zip(lists:seq(1, NumNodes), lists:duplicate(NumNodes, current)),
+    rt:set_config(rt_versions, VersionMap),
+
+    NL0 = lists:zip(CSNodes, RiakNodes),
+    {CS1, R1} = hd(NL0),
+    NodeList = [{CS1, R1, StanchionNode} | tl(NL0)],
+
+    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
+                N = rtdev:node_id(RiakNode),
+                stop_cs(N),
+                stop_stanchion(Stanchion),
+                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
+                rt:wait_until_unpingable(CSNode),
+                rt:wait_until_unpingable(Stanchion),
+                rt:wait_until_unpingable(RiakNode);
+            ({CSNode, RiakNode}) ->
+                N = rtdev:node_id(RiakNode),
+                stop_cs(N),
+                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
+                rt:wait_until_unpingable(CSNode),
+                rt:wait_until_unpingable(RiakNode)
+        end, NodeList),
+
+    %% XXX this is a hack
+    Path = os:getenv("RT_TARGET_CURRENT"),
+
+    %% Reset nodes to base state
+    lager:info("Resetting nodes to fresh state"),
+    %% run_git(Path, "status"),
+    rtdev:run_git(Path, "reset HEAD --hard"),
+    rtdev:run_git(Path, "clean -fd"),
+
+    rtdev:create_dirs(RiakNodes),
+
+    {_Versions, Configs} = lists:unzip(NodeConfig),
+
+    %% Set initial config
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
+                            Config)),
+                    update_cs_config(rt:config(csroot), N,
+                        proplists:get_value(cs, Config)),
+                    update_stanchion_config(rt:config(csroot),
+                        proplists:get_value(stanchion, Config));
+                ({{_CSNode, RiakNode}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
+                            Config)),
+                    update_cs_config(rt:config(csroot), N,
+                        proplists:get_value(cs, Config))
+            end,
+            lists:zip(NodeList, Configs)),
+
+    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
+                N = rtdev:node_id(RiakNode),
+                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "start"),
+                start_stanchion(N),
+                start_cs(N);
+            ({_CSNode, RiakNode}) ->
+                N = rtdev:node_id(RiakNode),
+                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "start"),
+                start_cs(N)
+        end, NodeList),
+
+    Nodes = {RiakNodes, CSNodes, StanchionNode},
+
+    [ok = rt:wait_until_pingable(N) || N <- RiakNodes ++ CSNodes ++
+        [StanchionNode]],
+
+    [ok = rt:check_singleton_node(N) || N <- RiakNodes],
+
+    lager:info("Deployed nodes: ~p", [Nodes]),
+    Nodes.
+
+start_cs(N) ->
+    Cmd = riakcscmd(rt:config(csroot), N, "start"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+stop_cs(N) ->
+    Cmd = riakcscmd(rt:config(csroot), N, "stop"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+start_stanchion(N) ->
+    Cmd = stanchioncmd(rt:config(csroot), N, "start"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+stop_stanchion(N) ->
+    Cmd = stanchioncmd(rt:config(csroot), N, "stop"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+update_cs_config(Prefix, N, Config) ->
+    update_app_config(riakcs_etcpath(Prefix, N) ++ "/app.config", Config).
+
+update_stanchion_config(Prefix, Config) ->
+    update_app_config(stanchion_etcpath(Prefix) ++ "/app.config", Config).
+
+update_app_config(ConfigFile,  Config) ->
+    lager:debug("~nReading config file at ~s~n", [ConfigFile]),
+    {ok, [BaseConfig]} = file:consult(ConfigFile),
+    MergeA = orddict:from_list(Config),
+    MergeB = orddict:from_list(BaseConfig),
+    NewConfig =
+        orddict:merge(fun(_, VarsA, VarsB) ->
+                              MergeC = orddict:from_list(VarsA),
+                              MergeD = orddict:from_list(VarsB),
+                              orddict:merge(fun(_, ValA, _ValB) ->
+                                                    ValA
+                                            end, MergeC, MergeD)
+                      end, MergeA, MergeB),
+    NewConfigOut = io_lib:format("~p.", [NewConfig]),
+    lager:debug("CONFIG FILE=~s~n",[ConfigFile]),
+    ?assertEqual(ok, file:write_file(ConfigFile, NewConfigOut)),
+    ok.
+
+
+deploy_cs(Config, N) ->
+    %%NodeId = io_lib:format("rcs-dev~b@127.0.0.1",[N]),
+    stop_cs(N),
+    timer:sleep(10000),
+    %% TODO: need a better method than sleep here
+
+    update_cs_config(rt:config(csroot), N, Config),
+
+    start_cs(N),
+    %timer:sleep(10000),
+    %% TODO:
+    %%rt:wait_until_unpingable(NodeId),
+    lager:info("Riak CS started").
+
+%% this differes from rtdev:deploy_xxx in that it only starts one node
+deploy_stanchion(Config, N) ->
+    %%NodeId = "stanchion@127.0.0.1",
+    stop_stanchion(N),
+    timer:sleep(10000),
+    %% TODO: need a better method than sleep here
+
+    %% Set initial config
+    update_stanchion_config(rt:config(csroot), Config),
+
+    start_stanchion(N),
+    %% TODO
+    %%rt:wait_until_unpingable(NodeId),
+    %timer:sleep(60000),
+    lager:info("Stanchion started").
+
+
+create_admin_user(Port, EmailAddr, Name) ->
+    lager:debug("Trying to create user ~p", [EmailAddr]),
+    Cmd="curl -s -H 'Content-Type: application/json' -X POST http://localhost:" ++
+        integer_to_list(Port) ++
+        "/user --data '{\"email\":\"" ++ EmailAddr ++  "\", \"name\":\"" ++ Name ++"\"}'",
+    Output = os:cmd(Cmd),
+    lager:debug("Create user output=~p~n",[Output]),
+    {struct, JsonData} = mochijson2:decode(Output),
+    KeyId = binary_to_list(proplists:get_value(<<"key_id">>, JsonData)),
+    KeySecret = binary_to_list(proplists:get_value(<<"key_secret">>, JsonData)),
+    Id = binary_to_list(proplists:get_value(<<"id">>, JsonData)),
+    Email = binary_to_list(proplists:get_value(<<"email">>, JsonData)),
+    lager:info("Riak CS Admin account created with ~p",[Email]),
+    lager:info("KeyId = ~p",[KeyId]),
+    lager:info("KeySecret = ~p",[KeySecret]),
+    lager:info("Id = ~p",[Id]),
+    {KeyId, KeySecret, Id}.
+
+
+
+%% gen_s3cmd_config() ->
+%%     "[default]~n" ++
+%%         "access_key = $IDNOQUOTES~n" ++
+%%         "bucket_location = US~n" ++
+%%         "cloudfront_host = cloudfront.amazonaws.com~n" ++
+%%         "cloudfront_resource = /2010-07-15/distribution~n" ++
+%%         "default_mime_type = binary/octet-stream~n" ++
+%%         "delete_removed = False~n" ++
+%%         "dry_run = False~n" ++
+%%         "enable_multipart = False~n" ++
+%%         "encoding = UTF-8~n" ++
+%%         "encrypt = False~n" ++
+%%         "follow_symlinks = False~n" ++
+%%         "force = False~n" ++
+%%         "get_continue = False~n" ++
+%%         "gpg_command = /usr/local/bin/gpg~n" ++
+%%         "gpg_decrypt = %(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s\" %(input_file)s\"~n" ++
+%%         "gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s\" %(input_file)s\"~n" ++
+%%         "gpg_passphrase = password~n" ++
+%%         "guess_mime_type = True~n" ++
+%%         "host_base = s3.amazonaws.com~n" ++
+%%         "host_bucket = %(bucket)s.s3.amazonaws.com~n" ++
+%%         "human_readable_sizes = False~n" ++
+%%         "list_md5 = False~n" ++
+%%         "log_target_prefix =~n" ++
+%%         "preserve_attrs = True~n" ++
+%%         "progress_meter = True~n" ++
+%%         "proxy_host = localhost~n" ++
+%%         "proxy_port = 8080~n" ++
+%%         "recursive = False~n" ++
+%%         "recv_chunk = 4096~n" ++
+%%         "reduced_redundancy = False~n" ++
+%%         "secret_key = $KEYNOQUOTES~n" ++
+%%         "send_chunk = 4096~n" ++
+%%         "simpledb_host = sdb.amazonaws.com~n" ++
+%%         "skip_existing = False~n" ++
+%%         "socket_timeout = 300~n" ++
+%%         "urlencoding_mode = normal~n" ++
+%%         "use_https = False~n" ++
+%%         "verbosity = WARNING~n".

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -1,0 +1,381 @@
+-module(repl_test).
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+cs_port(Node) ->
+    8370 + rtdev:node_id(Node).
+
+confirm() ->
+    Path = case os:getenv("RT_TARGET_CURRENT") of
+        false -> lager:info("RT_TARGET_CURRENT not defined."),
+                 lager:info("Defaulting to /tmp/rt/current"),
+            "/tmp/rt/current";
+        Value -> Value
+    end,
+    rt:set_config(csroot,Path),
+
+    EEConfig =
+    [
+        lager_config(),
+        {riak_core,
+            [{default_bucket_props, [{allow_mult, true}]}]},
+        {riak_kv,
+            [
+                {add_paths, [Path ++ "/cs/rtdev1/lib/riak_cs-1.1.0/ebin"]},
+                {storage_backend, riak_cs_kv_multi_backend},
+                {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
+                {multi_backend_default, be_default},
+                {multi_backend,
+                    [{be_default, riak_kv_eleveldb_backend,
+                            [
+                                {max_open_files, 50},
+                                {data_root, "./leveldb"}
+                            ]},
+                        {be_blocks, riak_kv_bitcask_backend,
+                            [
+                                {data_root, "./bitcask"}
+                            ]}
+                    ]}
+            ]},
+        {riak_repl,
+            [
+                {fullsync_on_connect, false},
+                {fullsync_interval, disabled},
+                {proxy_get, enabled}
+            ]}
+    ],
+
+
+    %% Note that riak_pb_port points to the first devrel
+    StanchionConfig =
+    [
+        lager_config(),
+        {stanchion,
+            [
+                {stanchion_port, 9095},
+                {riak_pb_port, 8081}
+            ]}],
+
+    {RiakNodes, _CSNodes, _Stanchion} = rtcs:deploy_nodes(6, [{riak, EEConfig}, {stanchion, StanchionConfig},
+            {cs, cs_config(1)}]),
+
+    timer:sleep(1000),
+
+    {ANodes, BNodes} = lists:split(3, RiakNodes),
+
+    %{ACSNodes, BCSNodes} = lists:split(3, RiakNodes),
+
+    lager:info("Build cluster A"),
+    replication:make_cluster(ANodes),
+
+    lager:info("Build cluster B"),
+    replication:make_cluster(BNodes),
+
+    %% STFU sasl
+    application:load(sasl),
+    application:set_env(sasl, sasl_error_logger, false),
+    erlcloud:start(),
+    timer:sleep(3000),
+
+    AFirst = hd(ANodes),
+    BFirst = hd(BNodes),
+
+    {A,B,C} = erlang:now(),
+    EmailAddr = lists:flatten(io_lib:format("~p~p~p@basho.com", [A,B,C])),
+    {AccessKeyId, SecretAccessKey, _Id} =
+        rtcs:create_admin_user(cs_port(AFirst), EmailAddr,"Test User"),
+    lager:info("Created user ~p with keys ~p ~p", [EmailAddr, AccessKeyId,
+            SecretAccessKey]),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(ANodes)),"http"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets()),
+
+    lager:info("creating bucket riak_test_bucket"),
+    ?assertEqual(ok, erlcloud_s3:create_bucket("riak_test_bucket")),
+
+    ?assertMatch([{buckets, [[{name, "riak_test_bucket"}, _]]}],
+        erlcloud_s3:list_buckets()),
+
+
+    ?assertEqual([],
+        proplists:get_value(contents,
+            erlcloud_s3:list_objects("riak_test_bucket"))),
+
+    Object1 = crypto:rand_bytes(4194304),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_one", Object1),
+
+    ?assertEqual(["object_one"],
+        [proplists:get_value(key, O) || O <- proplists:get_value(contents,
+                erlcloud_s3:list_objects("riak_test_bucket"))]),
+
+
+    Obj = erlcloud_s3:get_object("riak_test_bucket", "object_one"),
+    ?assertEqual(Object1, proplists:get_value(content,Obj)),
+
+    {D,E,F} = erlang:now(),
+    EmailAddr2 = lists:flatten(io_lib:format("~p~p~p@basho.com", [D,E,F])),
+    {AccessKeyId2, SecretAccessKey2, _Id2} =
+        rtcs:create_admin_user(cs_port(BFirst), EmailAddr2,"Test User2"),
+    lager:info("Created user ~p with keys ~p ~p", [EmailAddr2, AccessKeyId2,
+            SecretAccessKey2]),
+
+    erlcloud_s3:configure(AccessKeyId2, SecretAccessKey2,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    lager:info("new user isn't valid on secondary cluster, even though we "
+        "created it there"),
+    ?assertError({aws_error, _}, erlcloud_s3:list_buckets()),
+
+    erlcloud_s3:configure(AccessKeyId2, SecretAccessKey2,
+        "localhost",cs_port(hd(ANodes)),"http"),
+
+    lager:info("new user IS valid on the primary cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets()),
+
+    lager:info("set up replication between clusters"),
+
+    %% setup servers/listeners on A
+    Listeners = replication:add_listeners(ANodes),
+
+    %% verify servers are visible on all nodes
+    replication:verify_listeners(Listeners),
+
+    %% get the leader for the first cluster
+    replication:wait_until_leader(AFirst),
+    LeaderA = rpc:call(AFirst, riak_repl_leader, leader_node, []),
+
+    %% list of listeners not on the leader node
+    NonLeaderListeners = lists:keydelete(LeaderA, 3, Listeners),
+
+    %% setup sites on B
+    %% TODO: make `NumSites' an argument
+    NumSites = 1,
+    {Ip, Port, _} = hd(NonLeaderListeners),
+    replication:add_site(hd(BNodes), {Ip, Port, "site1"}),
+
+    %% verify sites are distributed on B
+    replication:verify_sites_balanced(NumSites, BNodes),
+
+    %% check the listener IPs were all imported into the site
+    replication:verify_site_ips(BFirst, "site1", Listeners),
+
+    replication:start_and_wait_until_fullsync_complete(LeaderA),
+
+    erlcloud_s3:configure(AccessKeyId2, SecretAccessKey2,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    lager:info("new user is valid on secondary cluster after fullsync, still"
+        " no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets()),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    lager:info("original user has the test bucket on the secondary cluster"
+        " now"),
+    ?assertMatch([{buckets, [[{name, "riak_test_bucket"}, _]]}],
+        erlcloud_s3:list_buckets()),
+
+    lager:info("Object written on primary cluster is readable from secondary "
+        "cluster"),
+    Obj2 = erlcloud_s3:get_object("riak_test_bucket", "object_one"),
+    ?assertEqual(Object1, proplists:get_value(content,Obj2)),
+
+    lager:info("write 2 more objects to the primary cluster"),
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(ANodes)),"http"),
+
+    Object2 = crypto:rand_bytes(4194304),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_two", Object2),
+
+    Object3 = crypto:rand_bytes(4194304),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_three", Object3),
+
+    lager:info("disconnect the clusters"),
+    LeaderB = rpc:call(hd(BNodes), riak_repl_leader, leader_node, []),
+    replication:del_site(LeaderB, "site1"),
+
+    lager:info("check we can still read the fullsynced object"),
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    Obj3 = erlcloud_s3:get_object("riak_test_bucket", "object_one"),
+    ?assertEqual(Object1, proplists:get_value(content,Obj3)),
+
+    lager:info("check all 3 objects are listed on the secondary cluster"),
+    ?assertEqual(["object_one", "object_three", "object_two"],
+        [proplists:get_value(key, O) || O <- proplists:get_value(contents,
+                erlcloud_s3:list_objects("riak_test_bucket"))]),
+
+    lager:info("check that the 2 other objects can't be read"),
+    %% XXX I expect errors here, but I get successful objects containing <<>>
+    %?assertError({aws_error, _}, erlcloud_s3:get_object("riak_test_bucket",
+            %"object_two")),
+    %?assertError({aws_error, _}, erlcloud_s3:get_object("riak_test_bucket",
+            %"object_three")),
+    Obj4 = erlcloud_s3:get_object("riak_test_bucket", "object_two"),
+    ?assertEqual(<<>>, proplists:get_value(content,Obj4)),
+    ?assertEqual(integer_to_list(byte_size(Object2)),
+        proplists:get_value(content_length,Obj4)),
+    Obj5 = erlcloud_s3:get_object("riak_test_bucket", "object_three"),
+    ?assertEqual(<<>>, proplists:get_value(content,Obj5)),
+    ?assertEqual(integer_to_list(byte_size(Object3)),
+        proplists:get_value(content_length,Obj5)),
+
+    lager:info("reconnect clusters"),
+    replication:add_site(hd(BNodes), {Ip, Port, "site1"}),
+
+    lager:info("check we can read object_two via proxy get"),
+    Obj6 = erlcloud_s3:get_object("riak_test_bucket", "object_two"),
+    ?assertEqual(Object2, proplists:get_value(content,Obj6)),
+
+    lager:info("disconnect the clusters again"),
+    replication:del_site(LeaderB, "site1"),
+
+    lager:info("check we still can't read object_three"),
+    Obj7 = erlcloud_s3:get_object("riak_test_bucket", "object_three"),
+    ?assertEqual(<<>>, proplists:get_value(content,Obj7)),
+
+    lager:info("check that proxy getting object_two wrote it locally, so we"
+        " can read it"),
+    Obj8 = erlcloud_s3:get_object("riak_test_bucket", "object_two"),
+    ?assertEqual(Object2, proplists:get_value(content,Obj8)),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(ANodes)),"http"),
+
+    lager:info("delete object_one while clusters are disconnected"),
+    erlcloud_s3:delete_object("riak_test_bucket", "object_one"),
+
+    lager:info("reconnect clusters"),
+    replication:add_site(hd(BNodes), {Ip, Port, "site1"}),
+
+    lager:info("delete object_two while clusters are connected"),
+    erlcloud_s3:delete_object("riak_test_bucket", "object_two"),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    lager:info("object_one is still visible on secondary cluster"),
+    Obj9 = erlcloud_s3:get_object("riak_test_bucket", "object_one"),
+    ?assertEqual(Object1, proplists:get_value(content,Obj9)),
+
+    lager:info("object_two is deleted"),
+    ?assertError({aws_error, _}, erlcloud_s3:get_object("riak_test_bucket",
+            "object_two")),
+
+    replication:start_and_wait_until_fullsync_complete(LeaderA),
+ 
+    lager:info("object_one is deleted after fullsync"),
+    ?assertError({aws_error, _}, erlcloud_s3:get_object("riak_test_bucket",
+            "object_one")),
+
+    lager:info("disconnect the clusters again"),
+    replication:del_site(LeaderB, "site1"),
+
+    Object3A = crypto:rand_bytes(4194304),
+    ?assert(Object3 /= Object3A),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(ANodes)),"http"),
+
+    lager:info("write a new version of object_three"),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_three", Object3A),
+
+    lager:info("Independantly write different object_four and object_five to bolth clusters"),
+
+    Object4A = crypto:rand_bytes(4194304),
+    Object4B = crypto:rand_bytes(4194304),
+
+    Object5A = crypto:rand_bytes(4194304),
+    Object5B = crypto:rand_bytes(4194304),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_four", Object4A),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    erlcloud_s3:put_object("riak_test_bucket", "object_four", Object4B),
+    erlcloud_s3:put_object("riak_test_bucket", "object_five", Object5B),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(ANodes)),"http"),
+
+    lager:info("delay writing object 5 on primary cluster 1 second after "
+        "writing to secondary cluster"),
+    timer:sleep(1000),
+    erlcloud_s3:put_object("riak_test_bucket", "object_five", Object5A),
+
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    lager:info("reconnect clusters"),
+    replication:add_site(hd(BNodes), {Ip, Port, "site1"}),
+
+    lager:info("secondary cluster has old version of object three"),
+    Obj10 = erlcloud_s3:get_object("riak_test_bucket", "object_three"),
+    ?assertEqual(Object3, proplists:get_value(content,Obj10)),
+
+    lager:info("secondary cluster has 'B' version of object four"),
+    Obj11 = erlcloud_s3:get_object("riak_test_bucket", "object_four"),
+    ?assertEqual(Object4B, proplists:get_value(content,Obj11)),
+
+    replication:start_and_wait_until_fullsync_complete(LeaderA),
+
+    lager:info("secondary cluster has new version of object three"),
+    Obj12 = erlcloud_s3:get_object("riak_test_bucket", "object_three"),
+    ?assertEqual(Object3A, proplists:get_value(content,Obj12)),
+
+    lager:info("secondary cluster has 'B' version of object four"),
+    Obj13 = erlcloud_s3:get_object("riak_test_bucket", "object_four"),
+    ?assertEqual(Object4B, proplists:get_value(content,Obj13)),
+
+    lager:info("secondary cluster has 'A' version of object five, because it "
+        "was written later"),
+    Obj14 = erlcloud_s3:get_object("riak_test_bucket", "object_five"),
+    ?assertEqual(Object5A, proplists:get_value(content,Obj14)),
+
+    lager:info("write 'A' version of object four again on primary cluster"),
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+    erlcloud_s3:put_object("riak_test_bucket", "object_four", Object4A),
+
+    lager:info("secondary cluster now has 'A' version of object four"),
+    erlcloud_s3:configure(AccessKeyId, SecretAccessKey,
+        "localhost",cs_port(hd(BNodes)),"http"),
+
+    Obj15 = erlcloud_s3:get_object("riak_test_bucket", "object_four"),
+    ?assertEqual(Object4A, proplists:get_value(content,Obj15)),
+    pass.
+
+
+cs_config(_N) ->
+    [
+        lager_config(),
+        {riak_cs,
+            [
+                {proxy_get, enabled},
+                {anonymous_user_creation, true},
+                {stanchion_port, 9095},
+                {cs_root_host, "localhost"}
+            ]
+        }].
+
+lager_config() ->
+    {lager, [
+            {handlers, [
+                    {lager_console_backend, debug},
+                    {lager_file_backend, [
+                            {"./log/error.log", error, 10485760, "$D0",5},
+                            {"./log/console.log", debug, 10485760, "$D0", 5}
+                        ]}
+                ]}
+        ]}.
+
+

--- a/riak_test/tests/replication.erl
+++ b/riak_test/tests/replication.erl
@@ -1,0 +1,558 @@
+-module(replication).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-import(rt, [deploy_nodes/2,
+             join/2,
+             wait_until_nodes_ready/1,
+             wait_until_no_pending_changes/1]).
+
+replication() ->
+    %% TODO: Don't hardcode # of nodes
+    NumNodes = 6,
+    ClusterASize = list_to_integer(get_os_env("CLUSTER_A_SIZE", "3")),
+    %% ClusterBSize = NumNodes - ClusterASize,
+    %% ClusterBSize = list_to_integer(get_os_env("CLUSTER_B_SIZE"), "2"),
+
+    %% Nodes = rt:nodes(NumNodes),
+    %% lager:info("Create dirs"),
+    %% create_dirs(Nodes),
+
+    Backend = list_to_atom(get_os_env("RIAK_BACKEND",
+            "riak_kv_bitcask_backend")),
+
+    lager:info("Deploy ~p nodes using ~p backend", [NumNodes, Backend]),
+    Conf = [
+            {riak_kv,
+             [
+                {storage_backend, Backend}
+             ]},
+            {riak_repl,
+             [
+                {fullsync_on_connect, false},
+                {fullsync_interval, disabled}
+             ]}
+    ],
+
+    Nodes = deploy_nodes(NumNodes, Conf),
+
+    {ANodes, BNodes} = lists:split(ClusterASize, Nodes),
+    lager:info("ANodes: ~p", [ANodes]),
+    lager:info("BNodes: ~p", [BNodes]),
+
+    lager:info("Build cluster A"),
+    make_cluster(ANodes),
+
+    lager:info("Build cluster B"),
+    make_cluster(BNodes),
+
+    replication(ANodes, BNodes, false).
+
+replication([AFirst|_] = ANodes, [BFirst|_] = BNodes, Connected) ->
+
+    TestHash = erlang:md5(term_to_binary(os:timestamp())),
+    TestBucket = <<TestHash/binary, "-systest_a">>,
+    FullsyncOnly = <<TestHash/binary, "-fullsync_only">>,
+    RealtimeOnly = <<TestHash/binary, "-realtime_only">>,
+    NoRepl = <<TestHash/binary, "-no_repl">>,
+
+    case Connected of
+        false ->
+            %% clusters are not connected, connect them
+
+            %% write some initial data to A
+            lager:info("Writing 100 keys to ~p", [AFirst]),
+            ?assertEqual([], do_write(AFirst, 1, 100, TestBucket, 2)),
+
+            %% setup servers/listeners on A
+            Listeners = add_listeners(ANodes),
+
+            %% verify servers are visible on all nodes
+            verify_listeners(Listeners),
+
+            %% get the leader for the first cluster
+            wait_until_leader(AFirst),
+            LeaderA = rpc:call(AFirst, riak_repl_leader, leader_node, []),
+
+            %% list of listeners not on the leader node
+            NonLeaderListeners = lists:keydelete(LeaderA, 3, Listeners),
+
+            %% setup sites on B
+            %% TODO: make `NumSites' an argument
+            NumSites = 4,
+            {Ip, Port, _} = hd(NonLeaderListeners),
+            add_site(hd(BNodes), {Ip, Port, "site1"}),
+            FakeListeners = gen_fake_listeners(NumSites-1),
+            add_fake_sites(BNodes, FakeListeners),
+
+            %% verify sites are distributed on B
+            verify_sites_balanced(NumSites, BNodes),
+
+            %% check the listener IPs were all imported into the site
+            verify_site_ips(BFirst, "site1", Listeners);
+        _ ->
+            lager:info("waiting for leader to converge on cluster A"),
+            ?assertEqual(ok, wait_until_leader_converge(ANodes)),
+            lager:info("waiting for leader to converge on cluster B"),
+            ?assertEqual(ok, wait_until_leader_converge(BNodes)),
+            %% get the leader for the first cluster
+            LeaderA = rpc:call(AFirst, riak_repl_leader, leader_node, []),
+            lager:info("Leader on cluster A is ~p", [LeaderA]),
+            [{Ip, Port, _}|_] = get_listeners(LeaderA)
+    end,
+
+    %% write some data on A
+    ?assertEqual(ok, wait_until_connection(LeaderA)),
+    %io:format("~p~n", [rpc:call(LeaderA, riak_repl_console, status, [quiet])]),
+    lager:info("Writing 100 more keys to ~p", [LeaderA]),
+    ?assertEqual([], do_write(LeaderA, 101, 200, TestBucket, 2)),
+
+    %% verify data is replicated to B
+    lager:info("Reading 100 keys written to ~p from ~p", [LeaderA, BFirst]),
+    ?assertEqual(0, wait_for_reads(BFirst, 101, 200, TestBucket, 2)),
+
+    case Connected of
+        false ->
+            %% check that the keys we wrote initially aren't replicated yet, because
+            %% we've disabled fullsync_on_connect
+            lager:info("Check keys written before repl was connected are not present"),
+            Res2 = rt:systest_read(BFirst, 1, 100, TestBucket, 2),
+            ?assertEqual(100, length(Res2)),
+
+            start_and_wait_until_fullsync_complete(LeaderA),
+
+            lager:info("Check keys written before repl was connected are present"),
+            ?assertEqual(0, wait_for_reads(BFirst, 1, 200, TestBucket, 2));
+        _ ->
+            ok
+    end,
+
+    %%
+    %% Failover tests
+    %%
+
+    lager:info("Testing master failover: stopping ~p", [LeaderA]),
+    rt:stop(LeaderA),
+    rt:wait_until_unpingable(LeaderA),
+    ASecond = hd(ANodes -- [LeaderA]),
+    wait_until_leader(ASecond),
+
+    LeaderA2 = rpc:call(ASecond, riak_repl_leader, leader_node, []),
+
+    lager:info("New leader is ~p", [LeaderA2]),
+
+    ?assertEqual(ok, wait_until_connection(LeaderA2)),
+
+    lager:info("Writing 100 more keys to ~p now that the old leader is down",
+        [ASecond]),
+
+    ?assertEqual([], do_write(ASecond, 201, 300, TestBucket, 2)),
+
+    %% verify data is replicated to B
+    lager:info("Reading 100 keys written to ~p from ~p", [ASecond, BFirst]),
+    ?assertEqual(0, wait_for_reads(BFirst, 201, 300, TestBucket, 2)),
+
+    %% get the leader for the first cluster
+    LeaderB = rpc:call(BFirst, riak_repl_leader, leader_node, []),
+
+    lager:info("Testing client failover: stopping ~p", [LeaderB]),
+    rt:stop(LeaderB),
+    rt:wait_until_unpingable(LeaderB),
+    BSecond = hd(BNodes -- [LeaderB]),
+    wait_until_leader(BSecond),
+
+    LeaderB2 = rpc:call(BSecond, riak_repl_leader, leader_node, []),
+
+    lager:info("New leader is ~p", [LeaderB2]),
+
+    ?assertEqual(ok, wait_until_connection(LeaderA2)),
+
+    lager:info("Writing 100 more keys to ~p now that the old leader is down",
+        [ASecond]),
+
+    ?assertEqual([], do_write(ASecond, 301, 400, TestBucket, 2)),
+
+    %% verify data is replicated to B
+    lager:info("Reading 101 keys written to ~p from ~p", [ASecond, BSecond]),
+    ?assertEqual(0, wait_for_reads(BSecond, 301, 400, TestBucket, 2)),
+
+    %% Testing fullsync with downed nodes
+    lager:info("Re-running fullsync with ~p and ~p down", [LeaderA, LeaderB]),
+
+    start_and_wait_until_fullsync_complete(LeaderA2),
+
+    %%
+    %% Per-bucket repl settings tests
+    %%
+
+    lager:info("Restarting down node ~p", [LeaderA]),
+    rt:start(LeaderA),
+    rt:wait_until_pingable(LeaderA),
+    start_and_wait_until_fullsync_complete(LeaderA2),
+
+    lager:info("Restarting down node ~p", [LeaderB]),
+    rt:start(LeaderB),
+    rt:wait_until_pingable(LeaderB),
+
+    lager:info("Nodes restarted"),
+
+    case nodes_all_have_version(ANodes, "1.1.0") of
+        true ->
+
+            make_bucket(LeaderA, NoRepl, [{repl, false}]),
+
+            case nodes_all_have_version(ANodes, "1.2.0") of
+                true ->
+                    make_bucket(LeaderA, RealtimeOnly, [{repl, realtime}]),
+                    make_bucket(LeaderA, FullsyncOnly, [{repl, fullsync}]),
+
+                    %% disconnect the other cluster, so realtime doesn't happen
+                    lager:info("disconnect the 2 clusters"),
+                    del_site(LeaderB, "site1"),
+
+                    lager:info("write 100 keys to a realtime only bucket"),
+                    ?assertEqual([], do_write(ASecond, 1, 100,
+                            RealtimeOnly, 2)),
+
+                    lager:info("reconnect the 2 clusters"),
+                    add_site(LeaderB, {Ip, Port, "site1"}),
+                    ?assertEqual(ok, wait_until_connection(LeaderA));
+                _ ->
+                    timer:sleep(1000)
+            end,
+
+            LeaderA3 = rpc:call(ASecond, riak_repl_leader, leader_node, []),
+
+            lager:info("write 100 keys to a {repl, false} bucket"),
+            ?assertEqual([], do_write(ASecond, 1, 100, NoRepl, 2)),
+
+            case nodes_all_have_version(ANodes, "1.2.0") of
+                true ->
+                    lager:info("write 100 keys to a fullsync only bucket"),
+                    ?assertEqual([], do_write(ASecond, 1, 100,
+                            FullsyncOnly, 2)),
+
+                    lager:info("Check the fullsync only bucket didn't replicate the writes"),
+                    Res6 = rt:systest_read(BSecond, 1, 100, FullsyncOnly, 2),
+                    ?assertEqual(100, length(Res6)),
+
+                    lager:info("Check the realtime only bucket that was written to offline "
+                        "isn't replicated"),
+                    Res7 = rt:systest_read(BSecond, 1, 100, RealtimeOnly, 2),
+                    ?assertEqual(100, length(Res7));
+                _ ->
+                    timer:sleep(1000)
+            end,
+
+            lager:info("Check the {repl, false} bucket didn't replicate"),
+            Res8 = rt:systest_read(BSecond, 1, 100, NoRepl, 2),
+            ?assertEqual(100, length(Res8)),
+
+            %% do a fullsync, make sure that fullsync_only is replicated, but
+            %% realtime_only and no_repl aren't
+            start_and_wait_until_fullsync_complete(LeaderA3),
+
+            case nodes_all_have_version(ANodes, "1.2.0") of
+                true ->
+                    lager:info("Check fullsync only bucket is now replicated"),
+                    ?assertEqual(0, wait_for_reads(BSecond, 1, 100,
+                            FullsyncOnly, 2)),
+
+                    lager:info("Check realtime only bucket didn't replicate"),
+                    Res10 = rt:systest_read(BSecond, 1, 100, RealtimeOnly, 2),
+                    ?assertEqual(100, length(Res10)),
+
+
+                    lager:info("Write 100 more keys into realtime only bucket"),
+                    ?assertEqual([], do_write(ASecond, 101, 200,
+                            RealtimeOnly, 2)),
+
+                    timer:sleep(5000),
+
+                    lager:info("Check the realtime keys replicated"),
+                    ?assertEqual(0, wait_for_reads(BSecond, 101, 200,
+                                RealtimeOnly, 2)),
+
+                    lager:info("Check the older keys in the realtime bucket did not replicate"),
+                    Res12 = rt:systest_read(BSecond, 1, 100, RealtimeOnly, 2),
+                    ?assertEqual(100, length(Res12));
+                _ ->
+                    ok
+            end,
+
+            lager:info("Check {repl, false} bucket didn't replicate"),
+            Res13 = rt:systest_read(BSecond, 1, 100, NoRepl, 2),
+            ?assertEqual(100, length(Res13));
+        _ ->
+            ok
+    end,
+
+    lager:info("Test passed"),
+    fin.
+
+verify_sites_balanced(NumSites, BNodes0) ->
+    Leader = rpc:call(hd(BNodes0), riak_repl_leader, leader_node, []),
+    case node_has_version(Leader, "1.2.0") of
+        true ->
+            BNodes = nodes_with_version(BNodes0, "1.2.0") -- [Leader],
+            NumNodes = length(BNodes),
+            case NumNodes of
+                0 ->
+                    %% only leader is upgraded, runs clients locally
+                    ?assertEqual(NumSites, client_count(Leader));
+                _ ->
+                    NodeCounts = [{Node, client_count(Node)} || Node <- BNodes],
+                    lager:notice("nodecounts ~p", [NodeCounts]),
+                    lager:notice("leader ~p", [Leader]),
+                    Min = NumSites div NumNodes,
+                    [?assert(Count >= Min) || {_Node, Count} <- NodeCounts]
+            end;
+        false ->
+            ok
+    end.
+
+make_cluster(Nodes) ->
+    [First|Rest] = Nodes,
+    [join(Node, First) || Node <- Rest],
+    ?assertEqual(ok, wait_until_nodes_ready(Nodes)),
+    ?assertEqual(ok, wait_until_no_pending_changes(Nodes)).
+
+%% does the node meet the version requirement?
+node_has_version(Node, Version) ->
+    NodeVersion =  rtdev:node_version(rtdev:node_id(Node)),
+    case NodeVersion of
+        current ->
+            %% current always satisfies any version check
+            true;
+        _ ->
+            NodeVersion >= Version
+    end.
+
+nodes_with_version(Nodes, Version) ->
+    [Node || Node <- Nodes, node_has_version(Node, Version)].
+
+nodes_all_have_version(Nodes, Version) ->
+    Nodes == nodes_with_version(Nodes, Version).
+
+client_count(Node) ->
+    Clients = rpc:call(Node, supervisor, which_children, [riak_repl_client_sup]),
+    length(Clients).
+
+gen_fake_listeners(Num) ->
+    Ports = gen_ports(11000, Num),
+    IPs = lists:duplicate(Num, "127.0.0.1"),
+    Nodes = [fake_node(N) || N <- lists:seq(1, Num)],
+    lists:zip3(IPs, Ports, Nodes).
+
+fake_node(Num) ->
+    lists:flatten(io_lib:format("fake~p@127.0.0.1", [Num])).
+
+add_fake_sites([Node|_], Listeners) ->
+    [add_site(Node, {IP, Port, fake_site(Port)})
+     || {IP, Port, _} <- Listeners].
+
+add_site(Node, {IP, Port, Name}) ->
+    lager:info("Add site ~p ~p:~p at node ~p", [Name, IP, Port, Node]),
+    Args = [IP, integer_to_list(Port), Name],
+    Res = rpc:call(Node, riak_repl_console, add_site, [Args]),
+    ?assertEqual(ok, Res),
+    timer:sleep(timer:seconds(5)).
+
+del_site(Node, Name) ->
+    lager:info("Del site ~p at ~p", [Name, Node]),
+    Res = rpc:call(Node, riak_repl_console, del_site, [[Name]]),
+    ?assertEqual(ok, Res),
+    timer:sleep(timer:seconds(5)).
+
+fake_site(Port) ->
+    lists:flatten(io_lib:format("fake_site_~p", [Port])).
+
+verify_listeners(Listeners) ->
+    Strs = [IP ++ ":" ++ integer_to_list(Port) || {IP, Port, _} <- Listeners],
+    [?assertEqual(ok, verify_listener(Node, Strs)) || {_, _, Node} <- Listeners].
+
+verify_listener(Node, Strs) ->
+    lager:info("Verify listeners ~p ~p", [Node, Strs]),
+    rt:wait_until(Node,
+        fun(_) ->
+                Status = rpc:call(Node, riak_repl_console, status, [quiet]),
+                lists:all(fun(Str) ->
+                            lists:keymember(Str, 2, Status)
+                    end, Strs)
+        end).
+
+add_listeners(Nodes=[FirstNode|_]) ->
+    Ports = gen_ports(9010, length(Nodes)),
+    IPs = lists:duplicate(length(Nodes), "127.0.0.1"),
+    PN = lists:zip3(IPs, Ports, Nodes),
+    [add_listener(FirstNode, Node, IP, Port) || {IP, Port, Node} <- PN],
+    timer:sleep(timer:seconds(5)),
+    PN.
+
+add_listener(N, Node, IP, Port) ->
+    lager:info("Adding repl listener to ~p ~s:~p", [Node, IP, Port]),
+    Args = [[atom_to_list(Node), IP, integer_to_list(Port)]],
+    Res = rpc:call(N, riak_repl_console, add_listener, Args),
+    ?assertEqual(ok, Res).
+
+del_listeners(Node) ->
+    Listeners = get_listeners(Node),
+    lists:foreach(fun(Listener={IP, Port, N}) ->
+                lager:info("deleting listener ~p on ~p", [Listener, Node]),
+                Res = rpc:call(Node, riak_repl_console, del_listener,
+                    [[atom_to_list(N), IP, integer_to_list(Port)]]),
+                ?assertEqual(ok, Res)
+        end, Listeners).
+
+get_listeners(Node) ->
+    Status = rpc:call(Node, riak_repl_console, status, [quiet]),
+    %% *sigh*
+    [
+        begin
+                NodeName = list_to_atom(string:substr(K, 10)),
+                [IP, Port] = string:tokens(V, ":"),
+                {IP, list_to_integer(Port), NodeName}
+        end || {K, V} <- Status, is_list(K), string:substr(K, 1, 9) == "listener_"
+    ].
+
+gen_ports(Start, Len) ->
+    lists:seq(Start, Start + Len - 1).
+
+get_os_env(Var) ->
+    case get_os_env(Var, undefined) of
+        undefined -> exit({os_env_var_undefined, Var});
+        Value -> Value
+    end.
+
+get_os_env(Var, Default) ->
+    case os:getenv(Var) of
+        false -> Default;
+        Value -> Value
+    end.
+
+verify_site_ips(Leader, Site, Listeners) ->
+    Status = rpc:call(Leader, riak_repl_console, status, [quiet]),
+    Key = lists:flatten([Site, "_ips"]),
+    IPStr = proplists:get_value(Key, Status),
+    IPs = lists:sort(re:split(IPStr, ", ")),
+    ExpectedIPs = lists:sort(
+        [list_to_binary([IP, ":", integer_to_list(Port)]) || {IP, Port, _Node} <-
+            Listeners]),
+    ?assertEqual(ExpectedIPs, IPs).
+
+make_bucket(Node, Name, Args) ->
+    Res = rpc:call(Node, riak_core_bucket, set_bucket, [Name, Args]),
+    ?assertEqual(ok, Res).
+
+start_and_wait_until_fullsync_complete(Node) ->
+    Status0 = rpc:call(Node, riak_repl_console, status, [quiet]),
+    Count = proplists:get_value(server_fullsyncs, Status0) + 1,
+    lager:info("waiting for fullsync count to be ~p", [Count]),
+
+    lager:info("Starting fullsync on ~p (~p)", [Node,
+            rtdev:node_version(rtdev:node_id(Node))]),
+    rpc:call(Node, riak_repl_console, start_fullsync, [[]]),
+    %% sleep because of the old bug where stats will crash if you call it too
+    %% soon after starting a fullsync
+    timer:sleep(500),
+
+    Res = rt:wait_until(Node,
+        fun(_) ->
+                Status = rpc:call(Node, riak_repl_console, status, [quiet]),
+                case proplists:get_value(server_fullsyncs, Status) of
+                    C when C >= Count ->
+                        true;
+                    _ ->
+                        false
+                end
+        end),
+    case node_has_version(Node, "1.2.0") of
+        true ->
+            ?assertEqual(ok, Res);
+        _ ->
+            case Res of
+                ok ->
+                    ok;
+                _ ->
+                    ?assertEqual(ok, wait_until_connection(Node)),
+                    lager:warning("Pre 1.2.0 node failed to fullsync, retrying"),
+                    start_and_wait_until_fullsync_complete(Node)
+            end
+    end,
+
+    lager:info("Fullsync on ~p complete", [Node]).
+
+wait_until_leader(Node) ->
+    Res = rt:wait_until(Node,
+        fun(_) ->
+                Status = rpc:call(Node, riak_repl_console, status, [quiet]),
+                case Status of
+                    {badrpc, _} ->
+                        false;
+                    _ ->
+                        case proplists:get_value(leader, Status) of
+                            undefined ->
+                                false;
+                            _ ->
+                                true
+                        end
+                end
+        end),
+    ?assertEqual(ok, Res).
+
+wait_until_leader_converge([Node|_] = Nodes) ->
+    rt:wait_until(Node,
+        fun(_) ->
+                length(lists:usort([begin
+                        Status = rpc:call(N, riak_repl_console, status, [quiet]),
+                        case Status of
+                            {badrpc, _} ->
+                                false;
+                            _ ->
+                                case proplists:get_value(leader, Status) of
+                                    undefined ->
+                                        false;
+                                    L ->
+                                        %lager:info("Leader for ~p is ~p",
+                                            %[N,L]),
+                                        L
+                                end
+                        end
+                end || N <- Nodes])) == 1
+        end).
+
+wait_until_connection(Node) ->
+    rt:wait_until(Node,
+        fun(_) ->
+                Status = rpc:call(Node, riak_repl_console, status, [quiet]),
+                case proplists:get_value(server_stats, Status) of
+                    [] ->
+                        false;
+                    [_C] ->
+                        true;
+                    Conns ->
+                        lager:warning("multiple connections detected: ~p",
+                            [Conns]),
+                        true
+                end
+        end, 80, 500). %% 40 seconds is enough for repl
+
+wait_for_reads(Node, Start, End, Bucket, R) ->
+    rt:wait_until(Node,
+        fun(_) ->
+                rt:systest_read(Node, Start, End, Bucket, R) == []
+        end),
+    length(rt:systest_read(Node, Start, End, Bucket, R)).
+
+do_write(Node, Start, End, Bucket, W) ->
+    case rt:systest_write(Node, Start, End, Bucket, W) of
+        [] ->
+            [];
+        Errors ->
+            lager:warning("~p errors while writing: ~p",
+                [length(Errors), Errors]),
+            timer:sleep(1000),
+            lists:flatten([rt:systest_write(Node, S, S, Bucket, W) ||
+                    {S, _Error} <- Errors])
+    end.
+


### PR DESCRIPTION
Please see riak_test/bin/README for basic info on how to run this.
### Notes
-  riak_cs devrel's need to be fixed if you want to remove the rtdevrel make targets and `rel/vars/rtdev[1-6]_vars.config` files. At that point, `/tmp/rt/current/cs/rtdev*` targets need to be changed in the code. The current devrel would not allow me to copy ./dev/\* to another directory and run, as paths were hardcoded as `../`.
- node_package needs to be pinned at 1.0.0. As of right now, node_package master looks for `/lib/env.sh`.
