### PR TITLE
spammy 'no user key' lager:info messages

### DIFF
--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -308,11 +308,11 @@ post_authentication({ok, User, UserObj}, RD, Ctx, Authorize, _) ->
                               user_object=UserObj});
 post_authentication({error, no_user_key}, RD, Ctx, Authorize, true) ->
     %% no keyid was given, proceed anonymously
-    lager:info("No user key"),
+    lager:debug("No user key"),
     Authorize(RD, Ctx);
 post_authentication({error, no_user_key}, RD, Ctx, _, false) ->
     %% no keyid was given, deny access
-    lager:info("No user key, deny"),
+    lager:debug("No user key, deny"),
     riak_cs_wm_utils:deny_access(RD, Ctx);
 post_authentication({error, bad_auth}, RD, Ctx, _, _) ->
     %% given keyid was found, but signature didn't match

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -136,11 +136,11 @@ handle_validation_response({ok, User, UserObj}, RD, Ctx, Next, _, _) ->
                          user_object=UserObj});
 handle_validation_response({error, no_user_key}, RD, Ctx, Next, _, true) ->
     %% no keyid was given, proceed anonymously
-    lager:info("No user key"),
+    lager:debug("No user key"),
     Next(RD, Ctx);
 handle_validation_response({error, no_user_key}, RD, Ctx, _, Conv2KeyCtx, false) ->
     %% no keyid was given, deny access
-    lager:info("No user key, deny"),
+    lager:debug("No user key, deny"),
     deny_access(RD, Conv2KeyCtx(Ctx));
 handle_validation_response({error, bad_auth}, RD, Ctx, _, Conv2KeyCtx, _) ->
     %% given keyid was found, but signature didn't match
@@ -555,7 +555,7 @@ object_access_authorize_helper(AccessType, Deletable,
             AccessRD = riak_cs_access_logger:set_user(OwnerId, RD),
             UpdLocalCtx = LocalCtx#key_context{owner=OwnerId},
             {false, AccessRD, Ctx#context{local_context=UpdLocalCtx}};
-        
+
         {false, _} -> % policy says undefined or false
             %% ACL check failed, deny access
             riak_cs_wm_utils:deny_access(RD, Ctx)


### PR DESCRIPTION
when running `make test-client`:

```
10:52:54.797 [info] No user key
10:52:55.093 [info] No user key
10:52:55.120 [info] No user key
10:52:55.182 [info] No user key
10:52:55.304 [info] No user key
10:52:55.371 [info] No user key
10:52:55.751 [info] No user key
10:52:55.879 [info] No user key
10:52:56.175 [info] No user key
10:52:56.206 [info] No user key
10:52:56.344 [info] No user key
10:52:56.428 [info] No user key
10:52:56.524 [info] No user key
10:52:56.585 [info] No user key
10:52:56.614 [info] No user key
```
