### PR TITLE
Update include/s3_api.hrl

### DIFF
--- a/include/s3_api.hrl
+++ b/include/s3_api.hrl
@@ -94,7 +94,7 @@
 -record(policy_v1, {
           version = <<"2008-10-17">> :: binary(),  % no other value is allowed than default
           id = undefined :: undefined | binary(),  % had better use uuid: should be UNIQUE
-          statement = [] :: [#statement{}]
+          statement = [] :: [#statement{}],
           creation_time=os:timestamp() :: erlang:timestamp()
          }).
 


### PR DESCRIPTION
`make rel` stopped with this bug.
- Added a comma into `-record(policy_v1)` definition
