### PR TITLE
Fix riak_moss_* module name reintroduced

### DIFF
--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -278,8 +278,8 @@ filter_manifests_by_state(Dict, AcceptedStates) ->
 leeway_elapsed(undefined) ->
     false;
 leeway_elapsed(Timestamp) ->
-    Now = riak_moss_utils:timestamp(os:timestamp()),
-    Now > (riak_moss_utils:timestamp(Timestamp) + riak_cs_gc:leeway_seconds()).
+    Now = riak_cs_utils:timestamp(os:timestamp()),
+    Now > (riak_cs_utils:timestamp(Timestamp) + riak_cs_gc:leeway_seconds()).
 
 orddict_values(OrdDict) ->
     [V || {_K, V} <- orddict:to_list(OrdDict)].


### PR DESCRIPTION
I accidently reintroduced riak_moss_utils in
026615d04b76cf537843a50c9fa3919c743344ef. Fix that.
