### PR TITLE
Delete manifests with a vector clock

### DIFF
--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -259,8 +259,7 @@ get_and_delete(RiakcPid, UUID, Bucket, Key) ->
             UpdatedManifests = orddict:erase(UUID, ResolvedManifests),
             case UpdatedManifests of
                 [] ->
-                    ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
-                    riakc_pb_socket:delete(RiakcPid, ManifestBucket, Key);
+                    riakc_pb_socket:delete_obj(RiakcPid, RiakObject);
                 _ ->
                     ObjectToWrite =
                         riakc_obj:update_value(RiakObject,


### PR DESCRIPTION
Previously we deleted just by BKey. We should've been
using the vector clock from the object.
