### PR TITLE
riak_test module to exercise stats

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -25,20 +25,26 @@
 -define(DEFAULT_PROTO, "http").
 
 setup(NumNodes) ->
-    Nodes = build_cluster(NumNodes),
+    %% Start the erlcloud app
+    erlcloud:start(),
+
+    {{AdminKeyId, AdminSecretKey},
+     {RiakNodes, _CSNodes, _Stanchion}=Nodes} = build_cluster(NumNodes),
+
+    AdminConfig = rtcs:config(AdminKeyId,
+                              AdminSecretKey,
+                              rtcs:cs_port(hd(RiakNodes))),
+
     %% STFU sasl
     application:load(sasl),
     application:set_env(sasl, sasl_error_logger, false),
-    %% Start the erlcloud app
-    erlcloud:start(),
-    Nodes.
+    {AdminConfig, Nodes}.
 
 build_cluster(NumNodes) ->
-     {RiakNodes, _, _} = Nodes =
-        rtcs:deploy_nodes(NumNodes, [{riak, ee_config()},
-                                     {stanchion, stanchion_config()},
-                                     {cs, cs_config()}]),
-    rt:wait_until_nodes_ready(RiakNodes),
+    {_, {RiakNodes, _, _}} = Nodes =
+        deploy_nodes(NumNodes, [{riak, ee_config()},
+                                {stanchion, stanchion_config()},
+                                {cs, cs_config()}]),
     lager:info("Build cluster"),
     rtcs:make_cluster(RiakNodes),
     rt:wait_until_ring_converged(RiakNodes),
@@ -58,9 +64,18 @@ create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),
     User = "Test User" ++ integer_to_list(UserIndex),
     Email = lists:flatten(io_lib:format("~p~p~p@basho.com", [A, B, C])),
-    {KeyId, Secret, _Id} =
-        rtcs:create_admin_user(cs_port(Node), Email, User),
+    {KeyId, Secret, _Id} = create_user(cs_port(Node), Email, User),
     lager:info("Created user ~p with keys ~p ~p", [Email, KeyId, Secret]),
+    {KeyId, Secret}.
+
+create_admin_user(Node) ->
+    User = "admin",
+    Email = "admin@me.com",
+    {KeyId, Secret, Id} = create_user(cs_port(Node), Email, User),
+    lager:info("Riak CS Admin account created with ~p",[Email]),
+    lager:info("KeyId = ~p",[KeyId]),
+    lager:info("KeySecret = ~p",[Secret]),
+    lager:info("Id = ~p",[Id]),
     {KeyId, Secret}.
 
 cs_port(Node) ->
@@ -173,24 +188,9 @@ deploy_nodes(NumNodes, InitialConfig) ->
     NL0 = lists:zip(CSNodes, RiakNodes),
     {CS1, R1} = hd(NL0),
     NodeList = [{CS1, R1, StanchionNode} | tl(NL0)],
-
     lager:info("NodeList: ~p", [NodeList]),
 
-    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
-                N = rtdev:node_id(RiakNode),
-                stop_cs(N),
-                stop_stanchion(),
-                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
-                rt:wait_until_unpingable(CSNode),
-                rt:wait_until_unpingable(Stanchion),
-                rt:wait_until_unpingable(RiakNode);
-            ({CSNode, RiakNode}) ->
-                N = rtdev:node_id(RiakNode),
-                stop_cs(N),
-                rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
-                rt:wait_until_unpingable(CSNode),
-                rt:wait_until_unpingable(RiakNode)
-        end, NodeList),
+    stop_all_nodes(NodeList),
 
     [reset_nodes(Project, Path) ||
         {Project, Path} <- [{riak_ee, rt:config(?EE_ROOT)},
@@ -202,27 +202,53 @@ deploy_nodes(NumNodes, InitialConfig) ->
     {_Versions, Configs} = lists:unzip(NodeConfig),
 
     %% Set initial config
-    rt:pmap(fun({_, default}) ->
-                    ok;
-               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
-                    N = rtdev:node_id(RiakNode),
-                    lager:info("Config: ~p~n~p", [Config, N]),
-                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
-                            Config)),
-                    update_cs_config(rt:config(?CS_CURRENT), N,
-                        proplists:get_value(cs, Config)),
-                    update_stanchion_config(rt:config(?STANCHION_CURRENT),
-                        proplists:get_value(stanchion, Config));
-                ({{_CSNode, RiakNode}, Config}) ->
-                    N = rtdev:node_id(RiakNode),
-                    lager:info("Config2: ~p~n~p", [Config, N]),
-                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
-                            Config)),
-                    update_cs_config(rt:config(?CS_CURRENT), N,
-                        proplists:get_value(cs, Config))
-            end,
-            lists:zip(NodeList, Configs)),
+    set_configs(NodeList, Configs),
+    start_all_nodes(NodeList),
 
+    Nodes = {RiakNodes, CSNodes, StanchionNode},
+    [ok = rt:wait_until_pingable(N) || N <- RiakNodes ++ CSNodes ++ [StanchionNode]],
+    [ok = rt:check_singleton_node(N) || N <- RiakNodes],
+
+    rt:wait_until_nodes_ready(RiakNodes),
+
+    %% Create admin user and set in cs and stanchion configs
+    AdminCreds = create_admin_user(hd(RiakNodes)),
+
+    %% Restart cs and stanchion nodes so admin user takes effect
+    stop_cs_and_stanchion_nodes(NodeList),
+
+    set_admin_creds_in_configs(NodeList, Configs, AdminCreds),
+
+    start_cs_and_stanchion_nodes(NodeList),
+    [ok = rt:wait_until_pingable(N) || N <- CSNodes ++ [StanchionNode]],
+
+    lager:info("Deployed nodes: ~p", [Nodes]),
+    {AdminCreds, Nodes}.
+
+start_cs_and_stanchion_nodes(NodeList) ->
+    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
+                    N = rtdev:node_id(RiakNode),
+                    start_stanchion(),
+                    start_cs(N);
+               ({_CSNode, RiakNode}) ->
+                    N = rtdev:node_id(RiakNode),
+                    start_cs(N)
+            end, NodeList).
+
+stop_cs_and_stanchion_nodes(NodeList) ->
+    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
+                    N = rtdev:node_id(RiakNode),
+                    stop_cs(N),
+                    stop_stanchion(),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(Stanchion);
+               ({CSNode, RiakNode}) ->
+                    N = rtdev:node_id(RiakNode),
+                    stop_cs(N),
+                    rt:wait_until_unpingable(CSNode)
+            end, NodeList).
+
+start_all_nodes(NodeList) ->
     rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
                     N = rtdev:node_id(RiakNode),
                     rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "start"),
@@ -234,17 +260,65 @@ deploy_nodes(NumNodes, InitialConfig) ->
                     rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "start"),
                     rt:wait_for_service(RiakNode, riak_kv),
                     start_cs(N)
-            end, NodeList),
+            end, NodeList).
 
-    Nodes = {RiakNodes, CSNodes, StanchionNode},
+stop_all_nodes(NodeList) ->
+    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
+                    N = rtdev:node_id(RiakNode),
+                    stop_cs(N),
+                    stop_stanchion(),
+                    rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(Stanchion),
+                    rt:wait_until_unpingable(RiakNode);
+               ({CSNode, RiakNode}) ->
+                    N = rtdev:node_id(RiakNode),
+                    stop_cs(N),
+                    rtdev:run_riak(N, rtdev:relpath(rtdev:node_version(N)), "stop"),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(RiakNode)
+            end, NodeList).
 
-    [ok = rt:wait_until_pingable(N) || N <- RiakNodes ++ CSNodes ++
-        [StanchionNode]],
+set_configs(NodeList, Configs) ->
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
+                                                                          Config)),
+                    update_cs_config(rt:config(?CS_CURRENT), N,
+                                     proplists:get_value(cs, Config)),
+                    update_stanchion_config(rt:config(?STANCHION_CURRENT),
+                                            proplists:get_value(stanchion, Config));
+               ({{_CSNode, RiakNode}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    rtdev:update_app_config(RiakNode, proplists:get_value(riak,
+                                                                          Config)),
+                    update_cs_config(rt:config(?CS_CURRENT), N,
+                                     proplists:get_value(cs, Config))
+            end,
+            lists:zip(NodeList, Configs)).
 
-    [ok = rt:check_singleton_node(N) || N <- RiakNodes],
-
-    lager:info("Deployed nodes: ~p", [Nodes]),
-    Nodes.
+set_admin_creds_in_configs(NodeList, Configs, AdminCreds) ->
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    update_cs_config(rt:config(?CS_CURRENT),
+                                     N,
+                                     proplists:get_value(cs, Config),
+                                     AdminCreds),
+                    update_stanchion_config(rt:config(?STANCHION_CURRENT),
+                                            proplists:get_value(stanchion, Config),
+                                            AdminCreds);
+               ({{_CSNode, RiakNode}, Config}) ->
+                    N = rtdev:node_id(RiakNode),
+                    update_cs_config(rt:config(?CS_CURRENT),
+                                     N,
+                                     proplists:get_value(cs, Config),
+                                     AdminCreds)
+            end,
+            lists:zip(NodeList, Configs)).
 
 reset_nodes(Project, Path) ->
     %% Reset nodes to base state
@@ -279,21 +353,37 @@ stop_stanchion() ->
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
+update_cs_config(Prefix, N, Config, {AdminKey, AdminSecret}) ->
+    CSSection = proplists:get_value(riak_cs, Config),
+    UpdConfig = [{riak_cs, update_admin_creds(CSSection, AdminKey, AdminSecret)} |
+                 proplists:delete(riak_cs, Config)],
+    update_cs_config(Prefix, N, UpdConfig).
+
 update_cs_config(Prefix, N, Config) ->
     CSSection = proplists:get_value(riak_cs, Config),
     UpdConfig = [{riak_cs, update_cs_port(CSSection, N)} |
-                  proplists:delete(riak_cs, Config)],
+                 proplists:delete(riak_cs, Config)],
     update_app_config(riakcs_etcpath(Prefix, N) ++ "/app.config", UpdConfig).
+
+update_admin_creds(Config, AdminKey, AdminSecret) ->
+    [{admin_key, AdminKey}, {admin_secret, AdminSecret} |
+     proplists:delete(admin_secret,
+                      proplists:delete(admin_key, Config))].
 
 update_cs_port(Config, N) ->
     PbPort = 10000 + (N * 10) + 7,
     [{riak_pb_port, PbPort} | proplists:delete(riak_pb_port, Config)].
 
+update_stanchion_config(Prefix, Config, {AdminKey, AdminSecret}) ->
+    StanchionSection = proplists:get_value(stanchion, Config),
+    UpdConfig = [{stanchion, update_admin_creds(StanchionSection, AdminKey, AdminSecret)} |
+                 proplists:delete(stanchion, Config)],
+    update_stanchion_config(Prefix, UpdConfig).
+
 update_stanchion_config(Prefix, Config) ->
     update_app_config(stanchion_etcpath(Prefix) ++ "/app.config", Config).
 
 update_app_config(ConfigFile,  Config) ->
-    lager:debug("~nReading config file at ~s~n", [ConfigFile]),
     {ok, [BaseConfig]} = file:consult(ConfigFile),
     MergeA = orddict:from_list(Config),
     MergeB = orddict:from_list(BaseConfig),
@@ -306,7 +396,6 @@ update_app_config(ConfigFile,  Config) ->
                                             end, MergeC, MergeD)
                       end, MergeA, MergeB),
     NewConfigOut = io_lib:format("~p.", [NewConfig]),
-    lager:debug("CONFIG FILE=~s~n",[ConfigFile]),
     ?assertEqual(ok, file:write_file(ConfigFile, NewConfigOut)),
     ok.
 
@@ -324,22 +413,31 @@ deploy_stanchion(Config) ->
     start_stanchion(),
     lager:info("Stanchion started").
 
-
-create_admin_user(Port, EmailAddr, Name) ->
+create_user(Port, EmailAddr, Name) ->
     lager:debug("Trying to create user ~p", [EmailAddr]),
     Cmd="curl -s -H 'Content-Type: application/json' http://localhost:" ++
         integer_to_list(Port) ++
         "/riak-cs/user --data '{\"email\":\"" ++ EmailAddr ++  "\", \"name\":\"" ++ Name ++"\"}'",
     lager:info("Cmd: ~p", [Cmd]),
-    Output = os:cmd(Cmd),
+    Delay = rt:config(rt_retry_delay),
+    Retries = rt:config(rt_max_wait_time) div Delay,
+    OutputFun = fun() -> os:cmd(Cmd) end,
+    Condition = fun(Res) -> Res /= [] end,
+    Output = wait_until(OutputFun, Condition, Retries, Delay),
     lager:debug("Create user output=~p~n",[Output]),
     {struct, JsonData} = mochijson2:decode(Output),
     KeyId = binary_to_list(proplists:get_value(<<"key_id">>, JsonData)),
     KeySecret = binary_to_list(proplists:get_value(<<"key_secret">>, JsonData)),
     Id = binary_to_list(proplists:get_value(<<"id">>, JsonData)),
-    Email = binary_to_list(proplists:get_value(<<"email">>, JsonData)),
-    lager:info("Riak CS Admin account created with ~p",[Email]),
-    lager:info("KeyId = ~p",[KeyId]),
-    lager:info("KeySecret = ~p",[KeySecret]),
-    lager:info("Id = ~p",[Id]),
     {KeyId, KeySecret, Id}.
+
+wait_until(_, _, 0, _) ->
+    fail;
+wait_until(Fun, Condition, Retries, Delay) ->
+    Result = Fun(),
+    case Condition(Result) of
+        true ->
+            Result;
+        false ->
+            wait_until(Fun, Condition, Retries-1, Delay)
+    end.

--- a/riak_test/tests/cs296_regression_test.erl
+++ b/riak_test/tests/cs296_regression_test.erl
@@ -10,14 +10,7 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/cs347_regression_test.erl
+++ b/riak_test/tests/cs347_regression_test.erl
@@ -12,14 +12,7 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/cs436_regression_test.erl
+++ b/riak_test/tests/cs436_regression_test.erl
@@ -10,14 +10,7 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -8,14 +8,7 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -13,14 +13,7 @@
 -define(BAD_PART_SIZE, 2*1024*1024).
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/object_get_conditional_test.erl
+++ b/riak_test/tests/object_get_conditional_test.erl
@@ -11,14 +11,7 @@
 -define(ETAG_NOTEXIST, "\"NoTeXiSt\"").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/object_get_test.erl
+++ b/riak_test/tests/object_get_test.erl
@@ -17,14 +17,7 @@
 
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} = rtcs:setup(4),
-
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(FirstNode)),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -6,7 +6,7 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    {RiakNodes, _CSNodes, _Stanchion} =
+    {_, {RiakNodes, _CSNodes, _Stanchion}} =
         rtcs:deploy_nodes(4, [{riak, rtcs:ee_config()},
                               {stanchion, rtcs:stanchion_config()},
                               {cs, rtcs:cs_config()}]),

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -1,0 +1,72 @@
+-module(stats_test).
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
+
+-define(TEST_BUCKET, "riak_test_bucket").
+
+confirm() ->
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
+
+    confirm_initial_stats(query_stats(UserConfig, rtcs:cs_port(hd(RiakNodes)))),
+
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    ?assertMatch([{buckets, [[{name, ?TEST_BUCKET}, _]]}],
+        erlcloud_s3:list_buckets(UserConfig)),
+
+    Object = crypto:rand_bytes(500),
+    erlcloud_s3:put_object(?TEST_BUCKET, "object_one", Object, UserConfig),
+    erlcloud_s3:get_object(?TEST_BUCKET, "object_one", UserConfig),
+    erlcloud_s3:delete_object(?TEST_BUCKET, "object_one", UserConfig),
+    erlcloud_s3:list_buckets(UserConfig),
+
+    lager:info("Confirming stats"),
+    Stats1 = query_stats(UserConfig, rtcs:cs_port(hd(RiakNodes))),
+    confirm_stat_count(Stats1, <<"service_get_buckets">>, 2),
+    confirm_stat_count(Stats1, <<"object_get">>, 1),
+    confirm_stat_count(Stats1, <<"object_put">>, 1),
+    confirm_stat_count(Stats1, <<"object_delete">>, 1),
+    pass.
+
+query_stats(UserConfig, Port) ->
+    lager:debug("Querying stats"),
+    Date = httpd_util:rfc1123_date(),
+    Cmd="curl -s -H 'Date: " ++ Date ++ "' -H 'Authorization: " ++
+        make_authorization(UserConfig, Date) ++ "' http://localhost:" ++
+        integer_to_list(Port) ++ "/riak-cs/stats",
+    lager:info("Stats query cmd: ~p", [Cmd]),
+    Output = os:cmd(Cmd),
+    lager:debug("Stats output=~p~n",[Output]),
+    {struct, JsonData} = mochijson2:decode(Output),
+    JsonData.
+
+confirm_initial_stats(StatData) ->
+    %% Check for values for all meters to be 0 when system is initially started
+    [?assertEqual([0,0.0,0.0,0.0,0.0,0.0],
+                  proplists:get_value(StatType, StatData))
+                  || StatType <- [<<"block_get">>,
+                                  <<"block_put">>,
+                                  <<"block_delete">>,
+                                  <<"service_get_buckets">>,
+                                  <<"bucket_list_keys">>,
+                                  <<"bucket_create">>,
+                                  <<"bucket_delete">>,
+                                  <<"bucket_get_acl">>,
+                                  <<"bucket_put_acl">>,
+                                  <<"object_get">>,
+                                  <<"object_put">>,
+                                  <<"object_head">>,
+                                  <<"object_delete">>,
+                                  <<"object_get_acl">>,
+                                  <<"object_put_acl">>]].
+
+confirm_stat_count(StatData, StatType, ExpectedCount) ->
+    ?assertEqual(ExpectedCount, hd(proplists:get_value(StatType, StatData))).
+
+make_authorization(Config, Date) ->
+    StringToSign = ["GET", $\n, [], $\n, [], $\n, Date, $\n, "/riak-cs/stats"],
+    Signature = base64:encode_to_string(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    lists:flatten(["AWS ", Config#aws_config.access_key_id, $:, Signature]).


### PR DESCRIPTION
Add `riak_test` module for the stats resource. Also refactor the cluster setup in the `rtcs` module so that the admin user credentials are set and the `riak_cs` and `stanchion` nodes are restarted for those settings to take effect. The `rtcs:setup` function return value has been changed to also return the admin account info and allows for some duplicated code to be eliminated in most of the test modules. These changes resolve a race condition where user creation is attempted prior to the `riak_cs` and `stanchion` applications being fully started.

Two caveats for this pr:
1. The refactoring in `rtcs` could be improved even more. I have decided to leave it as-is for the time being because I think the time right now is better spent doing other testing. 
2. The stats test is not exhaustive and could be expanded to do more. The impetus for creating this test was more to test the authentication code path it uses rather than the correct functioning of stats collection. The test does some functional verification of stats collection, but again I have elected to defer more work on it in favor or other testing tasks.
