### PR TITLE
Update erlcloud dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,6 +36,6 @@
         {velvet, "1.3.*", {git, "git@github.com:basho/velvet", {branch, "release/1.3"}}},
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", "8959a00cb552636c89a612da54ae74ca7f3e7878"}},
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", "4ee4934de744e3df95185aafe058dd5ab7980bff"}},
         {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{tag, "0.2.1"}}}
        ]}.


### PR DESCRIPTION
Forgot to upgrade after #438 and basho/erlcloud#8.
