### PR TITLE
Adjust the timeouts on the riak_cs_get_fsm_test.

### DIFF
--- a/test/riak_cs_get_fsm_test.erl
+++ b/test/riak_cs_get_fsm_test.erl
@@ -32,7 +32,7 @@ get_fsm_test_() ->
      fun teardown/1,
      [
       fun receives_manifest/0,
-      [{timeout, 5 + (X / 20), test_n_chunks_builder(X)} || X <- [1,2,5,9,100,1000]]
+      [{timeout, 30 + (X / 5), test_n_chunks_builder(X)} || X <- [1,2,5,9,100,1000]]
      ]}.
 
 calc_block_size(ContentLength, NumBlocks) ->


### PR DESCRIPTION
Increase the timeouts for the get_fsm test to be more forgiving on slower or busy systems.
