### PR TITLE
Riak_test driver of the CS client tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BASE_DIR         = $(shell pwd)
 ERLANG_BIN       = $(shell dirname $(shell which erl))
 REBAR           ?= $(BASE_DIR)/rebar
 OVERLAY_VARS    ?=
+CS_HTTP_PORT    ?= 8080
 
 .PHONY: rel stagedevrel deps test
 
@@ -51,7 +52,7 @@ test-client: test-clojure test-python test-erlang
 test-python: test-boto
 
 test-boto:
-	@python client_tests/python/boto_test.py
+	env CS_HTTP_PORT=${CS_HTTP_PORT} python client_tests/python/boto_test.py
 
 test-erlang: compile-client-test
 	@./rebar skip_deps=true client_test_run

--- a/client_tests/erlang/erlcloud_eqc.erl
+++ b/client_tests/erlang/erlcloud_eqc.erl
@@ -79,7 +79,7 @@ eqc_test_() ->
                                                        ?QC_OUT(prop_api_test(?DEFAULT_HOST,
                                                                              ?DEFAULT_PORT,
                                                                              ?DEFAULT_PROXY_HOST,
-                                                                             ?DEFAULT_PROXY_PORT)))))}
+                                                                             cs_port())))))}
       %% {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_parallel_api_test(?DEFAULT_HOST, ?DEFAULT_PORT)))))}
      ]
     }.
@@ -273,7 +273,7 @@ test() ->
     test(?DEFAULT_HOST, ?DEFAULT_PORT).
 
 test(Host, Port) ->
-    test(Host, Port, ?DEFAULT_PROXY_HOST, ?DEFAULT_PROXY_PORT, 500).
+    test(Host, Port, ?DEFAULT_PROXY_HOST, cs_port(), 500).
 
 test(Host, Port, ProxyHost, ProxyPort, Iterations) ->
     eqc:quickcheck(eqc:numtests(Iterations, prop_api_test(Host, Port, ProxyHost, ProxyPort))).
@@ -380,5 +380,13 @@ verify_object_list_contents(_, []) ->
 verify_object_list_contents(ExpectedKeys, [HeadContent | RestContents]) ->
     Key = proplists:get_value(key, HeadContent),
     verify_object_list_contents(lists:delete(Key, ExpectedKeys), RestContents).
+
+cs_port() ->
+    case os:getenv("CS_HTTP_PORT") of
+        false ->
+            ?DEFAULT_PROXY_PORT;
+        Str ->
+            list_to_integer(Str)
+    end.
 
 -endif.

--- a/client_tests/python/boto_test.py
+++ b/client_tests/python/boto_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import httplib, json, unittest, uuid, md5
+import os, httplib, json, unittest, uuid, md5
 from cStringIO import StringIO
 
 from file_generator import FileGenerator
@@ -38,9 +38,13 @@ def upload_multipart(bucket, key_name, parts_list):
     upload.complete_upload()
     return upload
 
-class S3ApiVerificationTestBase(unittest.TestCase):
-    host = "127.0.0.1"
-    port = 8080
+class S3ApiVerificationTest(unittest.TestCase):
+    host="127.0.0.1"
+    try:
+        port=int(os.environ['CS_HTTP_PORT'])
+    except:
+        port=8080
+    print "YYY I am using port %d" % port
 
     user1 = None
     user2 = None

--- a/client_tests/python/boto_test.py
+++ b/client_tests/python/boto_test.py
@@ -38,7 +38,7 @@ def upload_multipart(bucket, key_name, parts_list):
     upload.complete_upload()
     return upload
 
-class S3ApiVerificationTest(unittest.TestCase):
+class S3ApiVerificationTestBase(unittest.TestCase):
     host="127.0.0.1"
     try:
         port=int(os.environ['CS_HTTP_PORT'])

--- a/riak_test/README.md
+++ b/riak_test/README.md
@@ -30,8 +30,12 @@
                       {"1.2.0-ee", "RTEE_DEST_DIR/riak_ee-1.2.0"},
                       {"1.1.4-ee", "RTEE_DEST_DIR/riak_ee-1.1.4"},
                       {"1.0.3-ee", "RTEE_DEST_DIR/riak_ee-1.0.3"},
+
                       {cs_root, "RTCS_DEST_DIR"},
                       {cs_current, "RTCS_DEST_DIR/current"},
+                      %% Add cs_src_root to get access to client tests
+                      {cs_src_root, "YOUR/PATH/TO/RIAK-CS/SOURCE/TREE/riak_cs/"},
+
                       {"1.2.2-cs", "RTCS_DEST_DIR/riak-cs-1.2.2"},
                       {"1.1.0-cs", "RTCS_DEST_DIR/riak-cs-1.1.0"},
                       {"1.0.1-cs", "RTCS_DEST_DIR/riak-cs-1.0.1"},
@@ -54,6 +58,24 @@ setting up `riak_test` builds for Riak (by default
 
 1. To build the `riak_test` files use the `compile-riak-test` Makefile
 target or run `./rebar riak_test_compile`.
+
+1. The Riak client tests are now automated by the
+`tests/external_client_tests.erl` test.  There are several
+prerequisites:
+
+* Your $PATH must have `erl` available.
+* Your $PATH must have a version of Python available that also has
+  access to the Boto S3 libraries.
+* Your $PATH must have Clojure's "lein" available.  "lein" is the main
+  executable for the Leinigen tool.
+
+1. Before running the Riak client tests, your
+`~/.riak_test.config` file must contain an entry for `cs_src_root` in
+the `rtdev_path` list, as shown above.  The source in this directory
+must be successfully compiled using the top level `make all` target.
+
+1. Before running the Riak client tests, you must first use the
+commands `make clean-client-test` and then `make compile-client-test`.
 
 1. To execute a test, run the following from the `riak_test` repo:
 

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -47,6 +47,7 @@ setup(NumNodes, Configs) ->
 build_cluster(NumNodes, Configs) ->
     {_, {RiakNodes, _, _}} = Nodes =
         deploy_nodes(NumNodes, Configs),
+
     rt:wait_until_nodes_ready(RiakNodes),
     lager:info("Build cluster"),
     rtcs:make_cluster(RiakNodes),
@@ -129,9 +130,13 @@ ee_config() ->
     ].
 
 cs_config() ->
+    cs_config([]).
+
+cs_config(UserExtra) ->
     [
      lager_config(),
      {riak_cs,
+      UserExtra ++
       [
        {proxy_get, enabled},
        {anonymous_user_creation, true},

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -6,20 +6,9 @@
 -define(TEST_BUCKET, "riak_test_bucket").
 
 confirm() ->
-    CS_extra = [{enforce_multipart_part_size, false}],
-    {RiakNodes, _CSNodes, _Stanchion} =
-        rtcs:setup(1,
-                   rtcs:ee_config(),
-                   rtcs:stanchion_config(),
-                   rtcs:cs_config(CS_extra)),
+    {_UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4, [{cs, cs_config()}]),
 
-    FirstNode = hd(RiakNodes),
-
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
-
-    %% User config
-    CS_http_port = rtcs:cs_port(FirstNode),
-    _UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, CS_http_port),
+    CS_http_port = rtcs:cs_port(hd(RiakNodes)),
 
     lager:debug("cs_src_root = ~p", [rtdev:relpath(cs_src_root)]),
     %% NOTE: This 'cs_src_root' path must appear in
@@ -50,3 +39,17 @@ confirm() ->
     after
         os:cmd("rm -f " ++ StdoutStderr)
     end.
+
+cs_config() ->
+    [
+     rtcs:lager_config(),
+     {riak_cs,
+      [
+       {proxy_get, enabled},
+       {anonymous_user_creation, true},
+       {riak_pb_port, 10017},
+       {stanchion_port, 9095},
+       {cs_version, 010300},
+       {enforce_multipart_part_size, false}
+      ]
+     }].

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -22,7 +22,7 @@ confirm() ->
     _UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, CS_http_port),
 
     lager:debug("cs_src_root = ~p", [rtdev:relpath(cs_src_root)]),
-    %% NOTE: This 'riak_cs_root' path must appear in
+    %% NOTE: This 'cs_src_root' path must appear in
     %% ~/.riak_test.config in the 'rtdev' section, 'rtdev_path'
     %% subsection.
     CS_src_dir = rtdev:relpath(cs_src_root),

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -30,7 +30,7 @@ confirm() ->
     os:cmd("rm -f " ++ StdoutStderr),
 
     Cmd = lists:flatten(
-            io_lib:format("cd ~s; env CS_HTTP_PORT=~p make test-boto > ~s 2>&1 ; echo Res $?",
+            io_lib:format("cd ~s; env CS_HTTP_PORT=~p make test-erlang > ~s 2>&1 ; echo Res $?",
                           [CS_src_dir, CS_http_port, StdoutStderr])),
     lager:debug("Cmd = ~s", [Cmd]),
     Res = os:cmd(Cmd),
@@ -39,12 +39,11 @@ confirm() ->
     try
         case Res of
             "Res 0\n" ->
+                {ok, DebugOut0} = file:read_file(StdoutStderr), io:format("YYY Res = ~s\n", [DebugOut0]),
                 pass;
             _ ->
-                lager:error("Expected 0, got: ~s", [Res]),
-                {ok, DebugOut0} = file:read_file(StdoutStderr),
-                DebugOut = re:replace(DebugOut0, "\n", "\\\\n",
-                                      [global, multiline, {return, list}]),
+                lager:error("Expected 'Res 0', got: ~s", [Res]),
+                {ok, DebugOut} = file:read_file(StdoutStderr),
                 lager:error("Script output: ~s", [DebugOut]),
                 error(fail)
         end

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -1,0 +1,53 @@
+-module(external_client_tests).
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_BUCKET, "riak_test_bucket").
+
+confirm() ->
+    CS_extra = [{enforce_multipart_part_size, false}],
+    {RiakNodes, _CSNodes, _Stanchion} =
+        rtcs:setup(1,
+                   rtcs:ee_config(),
+                   rtcs:stanchion_config(),
+                   rtcs:cs_config(CS_extra)),
+
+    FirstNode = hd(RiakNodes),
+
+    {AccessKeyId, SecretAccessKey} = rtcs:create_user(FirstNode, 1),
+
+    %% User config
+    CS_http_port = rtcs:cs_port(FirstNode),
+    _UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, CS_http_port),
+
+    lager:debug("cs_src_root = ~p", [rtdev:relpath(cs_src_root)]),
+    %% NOTE: This 'riak_cs_root' path must appear in
+    %% ~/.riak_test.config in the 'rtdev' section, 'rtdev_path'
+    %% subsection.
+    CS_src_dir = rtdev:relpath(cs_src_root),
+    StdoutStderr = "/tmp/my_output." ++ os:getpid(),
+    os:cmd("rm -f " ++ StdoutStderr),
+
+    Cmd = lists:flatten(
+            io_lib:format("cd ~s; env CS_HTTP_PORT=~p make test-boto > ~s 2>&1 ; echo Res $?",
+                          [CS_src_dir, CS_http_port, StdoutStderr])),
+    lager:debug("Cmd = ~s", [Cmd]),
+    Res = os:cmd(Cmd),
+    lager:debug("YYY res = ~s", [Res]),
+
+    try
+        case Res of
+            "Res 0\n" ->
+                pass;
+            _ ->
+                lager:error("Expected 0, got: ~s", [Res]),
+                {ok, DebugOut0} = file:read_file(StdoutStderr),
+                DebugOut = re:replace(DebugOut0, "\n", "\\\\n",
+                                      [global, multiline, {return, list}]),
+                lager:error("Script output: ~s", [DebugOut]),
+                error(fail)
+        end
+    after
+        os:cmd("rm -f " ++ StdoutStderr)
+    end.

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -30,21 +30,21 @@ confirm() ->
     os:cmd("rm -f " ++ StdoutStderr),
 
     Cmd = lists:flatten(
-            io_lib:format("cd ~s; env CS_HTTP_PORT=~p make test-erlang > ~s 2>&1 ; echo Res $?",
+            io_lib:format("cd ~s; env CS_HTTP_PORT=~p make test-client > ~s 2>&1 ; echo Res $?",
                           [CS_src_dir, CS_http_port, StdoutStderr])),
     lager:debug("Cmd = ~s", [Cmd]),
     Res = os:cmd(Cmd),
-    lager:debug("YYY res = ~s", [Res]),
+    lager:debug("Res = ~s", [Res]),
+    {ok, DebugOut} = file:read_file(StdoutStderr),
+    %% This io:format will have every line tagged as "debug" output.
+    io:format("Verbose Res = ~s\n", [DebugOut]),
 
     try
         case Res of
             "Res 0\n" ->
-                {ok, DebugOut0} = file:read_file(StdoutStderr), io:format("YYY Res = ~s\n", [DebugOut0]),
                 pass;
             _ ->
                 lager:error("Expected 'Res 0', got: ~s", [Res]),
-                {ok, DebugOut} = file:read_file(StdoutStderr),
-                lager:error("Script output: ~s", [DebugOut]),
                 error(fail)
         end
     after


### PR DESCRIPTION
This is the minimal (?) amount necessary to get the client tests (Clojure, Python, Erlang) tests wrapped up and have `riak_test` drive them.
