### PR TITLE
Fix for 500 error when putting an object to a non-existent bucket

### DIFF
--- a/riak_test/tests/cs436_regression_test.erl
+++ b/riak_test/tests/cs436_regression_test.erl
@@ -1,0 +1,49 @@
+-module(cs436_regression_test).
+
+%% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/436">
+%% issue 436</a>. The issue description is: A 500 is returned instead of a 404 when
+%% trying to put to a nonexistent bucket.
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_BUCKET, "riak_test_bucket").
+
+confirm() ->
+    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
+
+    FirstNode = hd(RiakNodes),
+
+    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
+
+    %% User config
+    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+
+    lager:info("User is valid on the cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+
+    ?assertError({aws_error, {http_error, 404, _, _}},
+                 erlcloud_s3:put_object(?TEST_BUCKET,
+                                        "somekey",
+                                        crypto:rand_bytes(100),
+                                        UserConfig)),
+
+    %% Create and delete test bucket
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    ?assertMatch([{buckets, [[{name, ?TEST_BUCKET}, _]]}],
+        erlcloud_s3:list_buckets(UserConfig)),
+
+    lager:info("deleting bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+
+    %% Attempt to put object again and ensure result is still 404
+    ?assertError({aws_error, {http_error, 404, _, _}},
+                 erlcloud_s3:put_object(?TEST_BUCKET,
+                                        "somekey",
+                                        crypto:rand_bytes(100),
+                                        UserConfig)),
+    pass.

--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -161,8 +161,11 @@ bucket_acl(Bucket, RiakPid) ->
             %% resolve if possible.
             Contents = riakc_obj:get_contents(Obj),
             bucket_acl_from_contents(Bucket, Contents);
-        {error, _}=Error ->
-            Error
+        {error, Reason} ->
+            lager:debug("Failed to fetch ACL. Bucket ~p "
+                        " does not exist. Reason: ~p",
+                        [Bucket, Reason]),
+            {error, notfound}
     end.
 
 %% @doc Attempt to resolve an ACL for the bucket based on the contents.

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -522,6 +522,10 @@ object_access_authorize_helper(AccessType, Deletable,
             %% We want to bail out early if there are siblings when
             %% retrieving the bucket policy
             riak_cs_s3_response:api_error(E, RD, Ctx);
+        {error, notfound} ->
+            %% The call to `check_bucket_exists' returned `notfound'
+            %% so we can assume to bucket does not exist.
+            riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
         Policy ->
             check_object_authorization(AccessType, Deletable, Policy, RD, Ctx)
     end.
@@ -598,8 +602,10 @@ translate_bucket_policy(PolicyMod, Bucket, RiakPid) ->
             P;
         {error, policy_undefined} ->
             undefined;
-        {error, multiple_bucket_owners}=Error ->
-             Error
+        {error, notfound}=Error1 ->
+            Error1;
+        {error, multiple_bucket_owners}=Error2 ->
+             Error2
     end.
 
 %% Helper functions for dealing with combinations of Object ACL


### PR DESCRIPTION
Fix issue where attempting to put an object to a non-existent bucket results in a `500` instead of the expected `404`.  This is a regression introduced by some recent refactoring. Also included is a `riak_test` regression test for this issue.
