### PR TITLE
Siblings error after creating bucket

### DIFF
--- a/include/s3_api.hrl
+++ b/include/s3_api.hrl
@@ -95,6 +95,7 @@
           version = <<"2008-10-17">> :: binary(),  % no other value is allowed than default
           id = undefined :: undefined | binary(),  % had better use uuid: should be UNIQUE
           statement = [] :: [#statement{}]
+          creation_time=os:timestamp() :: erlang:timestamp()
          }).
 
 

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -398,96 +398,110 @@ extract_metadata(Headers) ->
 
 -spec bucket_access_authorize_helper(AccessType::atom(), boolean(),
                                      RD::term(), Ctx::#context{}) -> term().
-bucket_access_authorize_helper(AccessType, Deletable,
-                               RD, #context{user=User,
-                                            policy_module=PolicyMod,
-                                            riakc_pid=RiakPid}=Ctx)
-  when ( AccessType =:= bucket_acl orelse
-         AccessType =:= bucket_policy orelse
-         AccessType =:= bucket_location orelse
-         AccessType =:= bucket_version orelse
-         AccessType =:= bucket )
-       andalso is_boolean(Deletable) ->
-
+bucket_access_authorize_helper(AccessType, Deletable, RD, Ctx) ->
+    #context{riakc_pid=RiakPid,
+             policy_module=PolicyMod} = Ctx,
     Method = wrq:method(RD),
     RequestedAccess =
-        case AccessType of
-            bucket_acl -> riak_cs_acl_utils:requested_access(Method, true);
-            _ ->      riak_cs_acl_utils:requested_access(Method, false)
-        end,
-
+        riak_cs_acl_utils:requested_access(Method, is_acl_request(AccessType)),
     Bucket = list_to_binary(wrq:path_info(bucket, RD)),
     PermCtx = Ctx#context{bucket=Bucket,
                           requested_perm=RequestedAccess},
+    handle_bucket_acl_policy_response(
+      riak_cs_utils:get_bucket_acl_policy(Bucket, PolicyMod, RiakPid),
+      AccessType,
+      Deletable,
+      RD,
+      PermCtx).
 
-    case riak_cs_utils:get_bucket_acl_policy(Bucket, RiakPid) of
-        {error, notfound} ->
-            riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
+handle_bucket_acl_policy_response({error, notfound}, _, _, RD, Ctx) ->
+    riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
+handle_bucket_acl_policy_response({error, Reason}, _, _, RD, Ctx) ->
+    riak_cs_s3_response:api_error(Reason, RD, Ctx);
+handle_bucket_acl_policy_response({Acl, Policy}, AccessType, DeleteEligible, RD, Ctx) ->
+    #context{bucket=Bucket,
+             riakc_pid=RiakPid,
+             user=User,
+             requested_perm=RequestedAccess} = Ctx,
+    AclCheckRes = riak_cs_acl_utils:check_grants(User,
+                                                 Bucket,
+                                                 RequestedAccess,
+                                                 RiakPid,
+                                                 Acl),
+    Deletable = DeleteEligible andalso (RequestedAccess =:= 'WRITE'),
+    handle_acl_check_result(AclCheckRes, Acl, Policy, AccessType, Deletable, RD, Ctx).
 
-        {error, Reason} when is_atom(Reason) ->
-            riak_cs_s3_response:api_error(Reason, RD, Ctx);
+handle_acl_check_result(true, _, undefined, _, _, RD, Ctx) ->
+    %% because users are not allowed to create/destroy
+    %% buckets, we can assume that User is not
+    %% undefined here
+    AccessRD = riak_cs_access_log_handler:set_user(Ctx#context.user, RD),
+    {false, AccessRD, Ctx};
+handle_acl_check_result(true, _, Policy, AccessType, _, RD, Ctx) ->
+    %% because users are not allowed to create/destroy
+    %% buckets, we can assume that User is not
+    %% undefined here
+    User = Ctx#context.user,
+    PolicyMod = Ctx#context.policy_module,
+    AccessRD = riak_cs_access_log_handler:set_user(User, RD),
+    Access = PolicyMod:reqdata_to_access(RD, AccessType,
+                                         User?RCS_USER.canonical_id),
+    case PolicyMod:eval(Access, Policy) of
+        false ->     riak_cs_wm_utils:deny_access(AccessRD, Ctx);
+        _ ->      {false, AccessRD, Ctx}
+    end;
+handle_acl_check_result({true, _OwnerId}, _, _, _, true, RD, Ctx) ->
+    %% grants lied: this is a delete, and only the owner is allowed to
+    %% do that; setting user for the request anyway, so the error
+    %% tally is logged for them
+    AccessRD = riak_cs_access_log_handler:set_user(Ctx#context.user, RD),
+    riak_cs_wm_utils:deny_access(AccessRD, Ctx);
+handle_acl_check_result({true, OwnerId}, _, _, _, _, RD, Ctx) ->
+    %% this operation is allowed, but we need to get the owner's
+    %% record, and log the access against them instead of the actor
+    riak_cs_wm_utils:shift_to_owner(RD, Ctx, OwnerId, Ctx#context.riakc_pid);
+handle_acl_check_result(false, _, undefined, _, _Deletable, RD, Ctx) ->
+    %% No policy so emulate a policy eval failure to avoid code duplication
+    handle_policy_eval_result(Ctx#context.user, false, undefined, RD, Ctx);
+handle_acl_check_result(false, Acl, Policy, AccessType, _Deletable, RD, Ctx) ->
+    #context{riakc_pid=RiakPid,
+             user=User} = Ctx,
+    PolicyMod = Ctx#context.policy_module,
+    Access = PolicyMod:reqdata_to_access(RD,
+                                         AccessType,
+                                         User?RCS_USER.canonical_id),
+    PolicyResult = PolicyMod:eval(Access, Policy),
+    OwnerId = riak_cs_acl:owner_id(Acl, RiakPid),
+    handle_policy_eval_result(User, PolicyResult, OwnerId, RD, Ctx).
 
-        {ok, {BucketAcl, Policy}} ->
-
-            case riak_cs_acl_utils:check_grants(User,Bucket,RequestedAccess,RiakPid,BucketAcl) of
-                true ->
-                    %% because users are not allowed to create/destroy
-                    %% buckets, we can assume that User is not
-                    %% undefined here
-                    AccessRD = riak_cs_access_log_handler:set_user(User, RD),
-                    Access = PolicyMod:reqdata_to_access(RD, AccessType,
-                                                         User?RCS_USER.canonical_id),
-                    case PolicyMod:eval(Access, Policy) of
-                        true ->      {false, AccessRD, PermCtx};
-                        undefined -> {false, AccessRD, PermCtx};
-                        false ->     riak_cs_wm_utils:deny_access(AccessRD, Ctx)
-                    end;
-
-                {true, _OwnerId} when Deletable andalso (RequestedAccess == 'WRITE') ->
-                    %% grants lied: this is a delete, and only the
-                    %% owner is allowed to do that; setting user for
-                    %% the request anyway, so the error tally is
-                    %% logged for them
-                    AccessRD = riak_cs_access_log_handler:set_user(User, RD),
-                    riak_cs_wm_utils:deny_access(AccessRD, PermCtx);
-
-                {true, OwnerId} ->
-                    %% this operation is allowed, but we need to get
-                    %% the owner's record, and log the access against
-                    %% them instead of the actor
-                    riak_cs_wm_utils:shift_to_owner(RD, PermCtx, OwnerId, RiakPid);
-
-                false ->
-                    Access = PolicyMod:reqdata_to_access(RD, AccessType,
-                                                         User?RCS_USER.canonical_id),
-                    PolicyResult = PolicyMod:eval(Access, Policy),
-
-                    case {User, PolicyResult} of
-                        {undefined, _} ->
-                            %% no facility for logging bad access
-                            %% against unknown actors
-                            AccessRD = RD,
-                            riak_cs_wm_utils:deny_access(AccessRD, PermCtx);
-                        {_, true} ->
-                            OwnerId = riak_cs_acl:owner_id(BucketAcl, RiakPid),
-                            %% Policy says yes while ACL says no
-                            riak_cs_wm_utils:shift_to_owner(RD, PermCtx, OwnerId, RiakPid);
-
-                        {_, _} ->
-                            %% log bad requests against the actors
-                            %% that make them
-                            AccessRD = riak_cs_access_log_handler:set_user(User, RD),
-                            %% Check if the bucket actually exists so we can
-                            %% make the correct decision to return a 404 or 403
-                            case riak_cs_utils:check_bucket_exists(Bucket, RiakPid) of
-                                {ok, _} ->
-                                    riak_cs_wm_utils:deny_access(AccessRD, PermCtx);
-                                {error, Reason} ->
-                                    riak_cs_s3_response:api_error(Reason, RD, Ctx)
-                            end
-                    end
-            end
+handle_policy_eval_result(undefined, _, _, RD, Ctx) ->
+    %% no facility for logging bad access
+    %% against unknown actors
+    riak_cs_wm_utils:deny_access(RD, Ctx);
+handle_policy_eval_result(_, true, OwnerId, RD, Ctx) ->
+    %% Policy says yes while ACL says no
+    riak_cs_wm_utils:shift_to_owner(RD, Ctx, OwnerId, Ctx#context.riakc_pid);
+handle_policy_eval_result(User, _, _, RD, Ctx) ->
+    #context{riakc_pid=RiakPid,
+             user=User,
+             bucket=Bucket} = Ctx,
+    %% log bad requests against the actors that make them
+    AccessRD = riak_cs_access_log_handler:set_user(User, RD),
+    %% Check if the bucket actually exists so we can
+    %% make the correct decision to return a 404 or 403
+    case riak_cs_utils:check_bucket_exists(Bucket, RiakPid) of
+        {ok, _} ->
+            riak_cs_wm_utils:deny_access(AccessRD, Ctx);
+        {error, Reason} ->
+            riak_cs_s3_response:api_error(Reason, RD, Ctx)
     end.
+
+-spec is_acl_request(atom()) -> boolean().
+is_acl_request(ReqType) when ReqType =:= bucket_acl orelse
+                             ReqType =:= object_acl ->
+    true;
+is_acl_request(_) ->
+    false.
 
 -spec object_access_authorize_helper(AccessType::atom(), boolean(),
                                      RD::term(), Ctx::term()) -> term().
@@ -520,7 +534,7 @@ object_access_authorize_helper(AccessType, Deletable,
                     _ ->        Mfst?MANIFEST.acl
                 end,
 
-    {ok, {_BucketAcl, Policy}} = riak_cs_utils:get_bucket_acl_policy(Bucket, RiakPid),
+    Policy = PolicyMod:bucket_policy(Bucket, RiakPid),
     Access = PolicyMod:reqdata_to_access(RD, AccessType, CanonicalId),
 
     case {riak_cs_acl:object_access(Bucket,

--- a/test/riak_cs_s3_policy_test.erl
+++ b/test/riak_cs_s3_policy_test.erl
@@ -36,8 +36,10 @@ empty_statement_conversion_test()->
     JsonPolicy = "{\"Version\":\"2008-10-17\",\"Id\":\"hello\",\"Statement\":[]}",
     ?assertEqual(list_to_binary(JsonPolicy),
                  riak_cs_s3_policy:policy_to_json_term(Policy)),
-    ?assertEqual({ok, Policy},
-                 riak_cs_s3_policy:policy_from_json(list_to_binary(JsonPolicy))).
+    {ok, PolicyFromJson} = riak_cs_s3_policy:policy_from_json(list_to_binary(JsonPolicy)),
+    ?assertEqual(Policy?POLICY.id, PolicyFromJson?POLICY.id),
+    ?assertEqual(Policy?POLICY.statement, PolicyFromJson?POLICY.statement),
+    ?assertEqual(Policy?POLICY.version, PolicyFromJson?POLICY.version).
 
 sample_plain_allow_policy()->
     <<"{"
@@ -88,8 +90,11 @@ sample_policy_check_test()->
 sample_conversion_test()->
     JsonPolicy0 = sample_plain_allow_policy(),
     {ok, Policy} = riak_cs_s3_policy:policy_from_json(JsonPolicy0),
-    ?assertEqual({ok, Policy},
-                 riak_cs_s3_policy:policy_from_json(riak_cs_s3_policy:policy_to_json_term(Policy))).
+    {ok, PolicyFromJson} = riak_cs_s3_policy:policy_from_json(riak_cs_s3_policy:policy_to_json_term(Policy)),
+    ?assertEqual(Policy?POLICY.id, PolicyFromJson?POLICY.id),
+    ?assertEqual(Policy?POLICY.statement, PolicyFromJson?POLICY.statement),
+    ?assertEqual(Policy?POLICY.version, PolicyFromJson?POLICY.version).
+
 
 eval_all_ip_addr_test() ->
     ?assert(riak_cs_s3_policy:eval_all_ip_addr([{{192,168,0,1},{255,255,255,255}}], {192,168,0,1})),
@@ -106,7 +111,7 @@ eval_ip_addresses_test()->
                                               [{'aws:SourceIp', {{1,1,1,1}, {255,255,255,0}}},
                                                {'aws:SourceIp', {{23,23,0,0},{255,255,0,0}}}, hage])).
 
-eval_condition_test()->    
+eval_condition_test()->
     ?assert(riak_cs_s3_policy:eval_condition(#wm_reqdata{peer = "23.23.23.23"},
                                              {'IpAddress', [garbage,{chiba, boo},"saitama",
                                                             {'aws:SourceIp', {{23,23,0,0},{255,255,0,0}}}, hage]})).


### PR DESCRIPTION
This test is a bit artificial, but it simulates a network split case that can happen with Riak, and it creates a bucket that appears to be completely unaccessible afterward.  All attempts to access the bucket seem to throw this exception in riakc_object:

```
webmachine error: path="/testtest/"
{throw,siblings,[{riakc_obj,get_metadata,1,[{file,"src/riakc_obj.erl"},{line,147}]},{riak_cs_acl,bucket_acl,2,[{file,"src/riak_cs_acl.erl"},{line,125}]},{riak_cs_acl,bucket_access,4,[{file,"src/riak_cs_acl.erl"},{line,94}]},{riak_cs_wm_bucket,check_permission,2,[{file,"src/riak_cs_wm_bucket.erl"},{line,83}]},{riak_cs_wm_bucket,forbidden,2,[{file,"src/riak_cs_wm_bucket.erl"},{line,51}]},{webmachine_resource,resource_call,3,[{file,"src/webmachine_resource.erl"},{line,166}]},{webmachine_resource,do,3,[{file,"src/webmachine_resource.erl"},{line,125}]},{webmachine_decision_core,resource_call,1,[{file,"src/webmachine_decision_core.erl"},{line,48}]}]}
```

Steps to reproduce:
1. Create a 2 node cluster.  I used these options in the `riak_core` section of `app.config`, in case it's helpful.
   {ring_creation_size, 8},
   {default_bucket_props, [{allow_mult,true}]},
2. Shut down node #2.
3. Create the bucket: `s3cmd mb s3://testtest`
4. Put a file into the bucket: `s3cmd put ~/foo s3://testtest/foo1`
   - Not clear if this is 100% necessary, but it is fun.
5. Stop Riak node #1 and start Riak node #2.
   - It is probably necessary to alter your Riak CS & Stanchion configs to use the PB port for Riak.  If so, then stop, edit, & restart CS and Stanchion
6. Create the bucket again: `s3cmd mb s3://testtest`.  The creation is successful.
7. Put a file: `s3cmd put ~/foo s3://testtest/foo2`, get the siblings error.
8. All subsequent attempts to access the bucket fail.  The `s3cmd` output says:
   
   DEBUG: Response: {'status': 500, 'headers': {'date': 'Sat, 24 Nov 2012 22:21:49 GMT', 'content-length': '170', 'content-type': 'text/html', 'server': 'MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)'}, 'reason': 'Internal Server Error', 'data': '<html><head><title>500 Internal Server Error</title></head><body><h1>Internal Server Error</h1>The server encountered an error while processing this request</body></html>'}
   DEBUG: S3Error: 500 (Internal Server Error)
   DEBUG: HttpHeader: date: Sat, 24 Nov 2012 22:21:49 GMT
   DEBUG: HttpHeader: content-length: 170
   DEBUG: HttpHeader: content-type: text/html
   DEBUG: HttpHeader: server: MochiWeb/1.1 WebMachine/1.9.0 (someone had painted it blue)
