### PR TITLE
403 instead of 404 returned when trying to list nonexistent bucket

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -22,18 +22,18 @@
 ]}.
 
 {deps, [
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {branch, "master"}}},
+        {node_package, "1.1.*", {git, "git://github.com/basho/node_package", {tag, "1.1.0"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "wrd-content-length-with-streaming"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
-        {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},
-        {sext, ".*", {git, "git://github.com/esl/sext", "master"}},
+        {riakc, "1.3.1", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.1"}}},
+        {lager, "1.2.*", {git, "git://github.com/basho/lager", {tag, "1.2.0"}}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", {tag, "3280b736"}}},
+        {sext, ".*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {branch, "master"}}},
-        {stanchion, ".*", {git, "git@github.com:basho/stanchion", {branch, "master"}}},
-        {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
-        {folsom, ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},
-        {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{branch,"master"}}},
+        {stanchion, "1.2.*", {git, "git@github.com:basho/stanchion", {branch, "1.2"}}},
+        {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", {tag, "0.8.1"}}},
+        {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7"}}},
+        {erlcloud, "0.4.*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},
+        {riak_repl_pb_api,"0.1.0",{git,"git@github.com:basho/riak_repl_pb_api.git",{tag,"0.1.0"}}},
         {riak_test, ".*", {git, "git@github.com:/basho/riak_test", {branch, "master"}}}
        ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -33,8 +33,7 @@
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", {tag, "0.8.1"}}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7"}}},
         {erlcloud, "0.4.*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},
-        {riak_repl_pb_api,"0.1.0",{git,"git@github.com:basho/riak_repl_pb_api.git",{tag,"0.1.0"}}},
-        {riak_test, ".*", {git, "git@github.com:/basho/riak_test", {branch, "master"}}}
+        {riak_repl_pb_api,"0.1.0",{git,"git@github.com:basho/riak_repl_pb_api.git",{tag,"0.1.0"}}}
        ]}.
 
 {plugins, [rebar_riak_test_plugin]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 {sys, [
        {lib_dirs, ["../deps", "../apps"]},
-       {rel, "riak-cs", "1.1.0",
+       {rel, "riak-cs", "1.2.0",
         [
          kernel,
          stdlib,

--- a/src/riak_cs.app.src
+++ b/src/riak_cs.app.src
@@ -2,7 +2,7 @@
 {application, riak_cs,
  [
   {description, "riak_cs"},
-  {vsn, "1.1.0"},
+  {vsn, "1.2.0"},
   {modules, []},
   {registered, []},
   {applications, [

--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -119,7 +119,7 @@ bucket_access(Bucket, RequestedAccess, CanonicalId, RiakPid) ->
 %% @doc Get the ACL for a bucket
 -spec bucket_acl(binary(), pid()) -> {ok, acl()} | {error, term()}.
 bucket_acl(Bucket, RiakPid) ->
-    case riak_cs_utils:get_object(?BUCKETS_BUCKET, Bucket, RiakPid) of
+    case riak_cs_utils:check_bucket_exists(Bucket, RiakPid) of
         {ok, Obj} ->
             %% For buckets there will not be siblings.
             MD = riakc_obj:get_metadata(Obj),


### PR DESCRIPTION
Adds a check when a valid user account attempts to list a bucket so that a `404` is returned if the bucket does not exist in the system. If the bucket does exist the system continues to return a `403`. Also adds a `check_bucket_exists` helper function to the `riak_cs_utils` module.
