### PR TITLE
bucket policy: use binary_to_existing_atom/2 instead of binary_to_atom/2

### DIFF
--- a/include/rts.hrl
+++ b/include/rts.hrl
@@ -2,5 +2,13 @@
 -define(START_TIME, <<"StartTime">>).
 -define(END_TIME, <<"EndTime">>).
 
--define(START_TIME_ATOM, 'StartTime').
--define(END_TIME_ATOM, 'EndTime').
+%% http://docs.basho.com/riakcs/latest/cookbooks/Querying-Access-Statistics/
+-type usage_field_type() :: 'Count' | 'UserErrorCount' | 'SystemErrorCount'
+                          | 'BytesIn' | 'UserErrorBytesIn' | 'SystemErrorBytesIn'
+                          | 'BytesOut' | 'UserErrorBytesOut' | 'SystemErrorBytesOut'
+                          | 'BytesOutIncomplete'.
+
+-define(SUPPORTED_USAGE_FIELD, ['Count' , 'UserErrorCount' , 'SystemErrorCount',
+                                'BytesIn' , 'UserErrorBytesIn' , 'SystemErrorBytesIn',
+                                'BytesOut' , 'UserErrorBytesOut' , 'SystemErrorBytesOut',
+                                'BytesOutIncomplete']).

--- a/include/rts.hrl
+++ b/include/rts.hrl
@@ -1,3 +1,6 @@
 %% JSON keys used by rts module
 -define(START_TIME, <<"StartTime">>).
 -define(END_TIME, <<"EndTime">>).
+
+-define(START_TIME_ATOM, 'StartTime').
+-define(END_TIME_ATOM, 'EndTime').

--- a/include/rts.hrl
+++ b/include/rts.hrl
@@ -8,7 +8,14 @@
                           | 'BytesOut' | 'UserErrorBytesOut' | 'SystemErrorBytesOut'
                           | 'BytesOutIncomplete'.
 
--define(SUPPORTED_USAGE_FIELD, ['Count' , 'UserErrorCount' , 'SystemErrorCount',
-                                'BytesIn' , 'UserErrorBytesIn' , 'SystemErrorBytesIn',
-                                'BytesOut' , 'UserErrorBytesOut' , 'SystemErrorBytesOut',
-                                'BytesOutIncomplete']).
+-define(SUPPORTED_USAGE_FIELD,
+        ['Count' , 'UserErrorCount' , 'SystemErrorCount',
+         'BytesIn' , 'UserErrorBytesIn' , 'SystemErrorBytesIn',
+         'BytesOut' , 'UserErrorBytesOut' , 'SystemErrorBytesOut',
+         'BytesOutIncomplete']).
+
+-define(SUPPORTED_USAGE_FIELD_BIN,
+        [<<"Count">> , <<"UserErrorCount">> , <<"SystemErrorCount">>,
+         <<"BytesIn">> , <<"UserErrorBytesIn">> , <<"SystemErrorBytesIn">>,
+         <<"BytesOut">> , <<"UserErrorBytesOut">> , <<"SystemErrorBytesOut">>,
+         <<"BytesOutIncomplete">>]).

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -473,11 +473,7 @@ statement_from_pairs([{<<"Condition">>,{struct, Cs}}  |T], Stmt) ->
 
 -spec binary_to_action(binary()) -> s3_object_action() | s3_bucket_action().
 binary_to_action(Bin)->
-    % @TODO: use binary_to_existing_atom/2 to protect atom table.
-    % but no other good place to register atoms into atom tables
-    % defined in ?SUPPORTED_BUCKET_ACTION and ?SUPPORTED_OBJECT_ACTION
-    %binary_to_existing_atom(Bin, latin1).
-    binary_to_atom(Bin, latin1).
+    binary_to_existing_atom(Bin, latin1).
 
 % @TODO: error processing
 -spec parse_principal(binary() | [binary()]) -> principal().

--- a/src/riak_cs_wm_usage.erl
+++ b/src/riak_cs_wm_usage.erl
@@ -336,7 +336,7 @@ xml_sample_error({{Start, End}, Reason}, SubType, TypeLabel) ->
 
 %% @doc JSON deserializes with keys as binaries, but xmerl requires
 %% tag names to be atoms.
-xml_name(Other) -> binary_to_atom(Other, latin1).
+xml_name(Other) -> binary_to_existing_atom(Other, latin1).
 
 xml_reason(Reason) ->
     [if is_atom(Reason) -> atom_to_binary(Reason, latin1);

--- a/src/riak_cs_wm_usage.erl
+++ b/src/riak_cs_wm_usage.erl
@@ -130,6 +130,8 @@
 -define(KEY_ERRORS, 'Errors').
 -define(KEY_REASON, 'Reason').
 -define(KEY_MESSAGE, 'Message').
+-define(ATTR_START, 'StartTime').
+-define(ATTR_END, 'EndTime').
 
 -record(ctx, {
           auth_bypass :: boolean(),
@@ -336,7 +338,12 @@ xml_sample_error({{Start, End}, Reason}, SubType, TypeLabel) ->
 
 %% @doc JSON deserializes with keys as binaries, but xmerl requires
 %% tag names to be atoms.
-xml_name(Other) -> binary_to_existing_atom(Other, latin1).
+-spec xml_name(binary()) -> usage_field_type() | ?ATTR_START | ?ATTR_END.
+xml_name(?START_TIME) -> ?ATTR_START;
+xml_name(?END_TIME) -> ?ATTR_END;
+xml_name(UsageFieldName) ->
+    true = lists:member(UsageFieldName, ?SUPPORTED_USAGE_FIELD),
+    binary_to_existing_atom(UsageFieldName, latin1).
 
 xml_reason(Reason) ->
     [if is_atom(Reason) -> atom_to_binary(Reason, latin1);

--- a/src/riak_cs_wm_usage.erl
+++ b/src/riak_cs_wm_usage.erl
@@ -100,6 +100,7 @@
          produce_xml/2,
          finish_request/2
         ]).
+-on_load(on_load/0).
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -142,6 +143,13 @@
           body :: iodata(),
           etag :: iolist()
          }).
+
+on_load() ->
+    %% put atoms into atom table, for binary_to_existing_atom/2 in xml_name/1
+    ?SUPPORTED_USAGE_FIELD = lists:map(fun(Bin) ->
+                                               binary_to_existing_atom(Bin, latin1)
+                                       end, ?SUPPORTED_USAGE_FIELD_BIN),
+    ok.
 
 init(Config) ->
     %% Check if authentication is disabled and
@@ -342,7 +350,7 @@ xml_sample_error({{Start, End}, Reason}, SubType, TypeLabel) ->
 xml_name(?START_TIME) -> ?ATTR_START;
 xml_name(?END_TIME) -> ?ATTR_END;
 xml_name(UsageFieldName) ->
-    true = lists:member(UsageFieldName, ?SUPPORTED_USAGE_FIELD),
+    true = lists:member(UsageFieldName, ?SUPPORTED_USAGE_FIELD_BIN),
     binary_to_existing_atom(UsageFieldName, latin1).
 
 xml_reason(Reason) ->


### PR DESCRIPTION
```
use binary_to_existing_atom/2 to protect atom table.
but no other good place to register atoms into atom tables
defined in ?SUPPORTED_BUCKET_ACTION and ?SUPPORTED_OBJECT_ACTION
```

https://github.com/basho/riak_cs/blob/master/src/riak_cs_s3_policy.erl#L448
