### PR TITLE
Fix bucket ACL update incompatabilities

### DIFF
--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -143,6 +143,9 @@ bucket_access(_, RequestedAccess, CanonicalId, RiakPid, Acl) ->
             true;
         true ->
             {true, owner_id(Acl, RiakPid)};
+        false when IsOwner == true
+                   andalso RequestedAccess /= 'READ' ->
+            true;
         _ ->
             false
     end.

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -319,8 +319,6 @@ process_grant([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
 %% @doc Process an XML element containing information about
 %% an ACL permission grantee.
 -spec process_grantee([xmlElement()], acl_grant(), acl_owner(), pid()) -> acl_grant().
-process_grantee([], {{[], CanonicalId}, _Perms}, {DisplayName, CanonicalId}, _) ->
-    {{DisplayName, CanonicalId}, _Perms};
 process_grantee([], {{[], CanonicalId}, _Perms}, {DisplayName, CanonicalId, _}, _) ->
     {{DisplayName, CanonicalId}, _Perms};
 process_grantee([], {{[], CanonicalId}, _Perms}, _, RiakPid) ->

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -120,12 +120,12 @@ requested_access(Method, AclRequest) ->
             undefined
     end.
 
--spec check_grants(undefined | rcs_user(), binary(), atom(), pid()) -> 
+-spec check_grants(undefined | rcs_user(), binary(), atom(), pid()) ->
                           boolean() | {true, string()}.
 check_grants(User, Bucket, RequestedAccess, RiakPid) ->
     check_grants(User, Bucket, RequestedAccess, RiakPid, undefined).
 
--spec check_grants(undefined | rcs_user(), binary(), atom(), pid(), acl()|undefined) -> 
+-spec check_grants(undefined | rcs_user(), binary(), atom(), pid(), acl()|undefined) ->
                           boolean() | {true, string()}.
 check_grants(undefined, Bucket, RequestedAccess, RiakPid, BucketAcl) ->
     riak_cs_acl:anonymous_bucket_access(Bucket, RequestedAccess, RiakPid, BucketAcl);
@@ -288,7 +288,7 @@ process_grants([HeadElement | RestElements], Acl, RiakPid) ->
     ElementName = HeadElement#xmlElement.name,
     case ElementName of
         'Grant' ->
-            Grant = process_grant(Content, {{"", ""}, []}, RiakPid),
+            Grant = process_grant(Content, {{"", ""}, []}, Acl?ACL.owner, RiakPid),
             UpdAcl = Acl?ACL{grants=add_grant(Grant, Acl?ACL.grants)};
         _ ->
             _ = lager:debug("Encountered unexpected grants element: ~p", [ElementName]),
@@ -297,36 +297,40 @@ process_grants([HeadElement | RestElements], Acl, RiakPid) ->
     process_grants(RestElements, UpdAcl, RiakPid).
 
 %% @doc Process an XML element containing the grants for the acl.
--spec process_grant([xmlElement()], acl_grant(), pid()) -> acl_grant().
-process_grant([], Grant, _) ->
+-spec process_grant([xmlElement()], acl_grant(), acl_owner(), pid()) -> acl_grant().
+process_grant([], Grant, _, _) ->
     Grant;
-process_grant([HeadElement | RestElements], Grant, RiakPid) ->
+process_grant([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
     Content = HeadElement#xmlElement.content,
     ElementName = HeadElement#xmlElement.name,
     _ = lager:debug("ElementName: ~p", [ElementName]),
     _ = lager:debug("Content: ~p", [Content]),
     case ElementName of
         'Grantee' ->
-            UpdGrant = process_grantee(Content, Grant, RiakPid);
+            UpdGrant = process_grantee(Content, Grant, AclOwner, RiakPid);
         'Permission' ->
             UpdGrant = process_permission(Content, Grant);
         _ ->
             _ = lager:debug("Encountered unexpected grant element: ~p", [ElementName]),
             UpdGrant = Grant
     end,
-    process_grant(RestElements, UpdGrant, RiakPid).
+    process_grant(RestElements, UpdGrant, AclOwner, RiakPid).
 
 %% @doc Process an XML element containing information about
 %% an ACL permission grantee.
--spec process_grantee([xmlElement()], acl_grant(), pid()) -> acl_grant().
-process_grantee([], {{[], CanonicalId}, _Perms}, RiakPid) ->
+-spec process_grantee([xmlElement()], acl_grant(), acl_owner(), pid()) -> acl_grant().
+process_grantee([], {{[], CanonicalId}, _Perms}, {DisplayName, CanonicalId}, _) ->
+    {{DisplayName, CanonicalId}, _Perms};
+process_grantee([], {{[], CanonicalId}, _Perms}, {DisplayName, CanonicalId, _}, _) ->
+    {{DisplayName, CanonicalId}, _Perms};
+process_grantee([], {{[], CanonicalId}, _Perms}, _, RiakPid) ->
     %% Lookup the display name for the user with the
     %% canonical id of `CanonicalId'.
     DisplayName = name_for_canonical(CanonicalId, RiakPid),
     {{DisplayName, CanonicalId}, _Perms};
-process_grantee([], Grant, _) ->
+process_grantee([], Grant, _, _) ->
     Grant;
-process_grantee([HeadElement | RestElements], Grant, RiakPid) ->
+process_grantee([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
     [Content] = HeadElement#xmlElement.content,
     Value = Content#xmlText.value,
     ElementName = HeadElement#xmlElement.name,
@@ -335,10 +339,6 @@ process_grantee([HeadElement | RestElements], Grant, RiakPid) ->
             _ = lager:debug("ID value: ~p", [Value]),
             {{Name, _}, Perms} = Grant,
             UpdGrant = {{Name, Value}, Perms};
-        'DisplayName' ->
-            _ = lager:debug("Name value: ~p", [Value]),
-            {{_, Id}, Perms} = Grant,
-            UpdGrant = {{Value, Id}, Perms};
         'EmailAddress' ->
             _ = lager:debug("Email value: ~p", [Value]),
             Id = canonical_for_email(Value, RiakPid),
@@ -360,7 +360,7 @@ process_grantee([HeadElement | RestElements], Grant, RiakPid) ->
         _ ->
             UpdGrant = Grant
     end,
-    process_grantee(RestElements, UpdGrant, RiakPid).
+    process_grantee(RestElements, UpdGrant, AclOwner, RiakPid).
 
 %% @doc Process an XML element containing information about
 %% an ACL permission.

--- a/src/riak_cs_wm_bucket_acl.erl
+++ b/src/riak_cs_wm_bucket_acl.erl
@@ -29,7 +29,7 @@ allowed_methods() ->
 content_types_provided(RD, Ctx) ->
     {[{"application/xml", to_xml}], RD, Ctx}.
 
--spec content_types_accepted(#wm_reqdata{}, #context{}) -> 
+-spec content_types_accepted(#wm_reqdata{}, #context{}) ->
                                     {[{string(), atom()}], #wm_reqdata{}, #context{}}.
 content_types_accepted(RD, Ctx) ->
     case wrq:get_req_header("content-type", RD) of
@@ -51,19 +51,19 @@ to_xml(RD, Ctx=#context{start_time=StartTime,
                         user=User,
                         bucket=Bucket,
                         riakc_pid=RiakPid}) ->
-    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_get_acl">>, 
+    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_get_acl">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
     case riak_cs_acl:bucket_acl(Bucket, RiakPid) of
         {ok, Acl} ->
             X = {riak_cs_xml:to_xml(Acl), RD, Ctx},
             ok = riak_cs_stats:update_with_start(bucket_get_acl, StartTime),
-            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_get_acl">>, 
+            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_get_acl">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
             X;
         {error, Reason} ->
             Code = riak_cs_s3_response:status_code(Reason),
             X = riak_cs_s3_response:api_error(Reason, RD, Ctx),
-            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_get_acl">>, 
+            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_get_acl">>,
                                                [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
             X
     end.
@@ -74,7 +74,7 @@ accept_body(RD, Ctx=#context{user=User,
                              user_object=UserObj,
                              bucket=Bucket,
                              riakc_pid=RiakPid}) ->
-    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_put_acl">>, 
+    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_put_acl">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
     Body = binary_to_list(wrq:req_body(RD)),
     case Body of
@@ -90,8 +90,8 @@ accept_body(RD, Ctx=#context{user=User,
                     RiakPid);
         _ ->
             ACL = riak_cs_acl_utils:acl_from_xml(Body,
-                                                   User?RCS_USER.key_id,
-                                                   RiakPid)
+                                                 User?RCS_USER.key_id,
+                                                 RiakPid)
     end,
     case riak_cs_utils:set_bucket_acl(User,
                                         UserObj,
@@ -99,13 +99,12 @@ accept_body(RD, Ctx=#context{user=User,
                                         ACL,
                                         RiakPid) of
         ok ->
-            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_acl">>, 
+            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_acl">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
             {{halt, 200}, RD, Ctx};
         {error, Reason} ->
             Code = riak_cs_s3_response:status_code(Reason),
-            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_acl">>, 
+            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_acl">>,
                                                [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
             riak_cs_s3_response:api_error(Reason, RD, Ctx)
     end.
-


### PR DESCRIPTION
Fix two incompatibilities with bucket ACLs:
- Bucket owners should always be granted all ACL permissions except READ even when not explicitly granted. The first fix addresses the issue that bucket owners were being denied any access that was not explicitly granted. 
- Fix an issue with ACL updates when specified display_name for Owner element and a Grant element for the bucket owner do not match. This has the side-effect of avoiding a 2I query to riak in the case where the bucket owner is also the grantee.

These bugs were found running the `s3tests.functional.test_s3:test_bucket_acl_xml_write` test in the [ceph s3-test](https://github.com/ceph/s3-tests) suite.
