### PR TITLE
URL rewriting fails for buckets containing '.'

### DIFF
--- a/test/riak_cs_gen.erl
+++ b/test/riak_cs_gen.erl
@@ -14,6 +14,7 @@
 
 %% Generators
 -export([bucket/0,
+         bucket_or_blank/0,
          file_name/0,
          block_size/0,
          content_length/0,
@@ -31,6 +32,9 @@
 
 bucket() ->
     non_blank_string().
+
+bucket_or_blank() ->
+    maybe_blank_string().
 
 file_name() ->
     non_blank_string().
@@ -77,7 +81,10 @@ bounded_non_zero_nums() ->
     ?LET(X, not_zero(int()), X * 100000).
 
 non_blank_string() ->
-    ?LET(X,not_empty(list(lower_char())), list_to_binary(X)).
+    ?LET(X, not_empty(list(lower_char())), list_to_binary(X)).
+
+maybe_blank_string() ->
+    ?LET(X, list(lower_char()), list_to_binary(X)).
 
 %% Generate a lower 7-bit ACSII character that should not cause any problems
 %% with utf8 conversion.

--- a/test/riak_cs_s3_rewrite_eqc.erl
+++ b/test/riak_cs_s3_rewrite_eqc.erl
@@ -42,17 +42,17 @@ eqc_test_() ->
 %% ====================================================================
 
 prop_extract_bucket_from_host() ->
-    ?FORALL({Bucket, BaseHost},{riak_cs_gen:bucket_or_blank(), base_host()},
+    ?FORALL({Bucket, BaseHost},
+            {riak_cs_gen:bucket_or_blank(), base_host()},
+    ?IMPLIES(nomatch == re:run(Bucket, ":", [{capture, first}]),
             begin
                 BucketStr = binary_to_list(Bucket),
                 Host = compose_host(BucketStr, BaseHost),
-                BaseHostIdx = string:str(Host, BaseHost),
                 ExpectedBucket = expected_bucket(BucketStr, BaseHost),
                 ResultBucket =
-                    riak_cs_s3_rewrite:extract_bucket_from_host(Host,
-                                                                BaseHostIdx),
+                    riak_cs_s3_rewrite:bucket_from_host(Host, BaseHost),
                 equals(ExpectedBucket, ResultBucket)
-            end).
+            end)).
 
 %%====================================================================
 %% Helpers

--- a/test/riak_cs_s3_rewrite_eqc.erl
+++ b/test/riak_cs_s3_rewrite_eqc.erl
@@ -1,0 +1,84 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Quickcheck test module for `riak_cs_s3_rewrite'.
+
+-module(riak_cs_s3_rewrite_eqc).
+
+-include("riak_cs.hrl").
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% eqc property
+-export([prop_extract_bucket_from_host/0]).
+
+%% Helpers
+-export([test/0,
+         test/1]).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+-define(TEST_ITERATIONS, 1000).
+
+%%====================================================================
+%% Eunit tests
+%%====================================================================
+
+eqc_test_() ->
+    {spawn,
+     [
+      {timeout, 30, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_extract_bucket_from_host()))))}
+     ]
+    }.
+
+%% ====================================================================
+%% EQC Properties
+%% ====================================================================
+
+prop_extract_bucket_from_host() ->
+    ?FORALL({Bucket, BaseHost},{riak_cs_gen:bucket_or_blank(), base_host()},
+            begin
+                BucketStr = binary_to_list(Bucket),
+                Host = compose_host(BucketStr, BaseHost),
+                BaseHostIdx = string:str(Host, BaseHost),
+                ExpectedBucket = expected_bucket(BucketStr, BaseHost),
+                ResultBucket =
+                    riak_cs_s3_rewrite:extract_bucket_from_host(Host,
+                                                                BaseHostIdx),
+                equals(ExpectedBucket, ResultBucket)
+            end).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+test() ->
+    test(500).
+
+test(Iterations) ->
+    eqc:quickcheck(eqc:numtests(Iterations, prop_extract_bucket_from_host())).
+
+base_host() ->
+    oneof(["s3.amazonaws.com", "riakcs.net", "snarf", "hah-hah", ""]).
+
+compose_host([], BaseHost) ->
+    BaseHost;
+compose_host(Bucket, []) ->
+    Bucket;
+compose_host(Bucket, BaseHost) ->
+    Bucket ++ "." ++  BaseHost.
+
+expected_bucket([], _BaseHost) ->
+    undefined;
+expected_bucket(_Bucket, []) ->
+    undefined;
+expected_bucket(Bucket, _) ->
+    Bucket.
+
+-endif.


### PR DESCRIPTION
Properly extract bucket names that contain periods from the host header
