### PR TITLE
Don't use repository snapshots

### DIFF
--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,11 +1,11 @@
-(defproject java-s3-tests/java-s3-tests "0.0.1-SNAPSHOT" 
+(defproject java-s3-tests/java-s3-tests "0.0.1"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [com.amazonaws/aws-java-sdk "1.3.11"]
-                 [com.reiddraper/clj-aws-s3 "0.4.0-SNAPSHOT"]
+                 [com.reiddraper/clj-aws-s3 "0.4.0"]
                  [commons-codec/commons-codec "1.6"]
                  [clj-http "0.4.3"]
                  [cheshire "4.0.0"]]
   :profiles {:dev {:dependencies [[midje "1.4.0"]]}}
   :min-lein-version "2.0.0"
-  :plugins [[lein-midje "2.0.0-SNAPSHOT"]]
+  :plugins [[lein-midje "2.0.1"]]
   :description "integration tests for Riak CS using the offical Java SDK")


### PR DESCRIPTION
This specifies specific revisions and means you
can use the tests offline as long as your maven
cache has been populated (ie. you've run the tests
at least once before)
