### PR TITLE
Never send stop message to undefined pid in terminate

### DIFF
--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -18,6 +18,7 @@
          get_block/5, get_block/6,
          put_block/6,
          delete_block/5,
+         maybe_stop_block_servers/1,
          stop/1]).
 
 %% gen_server callbacks
@@ -98,6 +99,13 @@ put_block(Pid, Bucket, Key, UUID, BlockNumber, Value) ->
 -spec delete_block(pid(), binary(), binary(), binary(), pos_integer()) -> ok.
 delete_block(Pid, Bucket, Key, UUID, BlockNumber) ->
     gen_server:cast(Pid, {delete_block, self(), Bucket, Key, UUID, BlockNumber}).
+
+-spec maybe_stop_block_servers(undefined | [pid()]) -> ok.
+maybe_stop_block_servers(undefined) ->
+    ok;
+maybe_stop_block_servers(BlockServerPids) ->
+    _ = [stop(P) || P <- BlockServerPids],
+    ok.
 
 stop(Pid) ->
     gen_server:call(Pid, stop, infinity).

--- a/src/riak_cs_get_fsm.erl
+++ b/src/riak_cs_get_fsm.erl
@@ -363,14 +363,8 @@ handle_info(_Info, _StateName, StateData) ->
 terminate(_Reason, _StateName, #state{test=false,
                                       all_reader_pids=BlockServerPids,
                                       mani_fsm_pid=ManiPid}) ->
-
-    riak_cs_manifest_fsm:stop(ManiPid),
-    _ = case BlockServerPids of
-            undefined ->
-                ok;
-            _ ->
-                [riak_cs_block_server:stop(P) || P <- BlockServerPids]
-        end,
+    riak_cs_manifest_fsm:maybe_stop_manifest_fsm(ManiPid),
+    riak_cs_block_server:maybe_stop_block_servers(BlockServerPids),
     ok;
 terminate(_Reason, _StateName, #state{test=true,
                                       free_readers=ReaderPids}) ->

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -29,6 +29,7 @@
          delete_specific_manifest/2,
          update_manifest_with_confirmation/2,
          update_manifests_with_confirmation/2,
+         maybe_stop_manifest_fsm/1,
          stop/1]).
 
 %% gen_fsm callbacks
@@ -130,6 +131,13 @@ update_manifests_with_confirmation(Pid, Manifests) ->
 update_manifest_with_confirmation(Pid, Manifest) ->
     Dict = riak_cs_manifest_utils:new_dict(Manifest?MANIFEST.uuid, Manifest),
     update_manifests_with_confirmation(Pid, Dict).
+
+-spec maybe_stop_manifest_fsm(undefined | pid()) -> ok.
+maybe_stop_manifest_fsm(undefined) ->
+    ok;
+maybe_stop_manifest_fsm(ManiPid) ->
+    stop(ManiPid),
+    ok.
 
 stop(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, stop, infinity).

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -292,8 +292,8 @@ handle_info({'DOWN', CallerRef, process, _Pid, Reason}, _StateName, State=#state
 %%--------------------------------------------------------------------
 terminate(_Reason, _StateName, #state{mani_pid=ManiPid,
                                       all_writer_pids=BlockServerPids}) ->
-    maybe_stop_manifest_fsm(ManiPid),
-    maybe_stop_block_servers(BlockServerPids),
+    riak_cs_manifest_fsm:maybe_stop_manifest_fsm(ManiPid),
+    riak_cs_block_server:maybe_stop_block_servers(BlockServerPids),
     ok.
 
 %%--------------------------------------------------------------------
@@ -551,16 +551,3 @@ handle_receiving_last_chunk(NewData, State=#state{buffer_queue=BufferQueue,
     Reply = ok,
     {reply, Reply, all_received, NewStateData}.
 
--spec maybe_stop_manifest_fsm(undefined | pid()) -> ok.
-maybe_stop_manifest_fsm(undefined) ->
-    ok;
-maybe_stop_manifest_fsm(ManiPid) ->
-    riak_cs_manifest_fsm:stop(ManiPid),
-    ok.
-
--spec maybe_stop_block_servers(undefined | [pid()]) -> ok.
-maybe_stop_block_servers(undefined) ->
-    ok;
-maybe_stop_block_servers(BlockServerPids) ->
-    _ = [riak_cs_block_server:stop(P) || P <- BlockServerPids],
-    ok.


### PR DESCRIPTION
Add helper functions to repsective modules to allow
termination of servers, when the value may not have
been initialized yet.
