### PR TITLE
updated riak_test script.

### DIFF
--- a/riak_test/bin/rtdev-build-releases.sh
+++ b/riak_test/bin/rtdev-build-releases.sh
@@ -16,10 +16,8 @@
 # Or, alternatively, just substitute the paths to the kerl install paths as
 # that should work too.
 
-# R14B03=${R14B03:-$HOME/erlang-R14B03}
 # R14B04=${R14B04:-$HOME/erlang-R14B04}
 # R15B01=${R15B01:-$HOME/erlang-R15B01}
-R14B03=${R14B03:-$HOME/erlang/R14B03-64}
 R14B04=${R14B04:-$HOME/erlang/R14B04-64}
 R15B01=${R15B01:-$HOME/erlang/R15B01-64}
 
@@ -72,7 +70,6 @@ build()
     cd ..
 }
 
-checkbuild $R14B03
 checkbuild $R14B04
 checkbuild $R15B01
 

--- a/riak_test/bin/rtdev-build-releases.sh
+++ b/riak_test/bin/rtdev-build-releases.sh
@@ -70,14 +70,23 @@ build()
     cd ..
 }
 
+download()
+{
+  URI=$1
+  FILENAME=`echo $URI | awk -F/ '{ print $7 }'`
+  if [ ! -f $FILENAME ]; then
+    s3cmd get --continue $URI
+  fi
+}
+
 checkbuild $R14B04
 checkbuild $R15B01
 
 # Download Riak CS release source, need s3cmd configured
 # You must have the proper credentials configured in ~/.s3cfg for this to work.
-s3cmd get --continue s3://builds.basho.com/riak-cs/1.2/1.2.2/riak-cs-1.2.2.tar.gz
-s3cmd get --continue s3://builds.basho.com/riak-cs/1.1/1.1.0/riak-cs-1.1.0.tar.gz
-s3cmd get --continue s3://builds.basho.com/riak-cs/1.0/1.0.1/riak-cs-1.0.1.tar.gz
+download s3://builds.basho.com/riak-cs/1.2/1.2.2/riak-cs-1.2.2.tar.gz
+download s3://builds.basho.com/riak-cs/1.1/1.1.0/riak-cs-1.1.0.tar.gz
+download s3://builds.basho.com/riak-cs/1.0/1.0.1/riak-cs-1.0.1.tar.gz
 
 tar -xzf riak-cs-1.0.1.tar.gz
 build "riak-cs-1.0.1" $R14B04


### PR DESCRIPTION
- removed building R14B04 which is no longer used.
- checked if a package already exists before download.
