### PR TITLE
Fix prefix and delimiter for mp upload listing

### DIFF
--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -283,7 +283,7 @@ write_new_manifest(M, Opts, RiakcPidUnW) ->
                           undefined ->
                               % 4th arg, pid(), unused but honor the contract
                               riak_cs_acl_utils:canned_acl(
-                                "private", Owner, undefined, not_required); 
+                                "private", Owner, undefined, not_required);
                           AnAcl ->
                               AnAcl
                       end,
@@ -533,83 +533,108 @@ make_2i_key(Bucket, OwnerStr) when is_list(OwnerStr) ->
 make_2i_key2(Bucket, OwnerStr) ->
     iolist_to_binary(["rcs@", OwnerStr, "@", Bucket, "_bin"]).
 
-list_multipart_uploads2(Bucket, RiakcPid, Names, Opts, CallerKeyId) ->
-    %% Easy.
-    {_, _, _, Res} = lists:foldl(fun fold_get_multipart_id/2,
-                                 {RiakcPid, Bucket, CallerKeyId, []}, Names),
-    %% Not so easy: filter based on prefix, delimiter, key_marker, and
-    %%              upload_id_marker.
-    %%
-    %% First, set up helpers....
-    PrefixStr = proplists:get_value(prefix, Opts, ""),
-    PrefixStrLen = length(PrefixStr),
-    PrefixMatch = fun(Str) ->
-                          PrefixStr == lists:sublist(Str, PrefixStrLen)
-                  end,
-    KeyMStr = proplists:get_value(key_marker, Opts, ""),
-    UploadMBin = try
-                     base64url:decode(proplists:get_value(
-                                        upload_id_marker, Opts, ""))
-                 catch _:_ ->
-                         <<>>
-                 end,
-    Delimiter = case proplists:get_value(delimiter, Opts) of
-                    undefined -> undefined;
-                    [C]       -> C;
-                    _         -> undefined
-                end,
-    DelimiterMatch =
-        fun(Str) ->
-                StrLen = length(Str),
-                StrLen >= PrefixStrLen andalso
-                    lists:member(Delimiter,
-                                 lists:sublist(Str, PrefixStrLen + 1, StrLen))
+list_multipart_uploads2(Bucket, RiakcPid, Names, Opts, _CallerKeyId) ->
+    FilterFun =
+        fun(K, Acc) ->
+                filter_uploads_list(Bucket, K, Opts, RiakcPid, Acc)
         end,
+    {Manifests, Prefixes} = lists:foldl(FilterFun, {[], ordsets:new()}, Names),
+    {lists:sort(Manifests), ordsets:to_list(Prefixes)}.
 
-    %% Do some real work: filter the result set based on all criteria
-    Res2 = [M || M <- Res,
-                 Key <- [binary_to_list(M?MULTIPART_DESCR.key)],
-                 PrefixMatch(Key),
-                 Key > KeyMStr,
-                 M?MULTIPART_DESCR.upload_id > UploadMBin,
-                 Delimiter == undefined orelse
-                     not DelimiterMatch(Key)],
-    %% More work: find the common strings based on Delimiter
-    Common = if Delimiter == undefined ->
-                     [];
-                true ->
-                     Max = 999999999999999,     % arbitrarily big
-                     [hd(string:tokens(
-                           lists:sublist(binary_to_list(M?MULTIPART_DESCR.key),
-                                         PrefixStrLen+1, Max),
-                           [Delimiter])) || M <- Res,
-                         lists:member(Delimiter,
-                                      binary_to_list(M?MULTIPART_DESCR.key))]
-             end,
-    {lists:sort(Res2), lists:usort(Common)}.
+filter_uploads_list(Bucket, Key, Opts, RiakcPid, Acc) ->
+    multipart_manifests_for_key(Bucket, Key, Opts, Acc, RiakcPid).
 
-fold_get_multipart_id(Name, {RiakcPid, Bucket, CallerKeyId, Acc}) ->
-    case riak_cs_utils:get_manifests(RiakcPid, Bucket, Name) of
-        {ok, _Obj, Manifests} ->
-            L = [?MULTIPART_DESCR{
-                    key = element(2, M?MANIFEST.bkey),
-                    upload_id = UUID,
-                    owner_key_id = element(3, MpM?MULTIPART_MANIFEST.owner),
-                    owner_display = element(1, MpM?MULTIPART_MANIFEST.owner),
-                    initiated = M?MANIFEST.created} ||
-                    {UUID, M} <- Manifests,
-                    CallerKeyId == owner orelse
-                        iolist_to_binary(CallerKeyId) ==
-                        iolist_to_binary(element(3, (M?MANIFEST.acl)?ACL.owner)),
-                    M?MANIFEST.state == writing,
-                    MpM <- case proplists:get_value(multipart, M?MANIFEST.props) of
-                               undefined -> [];
-                               X         -> [X]
-                           end],
-            {RiakcPid, Bucket, CallerKeyId, L ++ Acc};
-        _Else ->
-            {RiakcPid, Bucket, CallerKeyId, Acc}
+parameter_filter(M, Acc, _, _, KeyMarker, _)
+  when M?MULTIPART_DESCR.key =< KeyMarker->
+    Acc;
+parameter_filter(M, Acc, _, _, KeyMarker, UploadIdMarker)
+  when M?MULTIPART_DESCR.key =< KeyMarker andalso
+       M?MULTIPART_DESCR.upload_id =< UploadIdMarker ->
+    Acc;
+parameter_filter(M, {Manifests, Prefixes}, undefined, undefined, _, _) ->
+    {[M | Manifests], Prefixes};
+parameter_filter(M, Acc, undefined, Delimiter, _, _) ->
+    Group = extract_group(M?MULTIPART_DESCR.key, Delimiter),
+    update_keys_and_prefixes(Acc, M, <<>>, 0, Group);
+parameter_filter(M, {Manifests, Prefixes}, Prefix, undefined, _, _) ->
+    PrefixLen = byte_size(Prefix),
+    case M?MULTIPART_DESCR.key of
+        << Prefix:PrefixLen/binary, _/binary >> ->
+            {[M | Manifests], Prefixes};
+        _ ->
+            {Manifests, Prefixes}
+    end;
+parameter_filter(M, {Manifests, Prefixes}=Acc, Prefix, Delimiter, _, _) ->
+    PrefixLen = byte_size(Prefix),
+    case M?MULTIPART_DESCR.key of
+        << Prefix:PrefixLen/binary, Rest/binary >> ->
+            Group = extract_group(Rest, Delimiter),
+            update_keys_and_prefixes(Acc, M, Prefix, PrefixLen, Group);
+        _ ->
+            {Manifests, Prefixes}
     end.
+
+extract_group(Key, Delimiter) ->
+    case binary:match(Key, [Delimiter]) of
+        nomatch ->
+            nomatch;
+        {Pos, Len} ->
+            binary:part(Key, {0, Pos+Len})
+    end.
+
+update_keys_and_prefixes({Keys, Prefixes}, Key, _, _, nomatch) ->
+    {[Key | Keys], Prefixes};
+update_keys_and_prefixes({Keys, Prefixes}, _, Prefix, PrefixLen, Group) ->
+    NewPrefix = << Prefix:PrefixLen/binary, Group/binary >>,
+    {Keys, ordsets:add_element(NewPrefix, Prefixes)}.
+
+multipart_manifests_for_key(Bucket, Key, Opts, Acc, RiakcPid) ->
+    ParameterFilter = build_parameter_filter(Opts),
+    Manifests = handle_get_manifests_result(
+                  riak_cs_utils:get_manifests(RiakcPid, Bucket, Key)),
+    lists:foldl(ParameterFilter, Acc, Manifests).
+
+build_parameter_filter(Opts) ->
+    Prefix = proplists:get_value(prefix, Opts),
+    Delimiter = proplists:get_value(delimiter, Opts),
+    KeyMarker = proplists:get_value(key_marker, Opts),
+    UploadIdMarker = base64url:decode(
+                           proplists:get_value(upload_id_marker, Opts)),
+    build_parameter_filter(Prefix, Delimiter, KeyMarker, UploadIdMarker).
+
+build_parameter_filter(Prefix, Delimiter, KeyMarker, UploadIdMarker) ->
+    fun(Key, Acc) ->
+            parameter_filter(Key, Acc, Prefix, Delimiter, KeyMarker, UploadIdMarker)
+    end.
+
+handle_get_manifests_result({ok, _Obj, Manifests}) ->
+   [multipart_description(M)
+                 || {_, M} <- Manifests,
+                    M?MANIFEST.state == writing,
+                    is_multipart_manifest(M)];
+handle_get_manifests_result(_) ->
+    [].
+
+-spec is_multipart_manifest(?MANIFEST{}) -> boolean().
+is_multipart_manifest(?MANIFEST{props=Props}) ->
+    case proplists:get_value(multipart, Props) of
+        undefined ->
+            false;
+        _ ->
+             true
+    end;
+is_multipart_manifest(_) ->
+    false.
+
+-spec multipart_description(?MANIFEST{}) -> ?MULTIPART_DESCR{}.
+multipart_description(Manifest) ->
+    MpM =  proplists:get_value(multipart, Manifest?MANIFEST.props),
+    ?MULTIPART_DESCR{
+       key = element(2, Manifest?MANIFEST.bkey),
+       upload_id = Manifest?MANIFEST.uuid,
+       owner_key_id = element(3, MpM?MULTIPART_MANIFEST.owner),
+       owner_display = element(1, MpM?MULTIPART_MANIFEST.owner),
+       initiated = Manifest?MANIFEST.created}.
 
 %% @doc Will cause error:{badmatch, {m_ibco, _}} if CallerKeyId does not exist
 

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -31,9 +31,9 @@ init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
-malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->    
+malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
     Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    %% need to unquote twice since we re-urlencode the string during rewrite in 
+    %% need to unquote twice since we re-urlencode the string during rewrite in
     %% order to trick webmachine dispatching
     %% NOTE: Bucket::binary(), *but* Key::string()
     Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
@@ -44,7 +44,7 @@ malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
 %% object ACL and compare the permission requested with the permission
 %% granted, and allow or deny access. Returns a result suitable for
 %% directly returning from the {@link forbidden/2} webmachine export.
--spec authorize(#wm_reqdata{}, #context{}) -> 
+-spec authorize(#wm_reqdata{}, #context{}) ->
                        {boolean() | {halt, term()}, #wm_reqdata{}, #context{}}.
 authorize(RD, Ctx0=#context{local_context=LocalCtx0, riakc_pid=RiakPid}) ->
     Method = wrq:method(RD),
@@ -91,13 +91,13 @@ check_permission(_, RD, Ctx=#context{requested_perm=RequestedAccess,
          end of
         true ->
             %% actor is the owner
-            AccessRD = riak_cs_access_logger:set_user(User, RD),
+            AccessRD = riak_cs_access_log_handler:set_user(User, RD),
             UserStr = User?RCS_USER.canonical_id,
             UpdLocalCtx = LocalCtx#key_context{owner=UserStr},
             {false, AccessRD, Ctx#context{local_context=UpdLocalCtx}};
         {true, OwnerId} ->
             %% bill the owner, not the actor
-            AccessRD = riak_cs_access_logger:set_user(OwnerId, RD),
+            AccessRD = riak_cs_access_log_handler:set_user(OwnerId, RD),
             UpdLocalCtx = LocalCtx#key_context{owner=OwnerId},
             {false, AccessRD, Ctx#context{local_context=UpdLocalCtx}};
         false ->


### PR DESCRIPTION
Refactor how the optional parameters to the commmand to list in-progress multipart uploads are handled. Replace multiple traversals of the list of manifest data with a single traversal for greater efficiency. This change resolves a failing condition with the existing `riak_test` module for multipart uploads.

`riak_test` output without this change:

```
15:37:48.517 [info] creating bucket "riak_test_bucket"
15:37:48.649 [info] Initiating multipart upload
15:37:48.793 [info] Uploading parts
15:37:49.152 [info] Completing multipart upload
15:37:49.321 [info] Initiating multipart upload
15:37:49.348 [info] Uploading parts
15:37:49.571 [info] Aborting multipart upload
15:37:51.647 [warning] mp_upload_test failed: {{assertion_failed,[{module,mp_upload_test},{line,85},{expression,"lists : member ( [ { prefix , Prefix1 } ] , CommonPrefixes1 )"},{expected,true},{value,false}]},[{mp_upload_test,'-confirm/0-fun-4-',1,[{file,"riak_test/tests/mp_upload_test.erl"},{line,85}]},{mp_upload_test,confirm,0,[{file,"riak_test/tests/mp_upload_test.erl"},{line,85}]}]}
15:37:51.647 [error] Error in process <0.186.0> on node 'riak_test@127.0.0.1' with exit value: {{assertion_failed,[{module,mp_upload_test},{line,85},{expression,"lists : member ( [ { prefix , Prefix1 } ] , CommonPrefixes1 )"},{expected,true},{value,false}]},[{mp_upload_test,'-confirm/0-fun-4-',1,[{file,"riak... 


15:37:51.647 [error] 
================ mp_upload_test failure stack trace =====================
{{assertion_failed,[{module,mp_upload_test},
                    {line,85},
                    {expression,"lists : member ( [ { prefix , Prefix1 } ] , CommonPrefixes1 )"},
                    {expected,true},
                    {value,false}]},
 [{mp_upload_test,'-confirm/0-fun-4-',1,
                  [{file,"riak_test/tests/mp_upload_test.erl"},{line,85}]},
  {mp_upload_test,confirm,0,
                  [{file,"riak_test/tests/mp_upload_test.erl"},{line,85}]}]}
=========================================================================

15:37:51.648 [notice] mp_upload_test Test Run Complete

Test Results:
mp_upload_test-riak_cs_kv_multi_backend,riak_kv_bitcask_backend: fail <<"{{assertion_failed,[{module,mp_upload_test},\n                    {line,85},\n                    {expression,\"lists : member ( [ { prefix , Prefix1 } ] , CommonPrefixes1 )\"},\n                    {expected,true},\n                    {value,false}]},\n [{mp_upload_test,'-confirm/0-fun-4-',1,\n                  [{file,\"riak_test/tests/mp_upload_test.erl\"},{line,85}]},\n  {mp_upload_test,confirm,0,\n                  [{file,\"riak_test/tests/mp_upload_test.erl\"},{line,85}]}]}">>
---------------------------------------------
1 Tests Failed
0 Tests Passed
That's 0.0% for those keeping score
```

`riak_test` output with this change:

```
15:31:37.364 [info] creating bucket "riak_test_bucket"
15:31:37.498 [info] Initiating multipart upload
15:31:37.642 [info] Uploading parts
15:31:38.056 [info] Completing multipart upload
15:31:38.205 [info] Initiating multipart upload
15:31:38.264 [info] Uploading parts
15:31:38.505 [info] Aborting multipart upload
15:31:43.476 [info] deleting bucket "riak_test_bucket"
15:31:43.811 [notice] mp_upload_test Test Run Complete

Test Results:
mp_upload_test-riak_cs_kv_multi_backend,riak_kv_bitcask_backend: pass
---------------------------------------------
0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score
```
