### PR TITLE
app.config cleanup

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -3,10 +3,27 @@
 [
  %% Riak CS configuration
  {riak_cs, [
+              %% == Basic Configuration ==
+
               %% Riak CS http/https port and IP address to listen at
               %% for object storage activity
               {cs_ip, "{{cs_ip}}"},
               {cs_port, {{cs_port}} } ,
+
+              %% Riak node to which Riak CS accesses
+              {riak_ip, "{{riak_ip}}"},
+              {riak_pb_port, {{riak_pb_port}} } ,
+
+              %% Configuration for access to request
+              %% serialization service
+              {stanchion_ip, "{{stanchion_ip}}"},
+              {stanchion_port, {{stanchion_port}} },
+              {stanchion_ssl, {{stanchion_ssl}} },
+
+              %% Admin user credentials. Admin access like /riak-cs/stats
+              %% requires this entry to be set properly.
+              {admin_key, "{{admin_key}}"},
+              {admin_secret, "{{admin_secret}}"},
 
               %% Port and IP address to listen on for system
               %% administration tasks. Uncomment the following lines
@@ -27,18 +44,6 @@
               %% via URL like http://bucket.s3.example.com/object/name
               {cs_root_host, "s3.amazonaws.com"},
 
-              %% Riak node to which Riak CS accesses
-              {riak_ip, "{{riak_ip}}"},
-              {riak_pb_port, {{riak_pb_port}} } ,
-
-
-              %% Enable this to allow the creation of an admin user, it's
-              %% recommended to enable this temporarily as necessary
-              {anonymous_user_creation, false},
-
-              {auth_bypass, {{auth_bypass}} } ,
-              {put_fsm_buffer_size_max, 10485760},
-
               %% Connection pools
               %% Each pool is specified as a nested
               %% tuple of {Name, {FixedSize, OverflowSize}}
@@ -48,21 +53,15 @@
                 {bucket_list_pool, {{bucket_list_pool_tuple}} }
                ]},
 
-              %% Configuration for access to bucket request
-              %% serialization service
-              {stanchion_ip, "{{stanchion_ip}}"},
-              {stanchion_port, {{stanchion_port}} },
-              {stanchion_ssl, {{stanchion_ssl}} },
+              %% == Rolling upgrade support ==
 
-              %% Admin user credentials. Admin access like /riak-cs/stats
-              %% requires this entry to be set properly.
-              {admin_key, "{{admin_key}}"},
-              {admin_secret, "{{admin_secret}}"},
-
-              %% == Riak CS stats HTTP API ==
-
-              %% true = enable the stats HTTP API, false = disable it
-              {riak_cs_stat, true},
+              %% Riak CS version number. This is used to selectively
+              %% enable new features for the current version to better
+              %% support rolling upgrades. New installs should not
+              %% need to modify this. If peforming a rolling upgrade
+              %% then set this value to 0 until all nodes have been
+              %% upgraded and then set back to the original value.
+              {cs_version, {{cs_version}} },
 
               %% == Usage recording ==
 

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -20,8 +20,18 @@
               {stanchion_port, {{stanchion_port}} },
               {stanchion_ssl, {{stanchion_ssl}} },
 
-              %% Admin user credentials. Admin access like /riak-cs/stats
-              %% requires this entry to be set properly.
+              %% Enable this to allow the creation of an admin user
+              %% when setting up a system. It is recommended to only
+              %% enable this temporarily unless your use-case
+              %% specifically dictates letting anonymous users to
+              %% create accounts.
+              {anonymous_user_creation, false},
+
+              %% Admin user credentials. Admin access like
+              %% /riak-cs/stats requires this entry to be set
+              %% properly. The credentials specified here must match
+              %% the admin credentials specified in the stanchion
+              %% app.config for the system to function properly.
               {admin_key, "{{admin_key}}"},
               {admin_secret, "{{admin_secret}}"},
 

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -25,6 +25,7 @@
 {stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
+{cs_version,        010300}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -25,6 +25,7 @@
 {stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
+{cs_version,        010300}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -25,6 +25,7 @@
 {stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
+{cs_version,        010300}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -25,6 +25,7 @@
 {stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
+{cs_version,        010300}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -25,6 +25,7 @@
 {stanchion_ssl,     false}.
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
+{cs_version,        010300}.
 
 %%
 %% etc/vm.args


### PR DESCRIPTION
Add an entry for `cs_version` to the app.config template. I think this should work since most people who are upgrading will keep their existing config files. 

Also remove some obsolete or more obscure options. _e.g._ I could not find `put_fsm_buffer_size_max` referenced anywhere in the code. Some of the options I removed may be needed, but it seems like a better approach is to handle documenting them instead of cluttering up the config file with them. Open to feedback on my choices in that regard.
