### PR TITLE
Copy runner script into `bin` rather than `sbin`

### DIFF
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -53,7 +53,7 @@
            {copy, "../deps/node_package/priv/base/nodetool",
                   "{{erts_vsn}}/bin/nodetool"},
            {template, "../deps/node_package/priv/base/runner",
-                  "sbin/riak-cs"},
+                  "bin/riak-cs"},
            {template, "../deps/node_package/priv/base/env.sh",
                   "lib/env.sh"},
 
@@ -66,7 +66,7 @@
            {template, "files/key.pem", "etc/key.pem"},
 
            %% Copy additional sbin scripts
-           {template, "../priv/sbin/riak-cs-access", "sbin/riak-cs-access"},
-           {template, "../priv/sbin/riak-cs-storage", "sbin/riak-cs-storage"},
-           {template, "../priv/sbin/riak-cs-gc", "sbin/riak-cs-gc"}
+           {template, "../priv/sbin/riak-cs-access", "bin/riak-cs-access"},
+           {template, "../priv/sbin/riak-cs-storage", "bin/riak-cs-storage"},
+           {template, "../priv/sbin/riak-cs-gc", "bin/riak-cs-gc"}
           ]}.

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -134,7 +134,7 @@ lager_config() ->
      ]}.
 
 riakcs_binpath(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/sbin/riak-cs", [Prefix, N]).
+    io_lib:format("~s/dev/dev~b/bin/riak-cs", [Prefix, N]).
 
 riakcs_etcpath(Prefix, N) ->
     io_lib:format("~s/dev/dev~b/etc", [Prefix, N]).
@@ -143,7 +143,7 @@ riakcscmd(Path, N, Cmd) ->
     lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
 
 stanchion_binpath(Prefix) ->
-    io_lib:format("~s/dev/stanchion/sbin/stanchion", [Prefix]).
+    io_lib:format("~s/dev/stanchion/bin/stanchion", [Prefix]).
 
 stanchion_etcpath(Prefix) ->
     io_lib:format("~s/dev/stanchion/etc", [Prefix]).


### PR DESCRIPTION
Reltool forces a `bin` directory to be created, so this change
just uses that standard.  `node_package` will copy the binary
into `sbin` anyway with the `bin_or_sbin` setting in the
`pkg.vars.config` file.
