### PR TITLE
Address some eunit test timeouts

### DIFF
--- a/test/riak_cs_gc_d_eqc.erl
+++ b/test/riak_cs_gc_d_eqc.erl
@@ -60,9 +60,9 @@
 eqc_test_() ->
     {spawn,
      [
-      {timeout, 20, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_set_interval()))))},
-      {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_manual_commands()))))},
-      {timeout, 20, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_status()))))}
+      {timeout, 20, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(10, ?QC_OUT(prop_set_interval()))))},
+      {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(30, ?QC_OUT(prop_manual_commands()))))},
+      {timeout, 20, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(10, ?QC_OUT(prop_status()))))}
      ]
     }.
 

--- a/test/riak_cs_get_fsm_eqc.erl
+++ b/test/riak_cs_get_fsm_eqc.erl
@@ -58,8 +58,8 @@ eqc_test_() ->
        fun setup/0,
        fun cleanup/1,
        [%% Run the quickcheck tests
-        {timeout, 300,
-         ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_get_fsm()))))}
+        {timeout, 30,
+         ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(15, ?QC_OUT(prop_get_fsm()))))}
        ]
       }
      ]

--- a/test/riak_cs_get_fsm_test.erl
+++ b/test/riak_cs_get_fsm_test.erl
@@ -44,8 +44,8 @@ get_fsm_should_never_fail_intermittently_test_() ->
       %% ContentLength = 10000, e.g. 1,2,5,100,1000.
       [{timeout, 300, fun() -> [ok = (test_n_chunks_builder(X))() ||
                                    _ <- lists:seq(1, Iters)] end} ||
-          {X, Iters} <- [{1, 500}, {2, 500}, {5, 500},
-                         {100, 300}, {1000, 30}]]
+          {X, Iters} <- [{1, 50}, {2, 50}, {5, 50},
+                         {100, 10}, {1000, 2}]]
      ]}.
 
 calc_block_size(ContentLength, NumBlocks) ->


### PR DESCRIPTION
- Use `eqc:testing_time` instead of a fixed number of iterations for `riak_cs_gc_d_eqc` and `riak_cs_get_fsm_eqc`
- Reduce the number of iterations used in `get_fsm_should_never_fail_intermittently_test_`. This test suite lives up to its name by not failing intermittently. Instead it fails constantly with a time out after 5 long minutes. The reduced iterations should give it a better chance of passing consistently on a wider variety of hardware. 
