### PR TITLE
List multipart uploads for nonexisting bucket -> ServiceUnavailable

### DIFF
--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -35,6 +35,7 @@ confirm() ->
     %% Test cases
     basic_upload_test_case(?TEST_BUCKET, ?TEST_KEY1, UserConfig),
     aborted_upload_test_case(?TEST_BUCKET, ?TEST_KEY2, UserConfig),
+    nonexistent_bucket_listing_test_case("fake-bucket", UserConfig),
 
     %% Start 10 uploads for 10 different keys
     Count1 = 10,
@@ -178,6 +179,9 @@ aborted_upload_test_case(Bucket, Key, Config) ->
     %% List bucket contents and verify key is still not listed
     ObjList2 = erlcloud_s3:list_objects(Bucket, Config),
     ?assertEqual([], proplists:get_value(contents, ObjList2)).
+
+nonexistent_bucket_listing_test_case(Bucket, Config) ->
+    ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3_multipart:list_uploads(Bucket, [], Config)).
 
 basic_upload_test_case(Bucket, Key, Config) ->
     %% Initiate a multipart upload

--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -39,24 +39,9 @@ malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
     LocalCtx = LocalCtx0#key_context{bucket=Bucket},
     {false, RD, Ctx#context{local_context=LocalCtx}}.
 
--spec authorize(#wm_reqdata{}, #context{}) ->
-                       {boolean() | {halt, term()}, #wm_reqdata{}, #context{}}.
-
-authorize(RD, Ctx=#context{riakc_pid=RiakcPid, local_context=LocalCtx}) ->
-    Bucket = LocalCtx#key_context.bucket,
-    ReqAccess = riak_cs_acl_utils:requested_access('GET', false),
-    case {riak_cs_utils:check_bucket_exists(Bucket, RiakcPid),
-          riak_cs_acl_utils:check_grants(Ctx#context.user, Bucket,
-                                         ReqAccess, RiakcPid)} of
-        {{ok, _}, true} ->
-            {false, RD, Ctx};
-        {{ok, _}, false} ->
-            {{halt, 403}, RD, Ctx};
-        {{error, Reason}, _} ->
-            riak_cs_s3_response:api_error(Reason, RD, Ctx);
-        _X ->
-            {{halt, 404}, RD, Ctx}
-    end.
+-spec authorize(#wm_reqdata{}, #context{}) -> {boolean() | {halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.
+authorize(RD, Ctx) ->
+    riak_cs_wm_utils:bucket_access_authorize_helper(bucket_uploads, true, RD, Ctx).
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -406,6 +406,7 @@ bucket_access_authorize_helper(AccessType, Deletable,
          AccessType =:= bucket_policy orelse
          AccessType =:= bucket_location orelse
          AccessType =:= bucket_version orelse
+         AccessType =:= bucket_uploads orelse
          AccessType =:= bucket )
        andalso is_boolean(Deletable) ->
 


### PR DESCRIPTION
For example:

```
% s3curl.pl --id=$MY_AWS_KEY --key=$MY_AWS_SECRET -- -x localhost:8080 'http://s3.amazonaws.com/bucket-does-not-exist/?uploads' -s | xmlpp.pl
<?xml version="1.0" encoding="UTF-8"?>

<Error>
  <Code>ServiceUnavailable</Code>
  <Message>Please reduce your request rate.</Message>
  <Resource>/bucket-does-not-exist</Resource>
  <RequestId></RequestId>
</Error>
```

The result ought to be:

```
% s3curl.pl --id=$MY_AWS_KEY --key=$MY_AWS_SECRET -- 'http://s3.amazonaws.com/bucket-does-not-exist/?uploads' -s | xmlpp.pl
<?xml version="1.0" encoding="UTF-8"?>

<Error>
  <Code>NoSuchBucket</Code>
  <Message>The specified bucket does not exist</Message>
  <BucketName>bucket-does-not-exist</BucketName>
  <RequestId>D6B96F833638EE7C</RequestId>
  <HostId>c/FvHbGAt5QhD7Svt5V3rQL1hjMojcTzjsFQQgbn8ZnoMmi8UibCcdo+ohkUxh8O</HostId>
</Error>
```
