### PR TITLE
Unquote URLs in the rewrite module

### DIFF
--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -29,7 +29,10 @@ rewrite(Method, _Scheme, _Vsn, Headers, RawPath) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"rewrite">>),
     Host = mochiweb_headers:get_value("host", Headers),
     HostBucket = bucket_from_host(Host),
-    {Path, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
+    %% Unquote the URL to accomodate some naughty client libs (looking
+    %% at you Fog)
+    {Path, QueryString, _} = mochiweb_util:urlsplit_path(
+                               mochiweb_util:unquote(RawPath)),
     RewrittenPath = rewrite_path(Method, Path, QueryString, HostBucket),
     RewrittenHeaders = mochiweb_headers:default(?RCS_REWRITE_HEADER,
                                                 rcs_rewrite_header(RawPath, HostBucket),

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -362,11 +362,11 @@ post_authentication({error, no_user_key}, RD, Ctx, _, false) ->
     riak_cs_wm_utils:deny_access(RD, Ctx);
 post_authentication({error, bad_auth}, RD, Ctx, _, _) ->
     %% given keyid was found, but signature didn't match
-    _ = lager:info("bad_auth"),
+    _ = lager:debug("bad_auth"),
     riak_cs_wm_utils:deny_access(RD, Ctx);
-post_authentication({error, _Reason}, RD, Ctx, _, _) ->
+post_authentication({error, Reason}, RD, Ctx, _, _) ->
     %% no matching keyid was found, or lookup failed
-    _ = lager:info("other"),
+    _ = lager:debug("Authentication error: ~p", [Reason]),
     riak_cs_wm_utils:deny_invalid_key(RD, Ctx).
 
 

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -145,11 +145,11 @@ handle_validation_response({error, no_user_key}, RD, Ctx, _, Conv2KeyCtx, false)
     deny_access(RD, Conv2KeyCtx(Ctx));
 handle_validation_response({error, bad_auth}, RD, Ctx, _, Conv2KeyCtx, _) ->
     %% given keyid was found, but signature didn't match
-    _ = lager:info("bad_auth"),
+    _ = lager:debug("bad_auth"),
     deny_access(RD, Conv2KeyCtx(Ctx));
-handle_validation_response({error, _Reason}, RD, Ctx, _, Conv2KeyCtx, _) ->
+handle_validation_response({error, Reason}, RD, Ctx, _, Conv2KeyCtx, _) ->
     %% no matching keyid was found, or lookup failed
-    _ = lager:info("other"),
+    _ = lager:debug("Authentication error: ~p", [Reason]),
     deny_invalid_key(RD, Conv2KeyCtx(Ctx)).
 
 %% @doc Look for an Authorization header in the request, and validate


### PR DESCRIPTION
Unquote URLs in the rewrite module to account for client libraries that escape the slash characters in URLs.

A test run with setting `auth_bypass` to `true` prior to this change:

```
10:16:30:s3tmp $ curl localhost:8080/riak-cs/user%2FA4JOE4IP-_O-WL2X8IQQ -H 'Authorization: A4JOE4IP-_O-WL2X8IQQ' -v
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* connected
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /riak-cs/user%2FA4JOE4IP-_O-WL2X8IQQ HTTP/1.1
> User-Agent: curl/7.28.0
> Host: localhost:8080
> Accept: */*
> Authorization: A4JOE4IP-_O-WL2X8IQQ
> 
< HTTP/1.1 404 Object Not Found
< Server: Riak CS
< Date: Tue, 19 Feb 2013 17:16:42 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
* Closing connection #0
```

And the same query with this change:

```
10:16:42:s3tmp $ curl localhost:8080/riak-cs/user%2FA4JOE4IP-_O-WL2X8IQQ -H 'Authorization: A4JOE4IP-_O-WL2X8IQQ' -v
* About to connect() to localhost port 8080 (#0)
*   Trying ::1...
* Connection refused
*   Trying 127.0.0.1...
* connected
* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /riak-cs/user%2FA4JOE4IP-_O-WL2X8IQQ HTTP/1.1
> User-Agent: curl/7.28.0
> Host: localhost:8080
> Accept: */*
> Authorization: A4JOE4IP-_O-WL2X8IQQ
> 
< HTTP/1.1 200 OK
< Vary: Accept
< Server: Riak CS
< ETag: "920ab5fead303750f3a97bae728609a8"
< Date: Tue, 19 Feb 2013 17:21:43 GMT
< Content-Type: application/xml
< Content-Length: 325
< 
* Connection #0 to host localhost left intact
<?xml version="1.0" encoding="UTF-8"?><User><Email>test1@test.com</Email><DisplayName>test1</DisplayName><Name>test1</Name><KeyId>A4JOE4IP-_O-WL2X8IQQ</KeyId><KeySecret>D58jqU0snKwegE_xIu0O-A7jrDFdbwh5Qyhr-A==</KeySecret><Id>b1071cc41ae85354e3452803199ef99b95d03ec079fbbffe0f4ca1c6951ff3ad</Id><Status>enabled</Status></User>* Closing connection #0
```
