### PR TITLE
Better handling of anonymous GET Service requests

### DIFF
--- a/src/riak_cs_wm_service.erl
+++ b/src/riak_cs_wm_service.erl
@@ -41,7 +41,7 @@ malformed_request(RD, Ctx) ->
 %%      but this is how S3 does things.
 forbidden(RD, Ctx) ->
     dt_entry(<<"forbidden">>),
-    case riak_cs_wm_utils:find_and_auth_user(RD, Ctx, fun auth_complete/2) of
+    case riak_cs_wm_utils:find_and_auth_user(RD, Ctx, fun auth_complete/2, false) of
         {false, _RD2, Ctx2} = FalseRet ->
             dt_return(<<"forbidden">>, [], [extract_name(Ctx2#context.user), <<"false">>]),
             FalseRet;


### PR DESCRIPTION
Anonymous service-level requests should be denied to avoid unnecessary error messages trying to list the buckets owned by an undefined user.
