### PR TITLE
Resource element content in error document is not S3 API resource

### DIFF
--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -89,12 +89,12 @@ api_error(Error, ReqData, Ctx) when is_atom(Error); is_tuple(Error) ->
                    ReqData, Ctx).
 
 error_response(StatusCode, Code, Message, RD, Ctx) ->
+    {OrigResource, _} = riak_cs_s3_rewrite:original_resource(RD),
     XmlDoc = [{'Error', [{'Code', [Code]},
                          {'Message', [Message]},
-                         {'Resource', [wrq:path(RD)]},
+                         {'Resource', [string:strip(OrigResource, right, $/)]},
                          {'RequestId', [""]}]}],
     respond(StatusCode, export_xml(XmlDoc), RD, Ctx).
-
 
 list_all_my_buckets_response(User, RD, Ctx) ->
     BucketsDoc =


### PR DESCRIPTION
After the change to rewrite the S3 URLs the rewritten path is being used as the content for the Resource element in S3 error responses.  Change to using the original resource with any trailing slashes removed instead.

The `cs347_regression_test` failure should be fixed by this change.
