### PR TITLE
Add helper fun to handle non bools in dtrace returns

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -30,13 +30,12 @@ setup(NumNodes) ->
 setup(NumNodes, Configs) ->
     %% Start the erlcloud app
     erlcloud:start(),
-    Cfgs = configs(Configs),
-    Nodes = build_cluster(NumNodes, Cfgs),
 
     %% STFU sasl
     application:load(sasl),
     application:set_env(sasl, sasl_error_logger, false),
 
+    Cfgs = configs(Configs),
     {{AdminKeyId, AdminSecretKey},
      {RiakNodes, _CSNodes, _Stanchion}=Nodes} = build_cluster(NumNodes, Cfgs),
 

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -1,0 +1,103 @@
+-module(too_large_entity_test).
+
+%% @doc `riak_test' module for testing the behavior in dealing with
+%% entities that violate the specified object size restrictions
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_BUCKET, "riak_test_bucket").
+-define(TEST_KEY1, "riak_test_key1").
+-define(TEST_KEY2, "riak_test_key2").
+-define(PART_COUNT, 5).
+-define(GOOD_PART_SIZE, 5*1024*1024).
+-define(BAD_PART_SIZE, 2*1024*1024).
+
+confirm() ->
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4, [{cs, cs_config()}]),
+
+    lager:info("User is valid on the cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+
+    ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(?TEST_BUCKET, UserConfig)),
+
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    ?assertMatch([{buckets, [[{name, ?TEST_BUCKET}, _]]}],
+                 erlcloud_s3:list_buckets(UserConfig)),
+
+    %% Test cases
+    too_large_upload_part_test_case(?TEST_BUCKET, ?TEST_KEY1, UserConfig),
+    too_large_object_put_test_case(?TEST_BUCKET, ?TEST_KEY2, UserConfig),
+
+    lager:info("deleting bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+
+    ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(?TEST_BUCKET, UserConfig)),
+    pass.
+
+generate_part_data(X, Size)
+  when 0 =< X, X =< 255 ->
+    list_to_binary(
+      [X || _ <- lists:seq(1, Size)]).
+
+too_large_upload_part_test_case(Bucket, Key, Config) ->
+    %% Initiate a multipart upload
+    lager:info("Initiating multipart upload"),
+    InitUploadRes = erlcloud_s3_multipart:initiate_upload(Bucket, Key, [], [], Config),
+    UploadId = erlcloud_s3_multipart:upload_id(InitUploadRes),
+
+    %% Verify the upload id is in list_uploads results and
+    %% that the bucket information is correct
+    UploadsList1 = erlcloud_s3_multipart:list_uploads(Bucket, [], Config),
+    Uploads1 = proplists:get_value(uploads, UploadsList1, []),
+    ?assertEqual(Bucket, proplists:get_value(bucket, UploadsList1)),
+    ?assert(upload_id_present(UploadId, Uploads1)),
+
+    lager:info("Uploading an oversize part"),
+    ?assertError({aws_error, {http_error, 400, _, _}},
+                 erlcloud_s3_multipart:upload_part(Bucket,
+                                                   Key,
+                                                   UploadId,
+                                                   1,
+                                                   generate_part_data(61, 2000),
+                                                   Config)).
+
+too_large_object_put_test_case(Bucket, Key, Config) ->
+    Object1 = crypto:rand_bytes(1001),
+    Object2 = crypto:rand_bytes(1000),
+
+    ?assertError({aws_error, {http_error, 400, _, _}},
+                 erlcloud_s3:put_object(Bucket, Key, Object1, Config)),
+
+    erlcloud_s3:put_object(Bucket, Key, Object2, Config),
+
+    ObjList1 = erlcloud_s3:list_objects(Bucket, Config),
+    ?assertEqual([Key],
+        [proplists:get_value(key, O) ||
+            O <- proplists:get_value(contents, ObjList1)]),
+
+    erlcloud_s3:delete_object(Bucket, Key, Config),
+
+    ObjList2 = erlcloud_s3:list_objects(Bucket, Config),
+    ?assertEqual([], proplists:get_value(contents, ObjList2)).
+
+upload_id_present(UploadId, UploadList) ->
+    [] /= [UploadData || UploadData <- UploadList,
+                         proplists:get_value(upload_id, UploadData) =:= UploadId].
+
+cs_config() ->
+    [
+     rtcs:lager_config(),
+     {riak_cs,
+      [
+       {proxy_get, enabled},
+       {anonymous_user_creation, true},
+       {riak_pb_port, 10017},
+       {stanchion_port, 9095},
+       {cs_version, 010300},
+       {max_content_length, 1000},
+       {enforce_multipart_part_size, false}
+      ]
+     }].

--- a/src/riak_cs_dtrace.erl
+++ b/src/riak_cs_dtrace.erl
@@ -16,6 +16,7 @@
          dt_wm_return/2,
          dt_wm_return/4,
          dt_wm_return_bool/3,
+         dt_wm_return_bool_with_default/4,
          dt_service_return/4,
          dt_bucket_return/4,
          dt_object_return/4]).
@@ -123,6 +124,14 @@ dt_wm_return_bool(Mod, Func, true) ->
     dt_wm_return(Mod, Func, [1], []);
 dt_wm_return_bool(Mod, Func, false) ->
     dt_wm_return(Mod, Func, [0], []).
+
+%% Like `dt_wm_return_bool', but uses a default
+%% boolean value from `Default' if the 3rd argument is
+%% a `{halt, integer()}' tuple
+dt_wm_return_bool_with_default(Mod, Func, Bool, _Default) when is_boolean(Bool) ->
+    dt_wm_return_bool(Mod, Func, Bool);
+dt_wm_return_bool_with_default(Mod, Func, {halt, _Code}, Default) when is_integer(_Code) ->
+    dt_wm_return_bool(Mod, Func, Default).
 
 dt_wm_return(Mod, Func) ->
     dt_wm_return(Mod, Func, [], []).

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -83,12 +83,16 @@ error_code(bad_request) -> "BadRequest";
 error_code(invalid_range) -> "InvalidRange";
 error_code(_) -> "ServiceUnavailable".
 
+%% These should match:
+%% http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+
 status_code(invalid_access_key_id) -> 403;
 status_code(invalid_email_address) -> 400;
 status_code(access_denied) ->  403;
 status_code(bucket_not_empty) ->  409;
 status_code(bucket_already_exists) -> 409;
 status_code(user_already_exists) -> 409;
+%% yes, 400, really, not 413
 status_code(entity_too_large) -> 400;
 status_code(entity_too_small) -> 400;
 status_code(bad_etag) -> 400;

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -96,7 +96,10 @@ malformed_request(RD, Ctx=#context{submodule=Mod,
                                           malformed_request,
                                           [RD, Ctx],
                                           ExportsFun),
-    riak_cs_dtrace:dt_wm_return_bool({?MODULE, Mod}, <<"malformed_request">>, Malformed),
+    riak_cs_dtrace:dt_wm_return_bool_with_default({?MODULE, Mod},
+                                                  <<"malformed_request">>,
+                                                  Malformed,
+                                                 false),
     R.
 
 
@@ -107,7 +110,10 @@ valid_entity_length(RD, Ctx=#context{submodule=Mod, exports_fun=ExportsFun}) ->
                                       valid_entity_length,
                                       [RD, Ctx],
                                       ExportsFun),
-    riak_cs_dtrace:dt_wm_return_bool({?MODULE, Mod}, <<"valid_entity_length">>, Valid),
+    riak_cs_dtrace:dt_wm_return_bool_with_default({?MODULE, Mod},
+                                                  <<"valid_entity_length">>,
+                                                  Valid,
+                                                  true),
     R.
 
 -type validate_checksum_response() :: {error, term()} |
@@ -121,7 +127,10 @@ validate_content_checksum(RD, Ctx=#context{submodule=Mod, exports_fun=ExportsFun
                                       validate_content_checksum,
                                       [RD, Ctx],
                                       ExportsFun),
-    riak_cs_dtrace:dt_wm_return_bool({?MODULE, Mod}, <<"validate_content_checksum">>, Valid),
+    riak_cs_dtrace:dt_wm_return_bool_with_default({?MODULE, Mod},
+                                                  <<"validate_content_checksum">>,
+                                                  Valid,
+                                                  true),
     R.
 
 -spec forbidden(#wm_reqdata{}, #context{}) -> {boolean() | {halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.


### PR DESCRIPTION
- Add comment about rationale behind some HTTP status codes

Tested by either trying to upload a > 5GB file, or setting the default max content length to something like 1MB.
