### PR TITLE
Put to a non-existent bucket -> HTTP 500 error 

### DIFF
--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -901,6 +901,8 @@ check_bucket_exists(Bucket, RiakPid) ->
                 _ ->
                     {ok, Obj}
             end;
+        {error, notfound} ->
+            {error, no_such_bucket};
         {error, _}=Error ->
             Error
     end.

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -603,7 +603,7 @@ translate_bucket_policy(PolicyMod, Bucket, RiakPid) ->
         %% 'no_such_bucket' but nothing else. if it comes it's a bug.
         {error, multiple_bucket_owners}=Error ->
             Error;
-        {error, notfound}=Error ->
+        {error, no_such_bucket}=Error ->
             Error
     end.
 

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -518,7 +518,7 @@ object_access_authorize_helper(AccessType, Deletable,
 
     #key_context{bucket=Bucket} = LocalCtx,
     case translate_bucket_policy(PolicyMod, Bucket, RiakPid) of
-        {error, multiple_bucket_owners=E} ->
+        {error, E} ->
             %% We want to bail out early if there are siblings when
             %% retrieving the bucket policy
             riak_cs_s3_response:api_error(E, RD, Ctx);
@@ -598,8 +598,13 @@ translate_bucket_policy(PolicyMod, Bucket, RiakPid) ->
             P;
         {error, policy_undefined} ->
             undefined;
+
+        %% here we are supposed to receive 'multiple_bucket_owners' or
+        %% 'no_such_bucket' but nothing else. if it comes it's a bug.
         {error, multiple_bucket_owners}=Error ->
-             Error
+            Error;
+        {error, notfound}=Error ->
+            Error
     end.
 
 %% Helper functions for dealing with combinations of Object ACL


### PR DESCRIPTION
s3cmd put ~/foo s3://testbotoXX/foo where the S3 bucket `testbotoXX` does not exist:

```
15:12:21.878 [error] webmachine error: path="/buckets/testbotoXX/objects/foo"
{error,{case_clause,{error,notfound}},[{riak_cs_wm_utils,translate_bucket_policy,3,[{file,"src/riak_cs_wm_utils.erl"},{line,596}]},{riak_cs_wm_utils,object_access_authorize_helper,4,[{file,"src/riak_cs_wm_utils.erl"},{line,520}]},{riak_cs_wm_common,authorize,2,[{file,"src/riak_cs_wm_common.erl"},{line,309}]},{riak_cs_wm_common,forbidden,2,[{file,"src/riak_cs_wm_common.erl"},{line,147}]},{webmachine_resource,resource_call,3,[{file,"src/webmachine_resource.erl"},{line,183}]},{webmachine_resource,do,3,[{file,"src/webmachine_resource.erl"},{line,141}]},{webmachine_decision_core,resource_call,1,[{file,"src/webmachine_decision_core.erl"},{line,48}]},{webmachine_decision_core,decision,1,[{file,"src/webmachine_decision_core.erl"},{line,212}]}]}
```
