### PR TITLE
Fix some of the issues found by dialyzer

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -31,7 +31,7 @@
           acl :: acl()}).
 
 -record(moss_bucket_v1, {
-          name :: string(),
+          name :: string() | binary(),
           last_action :: created | deleted,
           creation_date :: string(),
           modification_time :: erlang:timestamp(),

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -120,6 +120,14 @@ mark_as_scheduled_delete({error, _}=Error, _, _, _, _) ->
 %% @doc Call a `riak_cs_manifest_utils' function on a set of manifests
 %% to update the state of the manifests specified by `UUIDsToMark'
 %% and then write the updated values to riak.
+-spec mark_manifests(Response ::
+                     {ok, riakc_obj:riak_object(), [{binary(), lfs_manifest()}]} |
+                     {error, term()},
+                     UUIDsToMark :: [binary()],
+                     ManiFunction :: fun(),
+                     RiakcPid :: pid()) ->
+                    {ok, orddict:orddict()} |
+                    {error, term()}.
 mark_manifests({ok, RiakObject, Manifests}, UUIDsToMark, ManiFunction, RiakcPid) ->
     Marked = ManiFunction(Manifests, UUIDsToMark),
     UpdObj = riakc_obj:update_value(RiakObject, term_to_binary(Marked)),

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -439,12 +439,13 @@ pause_gc(State, StateData) ->
     _ = lager:info("Pausing garbage collection"),
     StateData#state{pause_state=State}.
 
+-spec cancel_timer(timeout(), timer:tref()) -> timeout() | undefined.
 cancel_timer(_, undefined) ->
     undefined;
 cancel_timer(infinity, TimerRef) ->
     %% Cancel the timer in case the interval has
     %% recently be set to `infinity'.
-    erlang:cancel_timer(TimerRef),
+    _ = erlang:cancel_timer(TimerRef),
     undefined;
 cancel_timer(_, TimerRef) ->
     handle_cancel_timer(erlang:cancel_timer(TimerRef)).

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -60,7 +60,7 @@
                 free_writers :: undefined | ordsets:ordset(pid()),
                 unacked_writes=ordsets:new() :: ordsets:ordset(non_neg_integer()),
                 next_block_id=0 :: non_neg_integer(),
-                all_writer_pids=[] :: list(pid())}).
+                all_writer_pids :: undefined | list(pid())}).
 
 %%%===================================================================
 %%% API
@@ -558,7 +558,7 @@ maybe_stop_manifest_fsm(ManiPid) ->
     riak_cs_manifest_fsm:stop(ManiPid),
     ok.
 
--spec maybe_stop_block_servers(undefined | pid()) -> ok.
+-spec maybe_stop_block_servers(undefined | [pid()]) -> ok.
 maybe_stop_block_servers(undefined) ->
     ok;
 maybe_stop_block_servers(BlockServerPids) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -193,7 +193,7 @@ delete_bucket(User, UserObj, Bucket, RiakPid) ->
     end.
 
 %% @doc Mark all active manifests as pending_delete.
--spec delete_object(binary(), binary(), pid()) -> ok | {error, term()}.
+-spec delete_object(binary(), binary(), pid()) -> ok | {error, notfound}.
 delete_object(Bucket, Key, RiakcPid) ->
     StartTime = os:timestamp(),
     case get_manifests(RiakcPid, Bucket, Key) of
@@ -207,7 +207,7 @@ delete_object(Bucket, Key, RiakcPid) ->
                                     RiakObject,
                                     RiakcPid),
             ok = riak_cs_stats:update_with_start(object_delete, StartTime);
-        {error, _}=Error ->
+        {error, notfound}=Error ->
             Error
     end.
 

--- a/src/riak_cs_wm_key.erl
+++ b/src/riak_cs_wm_key.erl
@@ -285,10 +285,7 @@ delete_resource(RD, Ctx=#key_context{bucket=Bucket,
         {error, notfound} ->
             %% it's not there; consider the delete successful
             DCode = 0,
-            ok;
-        {error, _Reason} ->
-            DCode = -1,
-            riak_cs_s3_response:api_error(delete_failed, RD, Ctx)
+            ok
     end,
     dt_return(<<"delete_resource">>, [DCode], [UserName, BFile_str]),
     dt_return_object(<<"file_delete">>, [DCode], [UserName, BFile_str]),


### PR DESCRIPTION
I've been running dialyzer like so:

`dialyzer -Wno_return -Wunmatched_returns --plt ~/.riak-cs_dialyzer_plt ebin | fgrep -v -f ./dialyzer.ignore-warnings`

notice I'm ignoring deps for now. Each commit should be an explanation of the error dialyzer found.
