### PR TITLE
HTTP GET "Range" header not supported

### DIFF
--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -21,6 +21,7 @@
          safe_block_size_from_manifest/1,
          initial_blocks/2,
          block_sequences_for_manifest/1,
+         block_sequences_for_manifest/2,
          new_manifest/9,
          new_manifest/11,
          remove_write_block/2,
@@ -117,6 +118,17 @@ block_sequences_for_manifest(?MANIFEST{uuid=UUID,
                                          PM?PART_MANIFEST.part_id) ||
                              PM <- Src])
     end.
+
+%% TODO: multipart is NOT yet considered.
+block_sequences_for_manifest(?MANIFEST{uuid=UUID} = Manifest, {Start, End}) ->
+    SafeBlockSize = safe_block_size_from_manifest(Manifest),
+    SkipInitial = Start rem SafeBlockSize,
+    KeepFinal = (End rem SafeBlockSize) + 1,
+    lager:debug("InitialBlock: ~p, FinalBlock: ~p~n",
+                [Start div SafeBlockSize, End div SafeBlockSize]),
+    lager:debug("SkipInitial: ~p, KeepFinal: ~p~n", [SkipInitial, KeepFinal]),
+    {[{UUID, B} || B <- lists:seq(Start div SafeBlockSize, End div SafeBlockSize)],
+     SkipInitial, KeepFinal}.
 
 %% @doc Return the configured file block fetch concurrency .
 -spec fetch_concurrency() -> pos_integer().

--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -97,7 +97,16 @@ initial_blocks(ContentLength, SafeBlockSize, UUID) ->
     Bs = initial_blocks(ContentLength, SafeBlockSize),
     [{UUID, B} || B <- Bs].
 
-block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest) ->    
+range_blocks(Start, End, SafeBlockSize, UUID) ->
+    SkipInitial = Start rem SafeBlockSize,
+    KeepFinal = (End rem SafeBlockSize) + 1,
+    lager:debug("InitialBlock: ~p, FinalBlock: ~p~n",
+                [Start div SafeBlockSize, End div SafeBlockSize]),
+    lager:debug("SkipInitial: ~p, KeepFinal: ~p~n", [SkipInitial, KeepFinal]),
+    {[{UUID, B} || B <- lists:seq(Start div SafeBlockSize, End div SafeBlockSize)],
+     SkipInitial, KeepFinal}.
+
+block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest) ->
     block_sequences_for_manifest(Manifest?MANIFEST{props=[]});
 block_sequences_for_manifest(?MANIFEST{uuid=UUID,
                                        content_length=ContentLength}=Manifest)->
@@ -119,16 +128,65 @@ block_sequences_for_manifest(?MANIFEST{uuid=UUID,
                              PM <- Src])
     end.
 
-%% TODO: multipart is NOT yet considered.
-block_sequences_for_manifest(?MANIFEST{uuid=UUID} = Manifest, {Start, End}) ->
+block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest, {Start, End}) ->
+    block_sequences_for_manifest(Manifest?MANIFEST{props=[]}, {Start, End});
+block_sequences_for_manifest(?MANIFEST{uuid=UUID}=Manifest,
+                             {Start, End})->
     SafeBlockSize = safe_block_size_from_manifest(Manifest),
-    SkipInitial = Start rem SafeBlockSize,
-    KeepFinal = (End rem SafeBlockSize) + 1,
-    lager:debug("InitialBlock: ~p, FinalBlock: ~p~n",
-                [Start div SafeBlockSize, End div SafeBlockSize]),
-    lager:debug("SkipInitial: ~p, KeepFinal: ~p~n", [SkipInitial, KeepFinal]),
-    {[{UUID, B} || B <- lists:seq(Start div SafeBlockSize, End div SafeBlockSize)],
-     SkipInitial, KeepFinal}.
+    case riak_cs_mp_utils:get_mp_manifest(Manifest) of
+        undefined ->
+            range_blocks(Start, End, SafeBlockSize, UUID);
+        MpM ->
+            PartManifests = MpM?MULTIPART_MANIFEST.parts,
+            block_sequences_for_part_manifests_skip(SafeBlockSize, PartManifests,
+                                                    Start, End)
+    end.
+
+block_sequences_for_part_manifests_skip(SafeBlockSize, [PM | Rest],
+                                        StartOffset, EndOffset) ->
+    lager:debug("StartOffset: ~p, EndOffset: ~p, PartLength: ~p~n",
+                [StartOffset, EndOffset, PM?PART_MANIFEST.content_length]),
+    case PM?PART_MANIFEST.content_length of
+        %% Skipped
+        PartLength when PartLength =< StartOffset ->
+            block_sequences_for_part_manifests_skip(
+              SafeBlockSize, Rest,
+              StartOffset - PartLength, EndOffset - PartLength);
+        %% The first block, more blocks needed
+        PartLength when PartLength =< EndOffset ->
+            {Blocks, SkipInitial, _KeepFinal} =
+                range_blocks(StartOffset, PartLength - 1,
+                               SafeBlockSize, PM?PART_MANIFEST.part_id),
+            block_sequences_for_part_manifests_keep(
+              SafeBlockSize, SkipInitial, Rest,
+              EndOffset - PartLength, [Blocks]);
+        %% The first block, also the last
+        _PartLength ->
+            range_blocks(StartOffset, EndOffset,
+                         SafeBlockSize, PM?PART_MANIFEST.part_id)
+    end.
+
+block_sequences_for_part_manifests_keep(SafeBlockSize, SkipInitial, [PM | Rest],
+                                        EndOffset, ListOfBlocks) ->
+    lager:debug("EndOffset: EndOffset: ~p, PartLength: ~p~n",
+                [EndOffset, PM?PART_MANIFEST.content_length]),
+    case PM?PART_MANIFEST.content_length of
+        %% More blocks needed
+        PartLength when PartLength =< EndOffset ->
+            block_sequences_for_part_manifests_keep(
+              SafeBlockSize, SkipInitial, Rest,
+              EndOffset - PartLength,
+              [initial_blocks(PM?PART_MANIFEST.content_length,
+                              SafeBlockSize, PM?PART_MANIFEST.part_id)
+               | ListOfBlocks]);
+        %% Reaches to the last block
+        _PartLength ->
+            {Blocks, _SkipInitial, KeepFinal}
+                = range_blocks(0, EndOffset,
+                               SafeBlockSize, PM?PART_MANIFEST.part_id),
+            {lists:append(lists:reverse([Blocks | ListOfBlocks])),
+             SkipInitial, KeepFinal}
+    end.
 
 %% @doc Return the configured file block fetch concurrency .
 -spec fetch_concurrency() -> pos_integer().

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -53,6 +53,7 @@ error_message(malformed_policy_principal) -> "Invalid principal in policy";
 error_message(malformed_policy_action) -> "Policy has invalid action";
 error_message(no_such_bucket_policy) -> "The bucket policy does not exist";
 error_message(bad_request) -> "Bad Request";
+error_message(invalid_range) -> "The requested range is not satisfiable";
 error_message(_) -> "Please reduce your request rate.".
 
 error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
@@ -74,6 +75,7 @@ error_code(malformed_policy_principal) -> "MalformedPolicy";
 error_code(malformed_policy_action) -> "MalformedPolicy";
 error_code(no_such_bucket_policy) -> "NoSuchBucketPolicy";
 error_code(bad_request) -> "BadRequest";
+error_code(invalid_range) -> "InvalidRange";
 error_code(_) -> "ServiceUnavailable".
 
 status_code(invalid_access_key_id) -> 403;
@@ -96,6 +98,7 @@ status_code(malformed_policy_principal) -> 400;
 status_code(malformed_policy_action) -> 400;
 status_code(no_such_bucket_policy) -> 404;
 status_code(bad_request) -> 400;
+status_code(invalid_range) -> 416;
 status_code(_) -> 503.
 
 

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -127,27 +127,40 @@ produce_body(RD, Ctx=#context{local_context=LocalCtx,
                _ -> <<"object_get">>
            end,
     riak_cs_dtrace:dt_object_entry(?MODULE, Func, [], [UserName, BFile_str]),
-    ContentLength = Mfst?MANIFEST.content_length,
+    ResourceLength = Mfst?MANIFEST.content_length,
     ContentMd5 = Mfst?MANIFEST.content_md5,
     LastModified = riak_cs_wm_utils:to_rfc_1123(Mfst?MANIFEST.created),
     ETag = "\"" ++ riak_cs_utils:binary_to_hexlist(ContentMd5) ++ "\"",
+    {{Start, End}, IsRange} = parse_range(RD, ResourceLength),
     NewRQ = lists:foldl(fun({K, V}, Rq) -> wrq:set_resp_header(K, V, Rq) end,
                         RD,
                         [{"ETag",  ETag},
                          {"Last-Modified", LastModified}
                         ] ++  Mfst?MANIFEST.metadata),
-    case Method == 'HEAD'
-        orelse
-    ContentLength == 0 of
-        true ->
-            riak_cs_get_fsm:stop(GetFsmPid),
-            StreamFun = fun() -> {<<>>, done} end;
-        false ->
-            riak_cs_get_fsm:continue(GetFsmPid),
-            StreamFun = fun() -> riak_cs_wm_utils:streaming_get(
+    StreamOp =
+        case Method == 'HEAD'
+            orelse
+            ResourceLength == 0 of
+            true ->
+                riak_cs_get_fsm:stop(GetFsmPid),
+                {known_length_stream, ResourceLength, fun() -> {<<>>, done} end};
+            false ->
+                riak_cs_get_fsm:continue(GetFsmPid, {Start, End}),
+                case IsRange of
+                    false ->
+                        {known_length_stream, ResourceLength,
+                         {<<>>, fun() ->
+                                        riak_cs_wm_utils:streaming_get(
+                                          GetFsmPid, StartTime, UserName, BFile_str)
+                                end}};
+                    true ->
+                        {stream, ResourceLength,
+                         fun(_RangeStart, _RangeEnd) ->
+                                 riak_cs_wm_utils:streaming_get(
                                    GetFsmPid, StartTime, UserName, BFile_str)
-                        end
-    end,
+                         end}
+                end
+        end,
     if Method == 'HEAD' ->
             riak_cs_dtrace:dt_object_return(?MODULE, <<"object_head">>,
                                                [], [UserName, BFile_str]),
@@ -155,7 +168,32 @@ produce_body(RD, Ctx=#context{local_context=LocalCtx,
        true ->
             ok
     end,
-    {{known_length_stream, ContentLength, {<<>>, StreamFun}}, NewRQ, Ctx}.
+    {StreamOp, NewRQ, Ctx}.
+
+parse_range(RD, ResourceLength) ->
+    case wrq:get_req_header("range", RD) of
+        undefined ->
+            {{0, ResourceLength - 1}, false};
+        RawRange ->
+            case webmachine_util:parse_range(RawRange, ResourceLength) of
+                [] ->
+                    %% TODO: S3 responds with 416
+                    %% HTTP/1.1 416 Requested Range Not Satisfiable
+                    %% Content-Type: application/xml
+                    %% <Error><Code>InvalidRange</Code>
+                    %% <Message>The requested range is not satisfiable</Message>
+                    %% <ActualObjectSize>11</ActualObjectSize>
+                    %% <RangeRequested>bytes=14-15</RangeRequested></Error>
+                    error(invalid_range);
+                [SingleRange] ->
+                    {SingleRange, true};
+                _MultipleRanges ->
+                    %% S3 responds full resource without a Content-Range header
+                    %% TODO: Not yet implemented
+                    throw(not_yet_implemented)
+                    %% {{0, ResourceLength - 1}, false}
+            end
+    end.
 
 %% @doc Callback for deleting an object.
 -spec delete_resource(#wm_reqdata{}, #context{}) -> {true, #wm_reqdata{}, #context{}}.

--- a/test/riak_cs_get_fsm_test.erl
+++ b/test/riak_cs_get_fsm_test.erl
@@ -65,7 +65,7 @@ test_n_chunks_builder(N) ->
             {ok, Pid} = riak_cs_get_fsm:test_link(<<"bucket">>, <<"key">>, ContentLength, BlockSize),
             Manifest = riak_cs_get_fsm:get_manifest(Pid),
             ?assertEqual(ContentLength, Manifest?MANIFEST.content_length),
-            riak_cs_get_fsm:continue(Pid),
+            riak_cs_get_fsm:continue(Pid, {0, ContentLength - 1}),
             try
                 expect_n_bytes(Pid, N, ContentLength)
             after


### PR DESCRIPTION
We aren't supporting the HTTP "Range" header, e.g.

```
GET http://test.s3.amazonaws.com/foofoo5.txt HTTP/1.1
Host: test.s3.amazonaws.com
Accept-Encoding: identity
Authorization: AWS NP3ZEHK_H9MBSHEP2XWS:5REBtA1MXLk+t5QHMz4Kx5mBzVQ=
x-amz-date: Fri, 19 Oct 2012 22:28:45 +0000
Range: bytes=1-
```

To duplicate via s3cmd:
1. Store a file of any size, call it `s3://buck/foo-object`
2. `echo bar > foo-object`
3. `s3cmd get --continue s3://buck/foo-object`

The output is:

```
[...]
DEBUG: Requesting Range: 4 .. end
DEBUG: Response: {'status': 500, 'headers': {'content-length': '170', 'server': 'MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)', 'last-modified': 'Sat, 20 Oct 2012 03:26:52 GMT', 'etag': '"78b295896cccae248b9ef825147a642f"', 'date': 'Fri, 19 Oct 2012 22:33:17 GMT', 'content-type': 'text/html'}, 'reason': 'Internal Server Error'}
DEBUG: S3Error: 500 (Internal Server Error)
DEBUG: HttpHeader: content-length: 170
DEBUG: HttpHeader: server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
DEBUG: HttpHeader: last-modified: Sat, 20 Oct 2012 03:26:52 GMT
DEBUG: HttpHeader: etag: "78b295896cccae248b9ef825147a642f"
DEBUG: HttpHeader: date: Fri, 19 Oct 2012 22:33:17 GMT
DEBUG: HttpHeader: content-type: text/html
ERROR: S3 error: 500 (Internal Server Error): 
```

And the error from the CS node is:

```
17:33:17.672 [error] webmachine error: path="/test/foofoo5.txt"
[{webmachine_request,range_parts,[{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[[resource_module|riak_cs_wm_key],['content-type',116,101,120,116,47,112,108,97,105,110]],[],[['content-encoding',105,100,101,110,116,105,116,121]],[],[],[],[],[],[],[],[]}}},undefined,"127.0.0.1",{wm_reqdata,'GET',http,{1,1},"127.0.0.1",{wm_reqstate,#Port<0.6013>,{dict,3,16,16,8,80,48,{[],...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...},...],...},...]
```

---

Required PRs
- Webmachine: https://github.com/basho/webmachine/pull/124
- mochiweb: https://github.com/basho/mochiweb/pull/7

Implementation TODOs:
- [x] GET object which is uploaded by multipart
