### PR TITLE
Last-Modified doesn't match btw HEAD /object and GET / (listkeys)

### DIFF
--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -327,7 +327,8 @@ to_rfc_1123(Date) when is_list(Date) ->
             iso_8601_to_rfc_1123(Date)
     end.
 
-%% @doc Convert an ISO 8601 date to RFC 1123 date
+%% @doc Convert an ISO 8601 date to RFC 1123 date. This function
+%% assumes the input time is already in GMT time.
 -spec iso_8601_to_rfc_1123(binary() | string()) -> string().
 iso_8601_to_rfc_1123(Date) when is_list(Date) ->
     iso_8601_to_rfc_1123(iolist_to_binary(Date));
@@ -337,8 +338,9 @@ iso_8601_to_rfc_1123(Date) when is_binary(Date) ->
       _T:1/binary,
       Hr:2/binary, _:1/binary, Mn:2/binary, _:1/binary, Sc:2/binary,
       _/binary>> = Date,
-    httpd_util:rfc1123_date({{b2i(Yr), b2i(Mo), b2i(Da)},
-                             {b2i(Hr), b2i(Mn), b2i(Sc)}}).
+    httpd_util:rfc1123_date(
+      erlang:universaltime_to_localtime({{b2i(Yr), b2i(Mo), b2i(Da)},
+                                         {b2i(Hr), b2i(Mn), b2i(Sc)}})).
 
 extract_name(User) when is_list(User) ->
     User;


### PR DESCRIPTION
When we get last-modified metadata via riak_cs_wm_object, then we get timestamp at GMT: this looks like valid time except timezone

```
HEAD /1gb2.txt HTTP/1.1
Host: test-idcf-0000.cs-ap-e1.ycloud.jp
Accept-Encoding: identity
content-length: 0
Authorization: AWS WCSPLRH8OA6DJ3-CJ3BP:t7YYDUDdqsrRLIivTbSGK9WS2qI=
x-amz-date: Mon, 04 Feb 2013 07:24:08 +0000

HTTP/1.1 200 OK
Server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
Last-Modified: Thu, 31 Jan 2013 19:20:19 GMT
ETag: "2e8a2590d031d0c59dee71ddb3faa2d5"
Date: Mon, 04 Feb 2013 07:24:08 GMT
Content-Type: text/plain
Content-Length: 1073741824
Connection: close
```

but, we get last-modified timestamp via "s3cmd ls" (in fact this is "GET /") then we get 

```
<?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Name>test-idcf-0000</Name><Prefix/><Marker/><MaxKeys>1000</MaxKeys><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated><Contents></Contents><Contents><Key>1gb2.txt</Key><Size>1073741824</Size><LastModified>2013-02-01T04:20:19.000Z</LastModified><ETag>"2e8a2590d031d0c59dee71ddb3faa2d5"</ETag>
```

Then we get different timestamp, looks like valid timestamp in JST.

AIs:
- [x] survey how S3 works and CS should work, what RFC1123 and iso8601 says
- [x] if bug, fix it

source code:
https://github.com/basho/riak_cs/blob/master/src/riak_cs_wm_utils.erl#L311
