### PR TITLE
Can't list object with Unicode name

### DIFF
--- a/client_tests/python/boto_test.py
+++ b/client_tests/python/boto_test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import httplib, json, unittest, uuid, md5
 from cStringIO import StringIO
@@ -311,6 +312,28 @@ class LargerMultipartFileUploadTest(S3ApiVerificationTestBase):
     def test_upload_3(self):
         mb_list = [15, 14, 13, 12, 11, 10]
         self.from_mb_list(mb_list)
+
+class UnicodeNamedObjectTest(S3ApiVerificationTestBase):
+    ''' test to check unicode object name works '''
+    utf8_key_name = u"utf8ファイル名.txt"
+    #                     ^^^^^^^^^ filename in Japanese
+
+    def test_unicode_object(self):
+        bucket = self.conn.create_bucket(self.bucket_name)
+        k = Key(bucket)
+        k.key = UnicodeNamedObjectTest.utf8_key_name
+        k.set_contents_from_string(self.data)
+        self.assertEqual(k.get_contents_as_string(), self.data)
+        self.assertIn(UnicodeNamedObjectTest.utf8_key_name,
+                      [obj.key for obj in bucket.list()])
+
+    def test_delete_object(self):
+        bucket = self.conn.create_bucket(self.bucket_name)
+        k = Key(bucket)
+        k.key = UnicodeNamedObjectTest.utf8_key_name
+        k.delete()
+        self.assertNotIn(UnicodeNamedObjectTest.utf8_key_name,
+                         [obj.key for obj in bucket.list()])
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/riak_cs_list_objects.erl
+++ b/src/riak_cs_list_objects.erl
@@ -77,13 +77,11 @@ new_response(?LOREQ{name=Name,
 %%--------------------------------------------------------------------
 
 -spec manifest_to_keycontent(lfs_manifest()) -> list_objects_key_content().
-manifest_to_keycontent(?MANIFEST{bkey=BKey,
+manifest_to_keycontent(?MANIFEST{bkey={_Bucket, Key},
                                  created=Created,
                                  content_md5=ContentMd5,
                                  content_length=ContentLength,
                                  acl=ACL}) ->
-    {_Bucket, UnprocessedKey} = BKey,
-    Key = list_to_binary(unicode:characters_to_list(UnprocessedKey, unicode)),
 
     LastModified = list_to_binary(riak_cs_wm_utils:to_iso_8601(Created)),
 

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -186,7 +186,7 @@ policy_to_json_term( ?POLICY{ version = ?AMZ_DEFAULT_VERSION,
     Stmts = lists:map(fun statement_to_pairs/1, Stmts0),
     % hope no unicode included
     Policy = [{"Version",?AMZ_DEFAULT_VERSION},{"Id", ID},{"Statement",Stmts}],
-    list_to_binary(mochijson2:encode(Policy)).
+    unicode:characters_to_binary(mochijson2:encode(Policy), unicode).
 
 -spec supported_object_action() -> [s3_object_action()].
 supported_object_action() -> ?SUPPORTED_OBJECT_ACTION.
@@ -289,7 +289,8 @@ resource_matches(BucketBin, KeyBin, #statement{resource=Resources})
                 undefined ->
                     Bucket;
                 _ when is_binary(KeyBin) ->
-                    binary_to_list(<<BucketBin/binary, "/", KeyBin/binary>>)
+                    unicode:characters_to_binary(<<BucketBin/binary, "/", KeyBin/binary>>,
+						 unicode)
             end,
     lists:any(fun(#arn_v1{path="*"}) ->    true;
                  (#arn_v1{path=Path}) ->

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -289,8 +289,7 @@ resource_matches(BucketBin, KeyBin, #statement{resource=Resources})
                 undefined ->
                     Bucket;
                 _ when is_binary(KeyBin) ->
-                    unicode:characters_to_binary(<<BucketBin/binary, "/", KeyBin/binary>>,
-						 unicode)
+                    unicode:characters_to_list(<<BucketBin/binary, "/", KeyBin/binary>>, unicode)
             end,
     lists:any(fun(#arn_v1{path="*"}) ->    true;
                  (#arn_v1{path=Path}) ->

--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -57,7 +57,7 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
         {ok, {Ds, Commons}} ->
             Us = [{'Upload',
                    [
-                    {'Key', [binary_to_list(D?MULTIPART_DESCR.key)]},
+                    {'Key', [unicode:characters_to_list(D?MULTIPART_DESCR.key, uncode)]},
                     {'UploadId', [binary_to_list(base64url:encode(D?MULTIPART_DESCR.upload_id))]},
                     {'Initiator',               % TODO: replace with ARN data?
                      [{'ID', [D?MULTIPART_DESCR.owner_key_id]},

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -173,7 +173,7 @@ format_value(undefined) ->
 format_value(Val) when is_atom(Val) ->
     atom_to_list(Val);
 format_value(Val) when is_binary(Val) ->
-    binary_to_list(Val);
+    unicode:characters_to_list(Val, unicode);
 format_value(Val) when is_integer(Val) ->
     integer_to_list(Val);
 format_value(Val) when is_list(Val) ->


### PR DESCRIPTION
uploading works, while listing fails.

```
12:01:00.661 [error] CRASH REPORT Process <0.3408.126> with 1 neighbours exited with reason: bad argument in call to erlang:list_to_binary([117,116,102,56,12501,12449,12452,12523,46,116,120,116]) in riak_cs_list_objects:manifest_to_keycontent/1 line 86 in gen_fsm:terminate/7 line 611
```
