### PR TITLE
Support for prefix and delimiter when listing objects in a bucket

### DIFF
--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -51,16 +51,17 @@ confirm() ->
     %% Use `max-keys' to restrict object list to 20 results
     Options1 = [{max_keys, 20}],
     ObjList1 = erlcloud_s3:list_objects(?TEST_BUCKET, Options1, UserConfig),
-    Marker1 = proplists:get_value(marker, ObjList1),
-    verify_object_list(ObjList1, 20),
+    verify_object_list(ObjList1, 20, 30),
 
     %% Use `marker' to request remainder of results
-    Options2 = [{marker, Marker1}],
-    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options2, UserConfig), 10),
+    Options2 = [{marker, "27"}],
+    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options2, UserConfig), 10, 30, 21),
 
     %% Put 2 sets of 4 objects with keys that have a common subdirectory
-    load_objects(?TEST_BUCKET, 4, "subdir/prefix1/", UserConfig),
-    load_objects(?TEST_BUCKET, 4, "subdir/prefix2/", UserConfig),
+    Prefix1 = "0/prefix1/",
+    Prefix2 = "0/prefix2/",
+    load_objects(?TEST_BUCKET, 4, Prefix1, UserConfig),
+    load_objects(?TEST_BUCKET, 4, Prefix2, UserConfig),
 
     %% Use `max-keys', `prefix' and `delimiter' to get first 30
     %% results back and verify results are truncated and 2 common
@@ -68,14 +69,20 @@ confirm() ->
     %% Unable to currently verify the `CommonPrefixes' for this is
     %% fact that ercloud does not support parsing the those response
     %% elements.
-    Options3 = [{max_keys, 30}, {prefix, "subdir"}, {delimiter, "/"}],
+    Options3 = [{max_keys, 30}, {prefix, "0/"}, {delimiter, "/"}],
     ObjList2 = erlcloud_s3:list_objects(?TEST_BUCKET, Options3, UserConfig),
-    Marker2 = proplists:get_value(marker, ObjList2),
-    verify_object_list(ObjList1, 28),
+    CommonPrefixes = proplists:get_value(common_prefixes, ObjList2),
+    ?assert(lists:member([{prefix, Prefix1}], CommonPrefixes)),
+    ?assert(lists:member([{prefix, Prefix2}], CommonPrefixes)),
+    verify_object_list(ObjList2, 28, 30),
 
     %% Request remainder of results
-    Options3 = [{marker, Marker2}],
-    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options3, UserConfig), 2),
+    Options4 = [{marker, "7"}],
+    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options4, UserConfig), 2, 30, 29),
+
+    delete_objects(?TEST_BUCKET, Count3, [], UserConfig),
+    delete_objects(?TEST_BUCKET, 4, Prefix1, UserConfig),
+    delete_objects(?TEST_BUCKET, 4, Prefix2, UserConfig),
 
     lager:info("deleting bucket ~p", [?TEST_BUCKET]),
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
@@ -93,7 +100,20 @@ load_objects(Bucket, Count, KeyPrefix, Config) ->
                             Config) || X <- lists:seq(1,Count)].
 
 verify_object_list(ObjList, ExpectedCount) ->
+    verify_object_list(ObjList, ExpectedCount, ExpectedCount, 1).
+
+verify_object_list(ObjList, ExpectedCount, TotalCount) ->
+    verify_object_list(ObjList, ExpectedCount, TotalCount, 1).
+
+verify_object_list(ObjList, ExpectedCount, TotalCount, 1) when ExpectedCount =:= TotalCount ->
     ?assertEqual(lists:sort([integer_to_list(X) || X <- lists:seq(1, ExpectedCount)]),
+                 [proplists:get_value(key, O) ||
+                     O <- proplists:get_value(contents, ObjList)]);
+verify_object_list(ObjList, ExpectedCount, TotalCount, Offset) ->
+    ?assertEqual(lists:sublist(
+                   lists:sort([integer_to_list(X) || X <- lists:seq(1, TotalCount)]),
+                   Offset,
+                   ExpectedCount),
                  [proplists:get_value(key, O) ||
                      O <- proplists:get_value(contents, ObjList)]).
 
@@ -104,3 +124,9 @@ delete_and_verify_objects(Bucket, Count, Config) ->
     verify_object_list(erlcloud_s3:list_objects(Bucket, Config), Count),
     erlcloud_s3:delete_object(Bucket, integer_to_list(Count), Config),
     delete_and_verify_objects(Bucket, Count-1, Config).
+
+delete_objects(Bucket, Count, Prefix, Config) ->
+    [erlcloud_s3:delete_object(Bucket,
+                               Prefix ++ integer_to_list(X),
+                               Config)
+     || X <- lists:seq(1, Count)].

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -32,7 +32,7 @@ confirm() ->
     Count1 = 10,
     load_objects(?TEST_BUCKET, Count1, UserConfig),
 
-    %%Successively list the buckets, verify the output, and delete an
+    %% Successively list the buckets, verify the output, and delete an
     %% object from the bucket until the bucket is empty again.
     delete_and_verify_objects(?TEST_BUCKET, Count1, UserConfig),
 
@@ -40,9 +40,42 @@ confirm() ->
     Count2 = 100,
     load_objects(?TEST_BUCKET, Count2, UserConfig),
 
-    %%Successively list the buckets, verify the output, and delete an
+    %% Successively list the buckets, verify the output, and delete an
     %% object from the bucket until the bucket is empty again.
     delete_and_verify_objects(?TEST_BUCKET, Count2, UserConfig),
+
+    %% Put 30 objects in the bucket
+    Count3 = 30,
+    load_objects(?TEST_BUCKET, Count3, UserConfig),
+
+    %% Use `max-keys' to restrict object list to 20 results
+    Options1 = [{max_keys, 20}],
+    ObjList1 = erlcloud_s3:list_objects(?TEST_BUCKET, Options1, UserConfig),
+    Marker1 = proplists:get_value(marker, ObjList1),
+    verify_object_list(ObjList1, 20),
+
+    %% Use `marker' to request remainder of results
+    Options2 = [{marker, Marker1}],
+    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options2, UserConfig), 10),
+
+    %% Put 2 sets of 4 objects with keys that have a common subdirectory
+    load_objects(?TEST_BUCKET, 4, "subdir/prefix1/", UserConfig),
+    load_objects(?TEST_BUCKET, 4, "subdir/prefix2/", UserConfig),
+
+    %% Use `max-keys', `prefix' and `delimiter' to get first 30
+    %% results back and verify results are truncated and 2 common
+    %% prefixes are returned.
+    %% Unable to currently verify the `CommonPrefixes' for this is
+    %% fact that ercloud does not support parsing the those response
+    %% elements.
+    Options3 = [{max_keys, 30}, {prefix, "subdir"}, {delimiter, "/"}],
+    ObjList2 = erlcloud_s3:list_objects(?TEST_BUCKET, Options3, UserConfig),
+    Marker2 = proplists:get_value(marker, ObjList2),
+    verify_object_list(ObjList1, 28),
+
+    %% Request remainder of results
+    Options3 = [{marker, Marker2}],
+    verify_object_list(erlcloud_s3:list_objects(?TEST_BUCKET, Options3, UserConfig), 2),
 
     lager:info("deleting bucket ~p", [?TEST_BUCKET]),
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
@@ -51,8 +84,11 @@ confirm() ->
     pass.
 
 load_objects(Bucket, Count, Config) ->
+    load_objects(Bucket, Count, [], Config).
+
+load_objects(Bucket, Count, KeyPrefix, Config) ->
     [erlcloud_s3:put_object(Bucket,
-                            integer_to_list(X),
+                            KeyPrefix ++ integer_to_list(X),
                             crypto:rand_bytes(1000),
                             Config) || X <- lists:seq(1,Count)].
 

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -66,9 +66,6 @@ confirm() ->
     %% Use `max-keys', `prefix' and `delimiter' to get first 30
     %% results back and verify results are truncated and 2 common
     %% prefixes are returned.
-    %% Unable to currently verify the `CommonPrefixes' for this is
-    %% fact that ercloud does not support parsing the those response
-    %% elements.
     Options3 = [{max_keys, 30}, {prefix, "0/"}, {delimiter, "/"}],
     ObjList2 = erlcloud_s3:list_objects(?TEST_BUCKET, Options3, UserConfig),
     CommonPrefixes = proplists:get_value(common_prefixes, ObjList2),

--- a/src/riak_cs_list_objects_fsm.erl
+++ b/src/riak_cs_list_objects_fsm.erl
@@ -108,7 +108,7 @@
                 use_cache :: boolean(),
                 %% Key to use to check for cached results from key listing
                 cache_key :: term(),
-                common_prefixes=[] :: list()}).
+                common_prefixes=ordsets:new() :: list()}).
 
 %% some useful shared types
 

--- a/src/riak_cs_list_objects_fsm.erl
+++ b/src/riak_cs_list_objects_fsm.erl
@@ -369,13 +369,9 @@ filter_prefix_keys(Keys, CommonPrefixes, ?LOREQ{prefix=Prefix,
         end,
     lists:foldl(PrefixFilter, {[], CommonPrefixes}, Keys).
 
-prefix_filter(Key, {Keys, Prefixes}, undefined, Delimiter) ->
-    case extract_group(Key, Delimiter) of
-        Key ->
-            {[Key | Keys], Prefixes};
-        Group ->
-            {Keys, ordsets:add_element(Group, Prefixes)}
-    end;
+prefix_filter(Key, Acc, undefined, Delimiter) ->
+    Group = extract_group(Key, Delimiter),
+    update_keys_and_prefixes(Acc, Key, <<>>, 0, Group);
 prefix_filter(Key, {Keys, Prefixes}, Prefix, undefined) ->
     PrefixLen = byte_size(Prefix),
     case Key of

--- a/src/riak_cs_list_objects_fsm.erl
+++ b/src/riak_cs_list_objects_fsm.erl
@@ -401,9 +401,7 @@ tagged_prefix_list(Prefixes) ->
 untagged_manifest_and_prefix(TaggedInput) ->
     Pred = fun({manifest, _}) -> true;
               (_Else) -> false end,
-    NotPred = fun(A) -> not Pred(A) end,
-    {A, B} = {lists:filter(Pred, TaggedInput),
-              lists:filter(NotPred, TaggedInput)},
+    {A, B} = lists:partition(Pred, TaggedInput),
     {[element(2, M) || M <- A],
      [element(2, P) || P <- B]}.
 

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -76,8 +76,8 @@ owner_content({OwnerName, OwnerId}) ->
 list_objects_response_to_xml(Resp) ->
     KeyContents = [key_content_to_xml(Content) ||
                    Content <- (Resp?LORESP.contents)],
-    %% CommonPrefixes = common_prefixes_to_xml(Resp?LORESP.common_prefixes),
-    CommonPrefixes = [],
+    CommonPrefixes = [common_prefix_to_xml(Prefix) ||
+                         Prefix <- Resp?LORESP.common_prefixes],
     Contents = [make_external_node('Name', Resp?LORESP.name),
                 make_external_node('Prefix', Resp?LORESP.prefix),
                 make_external_node('Marker', Resp?LORESP.marker),
@@ -96,6 +96,10 @@ key_content_to_xml(KeyContent) ->
          make_external_node('StorageClass', KeyContent?LOKC.storage_class),
          make_owner(KeyContent?LOKC.owner)],
     make_internal_node('Contents', Contents).
+
+common_prefix_to_xml(CommonPrefix) ->
+    make_internal_node('CommonPrefixes',
+                       [make_external_node('Prefix', CommonPrefix)]).
 
 -spec make_internal_node(atom(), term()) -> internal_node().
 make_internal_node(Name, Content) ->

--- a/test/riak_cs_list_objects_fsm_test.erl
+++ b/test/riak_cs_list_objects_fsm_test.erl
@@ -1,0 +1,82 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_cs_list_objects_fsm_test).
+
+-compile(export_all).
+
+-ifdef(TEST).
+
+-include("riak_cs.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% Tests for `riak_cs_list_objects_fsm:filter_prefix_keys/3'
+
+%% A request with no prefix, delimiter, or marker
+%% should just return the same list of keys
+simple_request_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>),
+    {ResultKeys, _CommonPrefixes} =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    ?assertEqual(lists:sort(Keys), lists:sort(ResultKeys)).
+
+prefix_request_1_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>, 1000,
+                                               [{prefix, <<"a">>}]),
+    Result =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    Expected = {[<<"a">>], []},
+    ?assertEqual(Expected, Result).
+
+prefix_request_2_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>, 1000,
+                                               [{prefix, <<"photos/">>}]),
+    {ResultKeys, CommonPrefixes} =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    Expected = {lists:sort(lists:sublist(Keys, 4, length(Keys))), []},
+    ?assertEqual(Expected, {lists:sort(ResultKeys), CommonPrefixes}).
+
+prefix_and_delimiter_1_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>, 1000,
+                                               [{prefix, <<"photos/">>},
+                                                {delimiter, <<"/">>}]),
+    {ResultKeys, CommonPrefixes} =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    Expected = {[], lists:sort([<<"photos/01/">>, <<"photos/02/">>])},
+    ?assertEqual(Expected, {ResultKeys, lists:sort(CommonPrefixes)}).
+
+%% The only difference from the above test is
+%% in the `prefix', note the lack of `/' after `photos'
+prefix_and_delimiter_2_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>, 1000,
+                                               [{prefix, <<"photos">>},
+                                                {delimiter, <<"/">>}]),
+    {ResultKeys, CommonPrefixes} =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    Expected = {[], lists:sort([<<"photos/">>])},
+    ?assertEqual(Expected, {ResultKeys, lists:sort(CommonPrefixes)}).
+
+prefix_and_delimiter_3_test() ->
+    Keys = keys(),
+    Request = riak_cs_list_objects:new_request(<<"bucket">>, 1000,
+                                               [{delimiter, <<"/">>}]),
+    {ResultKeys, CommonPrefixes} =
+        riak_cs_list_objects_fsm:filter_prefix_keys(Keys, [], Request),
+    Expected = {[<<"a">>, <<"b">>, <<"c">>], [<<"photos/">>]},
+    ?assertEqual(Expected, {lists:sort(ResultKeys), CommonPrefixes}).
+
+%% Test helpers
+
+keys() ->
+    [<<"a">>, <<"b">>, <<"c">>, <<"photos/01/foo">>, <<"photos/01/bar">>,
+     <<"photos/02/baz">>, <<"photos/02/quz">>].
+
+-endif.

--- a/test/riak_cs_list_objects_fsm_test.erl
+++ b/test/riak_cs_list_objects_fsm_test.erl
@@ -19,19 +19,20 @@ filter_prefix_keys_test_() ->
     [
         %% simple test
         test_creator(riak_cs_list_objects:new_request(<<"bucket">>),
-                     {keys(), []}),
+                     {keys_and_manifests(), []}),
 
         %% simple prefix
         test_creator(riak_cs_list_objects:new_request(<<"bucket">>,
                                                       1000,
                                                       [{prefix, <<"a">>}]),
-                     {[<<"a">>], []}),
+                     {keys_and_manifests([<<"a">>]), []}),
 
         %% simple prefix 2
         test_creator(riak_cs_list_objects:new_request(<<"bucket">>,
                                                       1000,
                                                       [{prefix, <<"photos/">>}]),
-                     {lists:sublist(keys(), 4, length(keys())), []}),
+                     {lists:sublist(keys_and_manifests(), 4,
+                      length(keys_and_manifests())), []}),
 
         %% prefix and delimiter
         test_creator(riak_cs_list_objects:new_request(<<"bucket">>,
@@ -53,13 +54,14 @@ filter_prefix_keys_test_() ->
         test_creator(riak_cs_list_objects:new_request(<<"bucket">>,
                                                       1000,
                                                       [{delimiter, <<"/">>}]),
-                     {[<<"a">>, <<"b">>, <<"c">>], [<<"photos/">>]})
+                     {keys_and_manifests([<<"a">>, <<"b">>, <<"c">>]),
+                      [<<"photos/">>]})
     ].
 
 %% Test creator
 
 test_creator(Request, Expected) ->
-    test_creator(keys(), Request, Expected).
+    test_creator(keys_and_manifests(), Request, Expected).
 
 test_creator(Keys, Request, Expected) ->
     fun () ->
@@ -74,6 +76,12 @@ test_creator(Keys, Request, Expected) ->
 two_tuple_sort({A, B}) ->
     {lists:sort(A),
      lists:sort(B)}.
+
+keys_and_manifests() ->
+    keys_and_manifests(keys()).
+
+keys_and_manifests(Items) ->
+    [{K, fake_manifest} || K <- Items].
 
 keys() ->
     [<<"a">>, <<"b">>, <<"c">>, <<"photos/01/foo">>, <<"photos/01/bar">>,


### PR DESCRIPTION
Support prefix and delimiter options for GET Objects requests. Includes support for CommonPrefixes in response documents.
