### PR TITLE
Gh420 multipart part size enforcement

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -106,7 +106,8 @@ cs_config() ->
        {proxy_get, enabled},
        {anonymous_user_creation, true},
        {riak_pb_port, 10017},
-       {stanchion_port, 9095}
+       {stanchion_port, 9095},
+       {cs_version, 010300}
       ]
      }].
 

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -37,6 +37,8 @@ error_message(user_already_exists) ->
     "The specified email address has already been registered. Email addresses must be unique among all users of the system. Please try again with a different email address.";
 error_message(entity_too_large) ->
     "Your proposed upload exceeds the maximum allowed object size.";
+error_message(entity_too_small) ->
+    "Your proposed upload is smaller than the minimum allowed object size. Each part must be at least 5 MB in size, except the last part.";
 error_message(invalid_user_update) ->
     "The user update you requested was invalid.";
 error_message(no_such_bucket) ->
@@ -62,6 +64,9 @@ error_code(bucket_not_empty) -> "BucketNotEmpty";
 error_code(bucket_already_exists) -> "BucketAlreadyExists";
 error_code(user_already_exists) -> "UserAlreadyExists";
 error_code(entity_too_large) -> "EntityTooLarge";
+error_code(entity_too_small) -> "EntityTooSmall";
+error_code(bad_etag) -> "InvalidPart";
+error_code(bad_etag_order) -> "InvalidPartOrder";
 error_code(invalid_user_update) -> "InvalidUserUpdate";
 error_code(no_such_bucket) -> "NoSuchBucket";
 error_code({riak_connect_failed, _}) -> "RiakConnectFailed";
@@ -85,6 +90,9 @@ status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;
 status_code(user_already_exists) -> 409;
 status_code(entity_too_large) -> 400;
+status_code(entity_too_small) -> 400;
+status_code(bad_etag) -> 400;
+status_code(bad_etag_order) -> 400;
 status_code(invalid_user_update) -> 400;
 status_code(no_such_bucket) -> 404;
 status_code({riak_connect_failed, _}) -> 503;

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -142,14 +142,6 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                     XErr = riak_cs_mp_utils:make_special_error("NoSuchUpload"),
                     RD2 = wrq:set_resp_body(XErr, RD),
                     {{halt, 404}, RD2, Ctx};
-                {error, bad_etag} ->
-                    XErr = riak_cs_mp_utils:make_special_error("InvalidPart"),
-                    RD2 = wrq:set_resp_body(XErr, RD),
-                    {{halt, 400}, RD2, Ctx};
-                {error, bad_etag_order} ->
-                    XErr = riak_cs_mp_utils:make_special_error("InvalidPartOrder"),
-                    RD2 = wrq:set_resp_body(XErr, RD),
-                    {{halt, 400}, RD2, Ctx};
                 {error, Reason} ->
                     riak_cs_s3_response:api_error(Reason, RD, Ctx)
             end


### PR DESCRIPTION
For GH issue #420 

Add multipart size enforcement.

Also, Refactoring: …
- Rewrite enforce_part_size(), thanks to Brett Hazen
- Remove debugging cruft in old enforce_part_size() to throw
  artificial error for parts=5 case
- Wrap QuickCheck stuff with -ifdef(EQC).
- Use a wrapper func to convert throw -> atom false.

Also, add checks for too-small parts and mp upload result = expectation
