### PR TITLE
Use named WM router table instead of starting them

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 
 {deps, [
         {node_package, ".*", {git, "git://github.com/basho/node_package", {branch, "master"}}},
-        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "sdc-fix-multiple-routers"}}},
+        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "master"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 
 {deps, [
         {node_package, ".*", {git, "git://github.com/basho/node_package", {branch, "master"}}},
-        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "master"}}},
+        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {branch, "sdc-fix-multiple-routers"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {branch, "master"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "master"}},

--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -139,7 +139,7 @@ web_spec(Name, Config) ->
 object_web_config(Options) ->
     [{dispatch, riak_cs_web:object_api_dispatch_table()},
      {name, object_web},
-     {router_name, object_web},
+     {dispatch_group, object_web},
      {ip, proplists:get_value(cs_ip, Options)},
      {port, proplists:get_value(cs_port, Options)},
      {nodelay, true},
@@ -152,7 +152,7 @@ object_web_config(Options) ->
 admin_web_config(Options) ->
     [{dispatch, riak_cs_web:admin_api_dispatch_table()},
      {name, admin_web},
-     {router_name, admin_web},
+     {dispatch_group, admin_web},
      {ip, proplists:get_value(admin_ip, Options)},
      {port, proplists:get_value(admin_port, Options, 8000)},
      {nodelay, true},

--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -110,7 +110,6 @@ web_specs(Options) ->
                 [{admin_web, admin_web_config(Options)},
                  {object_web, object_web_config(Options)}]
         end,
-    [router_spec(Name) || {Name, _} <- WebConfigs] ++
     [web_spec(Name, Config) || {Name, Config} <- WebConfigs].
 
 -spec pool_specs(proplist()) -> [supervisor:child_spec()].
@@ -130,12 +129,6 @@ pool_spec(Name, Workers, Overflow, WorkerStop) ->
                              {stop_fun, WorkerStop}]]},
      permanent, 5000, worker, [poolboy]}.
 
--spec router_spec(atom()) -> supervisor:child_spec().
-router_spec(Name) ->
-    {list_to_atom(atom_to_list(Name) ++ "_router"),
-     {webmachine_router, start_link, [Name]},
-     permanent, 5000, worker, dynamic}.
-
 -spec web_spec(atom(), proplist()) -> supervisor:child_spec().
 web_spec(Name, Config) ->
     {Name,
@@ -145,8 +138,8 @@ web_spec(Name, Config) ->
 -spec object_web_config(proplist()) -> proplist().
 object_web_config(Options) ->
     [{dispatch, riak_cs_web:object_api_dispatch_table()},
-     {default_router, false},
      {name, object_web},
+     {router_name, object_web},
      {ip, proplists:get_value(cs_ip, Options)},
      {port, proplists:get_value(cs_port, Options)},
      {nodelay, true},
@@ -159,6 +152,7 @@ object_web_config(Options) ->
 admin_web_config(Options) ->
     [{dispatch, riak_cs_web:admin_api_dispatch_table()},
      {name, admin_web},
+     {router_name, admin_web},
      {ip, proplists:get_value(admin_ip, Options)},
      {port, proplists:get_value(admin_port, Options, 8000)},
      {nodelay, true},


### PR DESCRIPTION
- Update to work with basho/webmachine#128
- Builds on #265

@seancribbs' Webmachine change uses a single Webmachine router
(the way it used to be) and uses multiple keys in an ETS table
to support multiple dispatch routes. This change removes the custom
routers from the supervisor and adds a `router_name` to the two
webmachine options. Only one of them is used if the admin and web
config share the same interface.
