### PR TITLE
Speed up bucket_empty check and fix process leak

### DIFF
--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -78,17 +78,8 @@ get_all_manifests(Pid) ->
     gen_fsm:sync_send_event(Pid, get_manifests, infinity).
 
 get_active_manifest(Pid) ->
-    case gen_fsm:sync_send_event(Pid, get_manifests, infinity) of
-        {ok, Manifests} ->
-            case riak_cs_manifest_utils:active_manifest(Manifests) of
-                {ok, _Active}=ActiveReply ->
-                    ActiveReply;
-                {error, no_active_manifest} ->
-                    {error, notfound}
-            end;
-        {error, notfound}=NotFound ->
-            NotFound
-    end.
+    Response = gen_fsm:sync_send_event(Pid, get_manifests, infinity),
+    riak_cs_utils:active_manifest_from_response(Response).
 
 get_specific_manifest(Pid, UUID) ->
     case gen_fsm:sync_send_event(Pid, get_manifests, infinity) of


### PR DESCRIPTION
A bucket is empty if at least one key has an
active manifest. Previously we'd list all the keys
in the bucket and then check _each_ one to see
if it's manifest was active. If the resulting
list was empty, the bucket was empty. Otherwise
it was not empty. This change takes advantage
of `lists:any/2` being lazy. Once the predicate
has returned `true` for a single item, it bails
out of the recursion. This patch also doesn't
use the manifest fsm, and just does a get directly
to the key and uses the pure manifest utilities
to decide if there's an active manifest or not.
We also add some helper functions, which are then
ported to be used in the manifest fsm.

This bug was originally found when a user
was having trouble with `s3cmd rb :s3//foo --recursive`.
The operation first tries to delete the (potentially large)
bucket, which triggers our bucket empty check. If the
bucket has more than 32k items, we run out of processes
unless +P is set higher (because of the leak).
