### PR TITLE
riak_cs_mp_utils:calc_multipart_21_dict fails when manifest.props is undefined

### DIFF
--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -99,10 +99,9 @@ initial_blocks(ContentLength, SafeBlockSize, UUID) ->
 block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest) ->    
     block_sequences_for_manifest(Manifest?MANIFEST{props=[]});
 block_sequences_for_manifest(?MANIFEST{uuid=UUID,
-                                       content_length=ContentLength,
-                                       props=Props}=Manifest) ->
+                                       content_length=ContentLength}=Manifest)->
     SafeBlockSize = safe_block_size_from_manifest(Manifest),
-    case proplists:get_value(multipart, Props) of
+    case riak_cs_mp_utils:get_mp_manifest(Manifest) of
         undefined ->
             initial_blocks(ContentLength, SafeBlockSize, UUID);
         X ->

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -53,7 +53,10 @@ calc_multipart_2i_dict(Ms, Bucket, _Key) when is_list(Ms) ->
     %% of bucket owner vs. non-bucket owner via two different 2I entries,
     %% one that includes the object owner and one that does not.
     L_2i = [
-            case proplists:get_value(multipart, M?MANIFEST.props) of
+            case proplists:get_value(multipart, case M?MANIFEST.props of 
+                                                    undefined -> []; 
+                                                    _ -> M?MANIFEST.props
+                                                end) of
                 undefined ->
                     [];
                 MpM when is_record(MpM, ?MULTIPART_MANIFEST_RECNAME) ->


### PR DESCRIPTION
leading to these in the console log when trying to GC:

2013-02-13 00:08:56.198 [error] <0.11199.0> gen_fsm <0.11199.0> in state waiting_command terminated with reason: no function clause matching proplists:get_value(multipart, undefined, undefined) line 222
2013-02-13 00:08:56.206 [error] <0.11199.0> CRASH REPORT Process <0.11199.0> with 3 neighbours exited with reason: no function clause matching proplists:get_value(multipart, undefined, undefined) line 222 in gen_fsm:terminate/7 line 611
2013-02-13 00:08:56.208 [error] <0.122.0> Supervisor riak_cs_sup had child riak_cs_gc_d started with riak_cs_gc_d:start_link() at <0.8490.0> exit with reason no function clause matching proplists:get_value(multipart, undefined, undefined) line 222 in context child_terminated
2013-02-13 00:08:56.210 [error] <0.11198.0> gen_server <0.11198.0> terminated with reason: no function clause matching proplists:get_value(multipart, undefined, undefined) line 222
2013-02-13 00:08:56.212 [error] <0.11198.0> CRASH REPORT Process <0.11198.0> with 0 neighbours exited with reason: no function clause matching proplists:get_value(multipart, undefined, undefined) line 222 in gen_server:terminate/6 line 747
2013-02-13 00:08:56.214 [error] <0.271.0> Supervisor riak_cs_delete_fsm_sup had child undefined started with {riak_cs_delete_fsm,start_link,undefined} at <0.11197.0> exit with reason no function clause matching proplists:get_value(multipart, undefined, undefined) line 222 in context child_terminated
