### PR TITLE
Add prereduce to storage calculation

### DIFF
--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -52,7 +52,7 @@ sum_bucket(Riak, Bucket) when is_list(Bucket) ->
 sum_bucket(Riak, Bucket) when is_binary(Bucket) ->
     FullBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
     Query = [{map, {modfun, riak_cs_storage, object_size_map},
-              none, false},
+              [do_prereduce], false},
              {reduce, {modfun, riak_cs_storage, object_size_reduce},
               none, true}],
     case riakc_pb_socket:mapred(Riak, FullBucket, Query) of


### PR DESCRIPTION
In my trivial test, the storage calculation for a bucket with 100K objects was reduced from 7s to 3s on a 6 node 256 partition cluster on physical hardware.
