### PR TITLE
Made webmachine log directory configurable through parameter http_logdir

### DIFF
--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -48,6 +48,12 @@ init([]) ->
         undefined ->
             Port = 80
     end,
+    case application:get_env(riak_cs, http_logdir) of
+        {ok, WebLogDir} ->
+            ok = filelib:ensure_dir(WebLogDir);
+        undefined ->
+            WebLogDir = "log"
+    end,
 
     %% Create child specifications
     WebConfig1 = [
@@ -55,7 +61,7 @@ init([]) ->
                  {ip, Ip},
                  {port, Port},
                  {nodelay, true},
-                 {log_dir, "log"},
+                 {log_dir, WebLogDir},
                  {rewrite_module, riak_cs_wm_rewrite},
                  {error_handler, riak_cs_wm_error_handler}],
     case application:get_env(riak_cs, ssl) of


### PR DESCRIPTION
I received a client request to make the Riak-CS http log directory configurable (ZenDesk ticket 3434). I updated riak_cs_sup.erl to look for environment variable 'http_logdir' (seemed to follow convention used in riak_core). Is this an acceptable solution?

The client is using Riak-CS 1.2.1 and have requested a patch.
