### PR TITLE
Fix sbin scripts and reltool misconfiguration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ stagedevrel: dev1 dev2 dev3 dev4
 rtdevrel: rtdev1 rtdev2 rtdev3 rtdev4 rtdev5 rtdev6
 
 rtdev1 rtdev2 rtdev3 rtdev4 rtdev5 rtdev6:
+	$(if $(RT_TARGET_CS),,$(error "RT_TARGET_CS var not set, see riak_test/ directory for details"))
 	mkdir -p $(RT_TARGET_CS)/$@
 	 (cd rel && ../rebar generate skip_deps=true target_dir=$(RT_TARGET_CS)/$@ overlay_vars=vars/$@_vars.config)
 

--- a/priv/sbin/riak-cs-access
+++ b/priv/sbin/riak-cs-access
@@ -1,23 +1,20 @@
-#!/bin/bash
+#!/bin/sh
 
 # Pull environment for this install
-source {{runner_bin_dir}}/lib/env.sh
+. "{{runner_base_dir}}/lib/env.sh"
 
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@
 
 # Make sure CWD is set to runner run dir
-cd $RUNNER_RUN_DIR
+cd $RUNNER_BASE_DIR
 
 # Check the first argument for instructions
 case "$1" in
     flush)
         # Make sure the local node IS running
-        RES=`$NODETOOL ping`
-        if [ "$RES" != "pong" ]; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        node_up_check
+
         shift
 
         $NODETOOL rpc riak_cs_access_console flush $@

--- a/priv/sbin/riak-cs-gc
+++ b/priv/sbin/riak-cs-gc
@@ -1,23 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
 # Pull environment for this install
-source {{runner_bin_dir}}/lib/env.sh
+. "{{runner_base_dir}}/lib/env.sh"
 
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@
 
 # Make sure CWD is set to runner run dir
-cd $RUNNER_RUN_DIR
+cd $RUNNER_BASE_DIR
 
 # Check the first argument for instructions
 case "$1" in
     batch|status|pause|resume|cancel|set-interval)
         # Make sure the local node IS running
-        RES=`$NODETOOL ping`
-        if [ "$RES" != "pong" ]; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        node_up_check
 
         $NODETOOL rpc riak_cs_gc_console $@
         ;;

--- a/priv/sbin/riak-cs-storage
+++ b/priv/sbin/riak-cs-storage
@@ -1,23 +1,19 @@
-#!/bin/bash
+#!/bin/sh
 
 # Pull environment for this install
-source {{runner_bin_dir}}/lib/env.sh
+. "{{runner_base_dir}}/lib/env.sh"
 
 # Make sure the user running this script is the owner and/or su to that user
 check_user $@
 
 # Make sure CWD is set to runner run dir
-cd $RUNNER_RUN_DIR
+cd $RUNNER_BASE_DIR
 
 # Check the first argument for instructions
 case "$1" in
     batch|status|pause|resume|cancel)
         # Make sure the local node IS running
-        RES=`$NODETOOL ping`
-        if [ "$RES" != "pong" ]; then
-            echo "Node is not running!"
-            exit 1
-        fi
+        node_up_check
 
         $NODETOOL rpc riak_cs_storage_console $@
         ;;

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -43,7 +43,11 @@
 {overlay_vars, "vars.config"}.
 
 {overlay, [
+           %% Setup basic dirs that packaging requires
            {mkdir, "log"},
+           {mkdir, "data/riak-cs"},
+
+           %% Copy base files for starting and interacting w/ node
            {copy, "../deps/node_package/priv/base/erl",
                   "{{erts_vsn}}/bin/erl"},
            {copy, "../deps/node_package/priv/base/nodetool",
@@ -52,10 +56,16 @@
                   "sbin/riak-cs"},
            {template, "../deps/node_package/priv/base/env.sh",
                   "lib/env.sh"},
+
+           %% Copy config files
            {template, "files/app.config", "etc/app.config"},
-                      {template, "files/vm.args", "etc/vm.args"},
+           {template, "files/vm.args", "etc/vm.args"},
+
+           %% Copy SSL Certs
            {template, "files/cert.pem", "etc/cert.pem"},
            {template, "files/key.pem", "etc/key.pem"},
+
+           %% Copy additional sbin scripts
            {template, "../priv/sbin/riak-cs-access", "sbin/riak-cs-access"},
            {template, "../priv/sbin/riak-cs-storage", "sbin/riak-cs-storage"},
            {template, "../priv/sbin/riak-cs-gc", "sbin/riak-cs-gc"}

--- a/rel/vars/rtdev1_vars.config
+++ b/rel/vars/rtdev1_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/rtdev2_vars.config
+++ b/rel/vars/rtdev2_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/rtdev3_vars.config
+++ b/rel/vars/rtdev3_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/rtdev4_vars.config
+++ b/rel/vars/rtdev4_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/rtdev5_vars.config
+++ b/rel/vars/rtdev5_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.

--- a/rel/vars/rtdev6_vars.config
+++ b/rel/vars/rtdev6_vars.config
@@ -34,10 +34,9 @@
 %% bin/riak_cs
 %%
 {data_dir,           "{{target_dir}}/data"}.
-{runner_script_dir,  "{{target_dir}}/sbin"}.
-{runner_bin_dir,     "{{target_dir}}"}.
-{runner_run_dir,     "{{target_dir}}"}.
-{runner_etc_dir,     "{{target_dir}}/etc"}.
-{runner_log_dir,     "{{target_dir}}/log"}.
+{runner_script_dir,  "$(cd ${0%/*} && pwd)"}.
+{runner_base_dir,    "{{runner_script_dir}}/.."}.
+{runner_etc_dir,     "$RUNNER_BASE_DIR/etc"}.
+{runner_log_dir,     "$RUNNER_BASE_DIR/log"}.
 {pipe_dir,           "/tmp/$RUNNER_BASE_DIR/"}.
 {runner_user,        ""}.


### PR DESCRIPTION
Additional shell scripts with variable substitutions existed in the `priv/sbin` directory that I missed when updating node_package directories and scripts.   I updated this to fall in line with the runner script `sbin/riak-cs`.

Also, in an a horrible attempt to clean up after riak-cs 1.1, I removed the empty directory `data/riak-cs` from `reltool.config` and that broke packaging.  Going forward I would like to have that configurable in node_package, but for now putting that directory back is the better fix.
