### PR TITLE
Use short http keepalive in erlcloud

### DIFF
--- a/client_tests/erlang/erlcloud_eqc.erl
+++ b/client_tests/erlang/erlcloud_eqc.erl
@@ -194,8 +194,7 @@ initial_state_data(Host, Port, ProxyHost, ProxyPort) ->
     #api_state{aws_config=#aws_config{s3_host=Host,
                                       s3_port=Port,
                                       s3_prot="http",
-                                      proxy_host=ProxyHost,
-                                      proxy_port=ProxyPort}}.
+                                      http_options=[{proxy, {{ProxyHost, ProxyPort}, []}}, {keep_alive_timeout, 100}]}}.
 
 next_state_data(start, user_created, S, AwsConfig, _C) ->
     S#api_state{aws_config=AwsConfig};
@@ -283,7 +282,7 @@ test(Host, Port, ProxyHost, ProxyPort, Iterations) ->
 create_user(Name, Email, Config) ->
     process_post(
       post_user_request(
-        compose_url(Config#aws_config.proxy_host, Config#aws_config.proxy_port),
+        compose_url(Config),
         compose_request(Name, Email)),
      Config).
 
@@ -325,8 +324,17 @@ item_to_record_field({<<"key_secret">>, KeySecret}, User) ->
 item_to_record_field(_, User) ->
     User.
 
+compose_url(#aws_config{http_options=HTTPOptions}) ->
+    {Host, Port} = grab_host_port(HTTPOptions),
+    compose_url(Host, Port).
+
 compose_url(Host, Port) ->
     lists:flatten(["http://", Host, ":", integer_to_list(Port), "/riak-cs/user"]).
+
+grab_host_port([{proxy, {{Host, Port}, _}} | _T]) ->
+    {Host, Port};
+grab_host_port([_H | T]) ->
+    grab_host_port(T).
 
 compose_request(Name, Email) ->
     binary_to_list(

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -51,7 +51,8 @@ config(Key, Secret, Port) ->
                     Port, % inets issue precludes using ?S3_PORT
                     ?DEFAULT_PROTO,
                     ?PROXY_HOST,
-                    Port).
+                    Port,
+                    [{keep_alive_timeout, 100}]).
 
 create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),


### PR DESCRIPTION
Use `wrd-http-options` erlcloud branch for testing
- Passes in short http keepalive to erlcloud (to further be passed
  to httpc)
- Grabs proxy host and port from http options instead of aws_config
