### PR TITLE
object with utf-8 unicode key can't be listed nor got

### DIFF
--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -119,7 +119,11 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
     %% in `riak_cs_lfs_utils' to determine if the object
     %% associated with each key is an `lfs_manifest' or not.
     Contents = [begin
-                    KeyString = binary_to_list(Key),
+                    % Key is just not a unicode string but just a
+                    % raw binary like <<229,159,188,231,142,137>>.
+                    % we need to convert to unicode string like [22524,29577].
+                    % this does not affect ascii characters.
+                    KeyString = unicode:characters_to_list(Key, unicode),
                     case ObjResp of
                         {ok, Manifest} ->
                             Size = integer_to_list(
@@ -159,7 +163,7 @@ user_to_xml_owner(?RCS_USER{canonical_id=CanonicalId, display_name=Name}) ->
 
 export_xml(XmlDoc) ->
     unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
 
 %% @doc Convert an error code string into its corresponding atom
 -spec error_code_to_atom(string()) -> atom().


### PR DESCRIPTION
- put a utf-8 named file => [ok]
- ls the bucket => returns bad name
- get the object => error

> $ s3cmd -c ~/local.s3cfg put UTF-8ファイル.txt s3://basho.co.jp
> UTF-8ファイル.txt -> s3://basho.co.jp/UTF-8ファイル.txt  [1 of 1]
>  9 of 9   100% in    0s   280.78 B/s  done
> $ s3cmd -c ~/local.s3cfg ls s3://basho.co.jp  
> 2012-10-30 08:55         9   s3://basho.co.jp/UTF-8ãã¡ã¤ã«.txt
> $ s3cmd -c ~/local.s3cfg get s3://basho.co.jp/UTF-8ファイル.txt    
> 
> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
>     An unexpected error has occurred.
>   Please report the following lines to:
>    s3tools-bugs@lists.sourceforge.net
> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
> 
> Problem: UnicodeEncodeError: 'ascii' codec can't encode characters in position 22-25: ordinal not in range(128)
> S3cmd:   1.0.1
> 
> Traceback (most recent call last):
>   File "/opt/local/bin/s3cmd", line 2006, in <module>
>     main()
>   File "/opt/local/bin/s3cmd", line 1950, in main
>     cmd_func(args)
>   File "/opt/local/bin/s3cmd", line 439, in cmd_object_get
>     remote_list = fetch_remote_list(args, require_attribs = False)
>   File "/opt/local/bin/s3cmd", line 281, in fetch_remote_list
>     uri_str = str(uri)
> UnicodeEncodeError: 'ascii' codec can't encode characters in position 22-25: ordinal not in range(128)

The original filename was:  e383 95e3 82a1 e382 a4e3 83ab (ファイル)
The filename got by ls was: c3 a3c2 83c2 95c3 a3c2 82c2 a1c3 a3c2 82c2 a4c3 a3c2 83c2 ab

and 

> > > u"ファイル"
> > > u'\u30d5\u30a1\u30a4\u30eb'
> > > u"ファイル".encode("utf-8")
> > > '\xe3\x83\x95\xe3\x82\xa1\xe3\x82\xa4\xe3\x83\xab'
> > > u"ファイル".encode("utf-8").decode("latin-1")
> > > u'\xe3\x83\x95\xe3\x82\xa1\xe3\x82\xa4\xe3\x83\xab'
> > > u"ファイル".encode("utf-8").decode("latin-1").encode("utf-8")
> > > '\xc3\xa3\xc2\x83\xc2\x95\xc3\xa3\xc2\x82\xc2\xa1\xc3\xa3\xc2\x82\xc2\xa4\xc3\xa3\xc2\x83\xc2\xab'

So, the problem seems: Riak or Riak CS the UTF-8 string encodes again to UTF-8.
