### PR TITLE
Clean up and fix edge case in GC moving

### DIFF
--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -280,7 +280,7 @@ get_and_update(RiakcPid, WrappedManifests, Bucket, Key) ->
     case riak_cs_utils:get_manifests(RiakcPid, Bucket, Key) of
         {ok, RiakObject, Manifests} ->
             NewManiAdded = riak_cs_manifest_resolution:resolve([WrappedManifests, Manifests]),
-            OverwrittenUUIDs = riak_cs_manifest_utils:overwritten_UUIDs(Manifests),
+            OverwrittenUUIDs = riak_cs_manifest_utils:overwritten_UUIDs(NewManiAdded),
             Result = case OverwrittenUUIDs of
                 [] ->
                     ObjectToWrite = riakc_obj:update_value(RiakObject,

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -82,7 +82,7 @@ overwritten_UUIDs_no_active_fold({UUID, _}, Acc) ->
 -spec overwritten_UUIDs_active_fold_helper(lfs_manifest()) ->
     fun(({binary(), lfs_manifest()}, [binary()]) -> [binary()]).
 overwritten_UUIDs_active_fold_helper(Active) ->
-    fun ({UUID, Manifest}, Acc) ->
+    fun({UUID, Manifest}, Acc) ->
             case {UUID, Manifest} of
                 {_UUID, Active} ->
                     Acc;
@@ -163,7 +163,7 @@ manifests_to_gc(PendingDeleteUUIDs, Manifests) ->
 -spec pending_delete_helper([binary()]) ->
     fun((binary(), lfs_manifest()) -> boolean()).
 pending_delete_helper(UUIDs) ->
-    fun (Key, Manifest) ->
+    fun(Key, Manifest) ->
             lists:member(Key, UUIDs) orelse retry_manifest(Manifest)
     end.
 
@@ -202,8 +202,8 @@ prune(Dict, Time) ->
 
 -spec upgrade_wrapped_manifests([orddict:orddict()]) -> [orddict:orddict()].
 upgrade_wrapped_manifests(ListofOrdDicts) ->
-    DictMapFun = fun (_Key, Value) -> upgrade_manifest(Value) end,
-    MapFun = fun (Value) -> orddict:map(DictMapFun, Value) end,
+    DictMapFun = fun(_Key, Value) -> upgrade_manifest(Value) end,
+    MapFun = fun(Value) -> orddict:map(DictMapFun, Value) end,
     lists:map(MapFun, ListofOrdDicts).
 
 %% @doc Upgrade the manifest to the most recent
@@ -261,7 +261,7 @@ upgrade_manifest(?MANIFEST{}=M) ->
 -spec filter_manifests_by_state(orddict:orddict(), [atom()]) -> orddict:orddict().
 filter_manifests_by_state(Dict, AcceptedStates) ->
     AcceptManifest =
-        fun (_, ?MANIFEST{state=State}) ->
+        fun(_, ?MANIFEST{state=State}) ->
                 lists:member(State, AcceptedStates)
         end,
     orddict:filter(AcceptManifest, Dict).


### PR DESCRIPTION
Previously the manifests marked as scheduled
delete and moved to GC bucket would be any
in the `pending_delete` state. This was for
two reasons. One, `handle_mark_as_pending_delete`
would grab the `pending_delete` manifests based
on observing all the manifests, not just the
specific UUIDs passed in. Two, `pending_delete_manifest/2`
assumed that manifests were updated as their blocks were deleted.
This was based on an outdated view of GC. Now, the manifests
are copied into the GC bucket the GC daemon views and manipulates
them from this bucket.

This change makes it so that the manifests that are moved
to the GC bucket are:
1. the UUIDs passed into the GC function to begin with
2. any `pending_delete` manifests that appear to have been abandoned.
   This means manifests that were put into the `pending_delete` state
   but were never (or likely never) successfully moved to the GC bucket
   and marked as `scheduled_delete`.
