### PR TITLE
Velvet dependency to `release/1.3` branch

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}},
         {sext, ".*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, ".*", {git, "git@github.com:basho/velvet", "83f40fc3a741788ef4757d65c2dc471b743e0216"}},
+        {velvet, "1.3.*", {git, "git@github.com:basho/velvet", {branch, "release/1.3"}}},
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", "8959a00cb552636c89a612da54ae74ca7f3e7878"}},


### PR DESCRIPTION
Should mean we use lager 1.2.2 now, as shown
from `./rebar list-deps`.
