### PR TITLE
Replace stanchion dep with velvet

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,7 +29,7 @@
         {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},
         {sext, ".*", {git, "git://github.com/esl/sext", "master"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {branch, "master"}}},
-        {stanchion, ".*", {git, "git@github.com:basho/stanchion", {branch, "master"}}},
+        {velvet, ".*", {git, "git@github.com:basho/velvet", {branch, "master"}}},
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", {branch, "master"}}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {branch, "master"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {branch, "master"}}},


### PR DESCRIPTION
Change `rebar.config` to use `velvet`, the `stanchion` client as a dep instead of `stanchion` itself.

New repo for the velvet client lib is [here](https://github.com/basho/velvet)

_Note:_ The `velvet` repo is not in its final state yet. This is just an intermediate step and more refactoring is on the way.
