### PR TITLE
Address bucket-level S3 API compatibility issues

### DIFF
--- a/src/riak_cs_list_objects_fsm.erl
+++ b/src/riak_cs_list_objects_fsm.erl
@@ -531,7 +531,7 @@ prepare_state_for_mapred(State=#state{req=Request,
 make_response(Request=?LOREQ{max_keys=NumKeysRequested}, ObjectBuffer, CommonPrefixes) ->
     ObjectPrefixTuple = {ObjectBuffer, CommonPrefixes},
     NumObjects = manifests_and_prefix_length(ObjectPrefixTuple),
-    IsTruncated = NumObjects > NumKeysRequested,
+    IsTruncated = NumObjects > NumKeysRequested andalso NumKeysRequested > 0,
     SlicedTaggedItems = manifests_and_prefix_slice(ObjectPrefixTuple,
                                                    NumKeysRequested),
     {NewManis, NewPrefixes} = untagged_manifest_and_prefix(SlicedTaggedItems),

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -56,6 +56,8 @@ error_message(malformed_policy_principal) -> "Invalid principal in policy";
 error_message(malformed_policy_action) -> "Policy has invalid action";
 error_message(no_such_bucket_policy) -> "The bucket policy does not exist";
 error_message(bad_request) -> "Bad Request";
+error_message(invalid_argument) -> "Invalid Argument";
+error_message(unresolved_grant_email) -> "The e-mail address you provided does not match any account on record.";
 error_message(invalid_range) -> "The requested range is not satisfiable";
 error_message(invalid_bucket_name) -> "The specified bucket is not valid.";
 error_message(_) -> "Please reduce your request rate.".
@@ -83,8 +85,10 @@ error_code(malformed_policy_principal) -> "MalformedPolicy";
 error_code(malformed_policy_action) -> "MalformedPolicy";
 error_code(no_such_bucket_policy) -> "NoSuchBucketPolicy";
 error_code(bad_request) -> "BadRequest";
+error_code(invalid_argument) -> "InvalidArgument";
 error_code(invalid_range) -> "InvalidRange";
 error_code(invalid_bucket_name) -> "InvalidBucketName";
+error_code(unresolved_grant_email) -> "UnresolvableGrantByEmailAddress";
 error_code(_) -> "ServiceUnavailable".
 
 %% These should match:
@@ -116,6 +120,8 @@ status_code(malformed_policy_principal) -> 400;
 status_code(malformed_policy_action) -> 400;
 status_code(no_such_bucket_policy) -> 404;
 status_code(bad_request) -> 400;
+status_code(invalid_argument) -> 400;
+status_code(unresolved_grant_email) -> 400;
 status_code(invalid_range) -> 416;
 status_code(invalid_bucket_name) -> 400;
 status_code(_) -> 503.

--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -62,9 +62,11 @@ rewrite_path(_Method, Path, _QS, "usage") ->
     "/usage" ++ Path;
 rewrite_path(Method, "/", [], Bucket) when Method =/= 'GET' ->
     lists:flatten(["/buckets/", Bucket]);
-rewrite_path(_Method, "/", QS, Bucket) ->
+rewrite_path(Method, "/", QS, Bucket) ->
     {SubResources, QueryParams} = get_subresources(QS),
-    lists:flatten(["/buckets/", Bucket, format_bucket_qs(QueryParams, SubResources)]);
+    lists:flatten(["/buckets/", Bucket, format_bucket_qs(Method,
+                                                         QueryParams,
+                                                         SubResources)]);
 rewrite_path(_Method, Path, QS, Bucket) ->
     lists:flatten(["/buckets/",
                    Bucket,
@@ -121,14 +123,14 @@ separate_bucket_from_path([Bucket | RestPath]) ->
 
 %% @doc Format a bucket operation query string to conform the the
 %% rewrite rules.
--spec format_bucket_qs(query_params(), subresources()) -> string().
-format_bucket_qs([], []) ->
+-spec format_bucket_qs(atom(), query_params(), subresources()) -> string().
+format_bucket_qs('POST', [{"delete", []}], []) ->
     "/objects";
-format_bucket_qs([{"delete", []}], []) ->
-    "/objects";
-format_bucket_qs(QueryParams, []) ->
-    ["/objects", format_query_params(QueryParams)];
-format_bucket_qs(QueryParams, SubResources) ->
+format_bucket_qs(Method, QueryParams, [])
+  when Method =:= 'GET'; Method =:= 'POST' ->
+    ["/objects",
+     format_query_params(QueryParams)];
+format_bucket_qs(_Method, QueryParams, SubResources) ->
     [format_subresources(SubResources),
      format_query_params(QueryParams)].
 

--- a/src/riak_cs_wm_object_acl.erl
+++ b/src/riak_cs_wm_object_acl.erl
@@ -172,31 +172,41 @@ accept_body(RD, Ctx=#context{local_context=#key_context{get_fsm_pid=GetFsmPid,
                                       [], [UserName, BFile_str]),
     riak_cs_get_fsm:stop(GetFsmPid),
     Body = binary_to_list(wrq:req_body(RD)),
-    case Body of
-        [] ->
-            %% Check for `x-amz-acl' header to support
-            %% the use of a canned ACL.
-            Acl = riak_cs_acl_utils:canned_acl(
-                    wrq:get_req_header("x-amz-acl", RD),
-                    {User?RCS_USER.display_name,
-                     User?RCS_USER.canonical_id,
-                     User?RCS_USER.key_id},
-                    riak_cs_wm_utils:bucket_owner(Bucket, RiakPid));
-        _ ->
-            Acl = riak_cs_acl_utils:acl_from_xml(Body,
-                                                   User?RCS_USER.key_id,
-                                                   RiakPid)
-    end,
-    %% Write new ACL to active manifest
-    Key = list_to_binary(KeyStr),
-    case riak_cs_utils:set_object_acl(Bucket, Key, Mfst, Acl, RiakPid) of
-        ok ->
+    AclRes =
+        case Body of
+            [] ->
+                %% Check for `x-amz-acl' header to support
+                %% the use of a canned ACL.
+                CannedAcl = riak_cs_acl_utils:canned_acl(
+                              wrq:get_req_header("x-amz-acl", RD),
+                              {User?RCS_USER.display_name,
+                               User?RCS_USER.canonical_id,
+                               User?RCS_USER.key_id},
+                              riak_cs_wm_utils:bucket_owner(Bucket, RiakPid)),
+                {ok, CannedAcl};
+            _ ->
+                riak_cs_acl_utils:acl_from_xml(Body,
+                                               User?RCS_USER.key_id,
+                                               RiakPid)
+        end,
+    case AclRes of
+        {ok, Acl} ->
+            %% Write new ACL to active manifest
+            Key = list_to_binary(KeyStr),
+            case riak_cs_utils:set_object_acl(Bucket, Key, Mfst, Acl, RiakPid) of
+                ok ->
+                    riak_cs_dtrace:dt_object_return(?MODULE, <<"object_put_acl">>,
+                                                    [200], [UserName, BFile_str]),
+                    {{halt, 200}, RD, Ctx};
+                {error, Reason} ->
+                    Code = riak_cs_s3_response:status_code(Reason),
+                    riak_cs_dtrace:dt_object_return(?MODULE, <<"object_put_acl">>,
+                                                    [Code], [UserName, BFile_str]),
+                    riak_cs_s3_response:api_error(Reason, RD, Ctx)
+            end;
+        {error, Reason2} ->
+            Code = riak_cs_s3_response:status_code(Reason2),
             riak_cs_dtrace:dt_object_return(?MODULE, <<"object_put_acl">>,
-                                               [200], [UserName, BFile_str]),
-            {{halt, 200}, RD, Ctx};
-        {error, Reason} ->
-            Code = riak_cs_s3_response:status_code(Reason),
-            riak_cs_dtrace:dt_object_return(?MODULE, <<"object_put_acl">>,
-                                               [Code], [UserName, BFile_str]),
-            riak_cs_s3_response:api_error(Reason, RD, Ctx)
+                                            [Code], [UserName, BFile_str]),
+            riak_cs_s3_response:api_error(Reason2, RD, Ctx)
     end.

--- a/src/riak_cs_wm_objects.erl
+++ b/src/riak_cs_wm_objects.erl
@@ -101,7 +101,7 @@ get_option(Option, undefined) ->
 get_option(Option, Value) ->
     {Option, list_to_binary(Value)}.
 
--spec get_max_keys(#wm_reqdata{}) -> integer() | 'bad_request'.
+-spec get_max_keys(#wm_reqdata{}) -> integer() | 'invalid_argument'.
 get_max_keys(RD) ->
     case wrq:get_qs_value("max-keys", RD) of
         undefined ->
@@ -111,6 +111,6 @@ get_max_keys(RD) ->
                 erlang:min(list_to_integer(StringKeys),
                            ?DEFAULT_LIST_OBJECTS_MAX_KEYS)
             catch _:_ ->
-                    bad_request
+                    invalid_argument
             end
     end.

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -112,8 +112,6 @@ make_internal_node(Name, Attributes, Content) ->
     {Name, Attributes, Content}.
 
 -spec make_external_node(atom(), term()) -> external_node().
-make_external_node('ETag', Content) ->
-    {'ETag', ["\"" ++ format_value(Content) ++ "\""]};
 make_external_node(Name, Content) ->
     {Name, [format_value(Content)]}.
 
@@ -209,13 +207,13 @@ list_objects_response_to_xml_test() ->
     Owner2 = #list_objects_owner_v1{id = <<"TESTID2">>, display_name = <<"tester2">>},
     Content1 = ?LOKC{key = <<"testkey1">>,
                      last_modified = riak_cs_wm_utils:to_iso_8601("Thu, 29 Nov 2012 17:50:30 GMT"),
-                     etag = <<"fba9dede6af29711d7271245a35813428">>,
+                     etag = <<"\"fba9dede6af29711d7271245a35813428\"">>,
                      size = 12345,
                      owner = Owner1,
                      storage_class = <<"STANDARD">>},
     Content2 = ?LOKC{key = <<"testkey2">>,
                      last_modified = riak_cs_wm_utils:to_iso_8601("Thu, 29 Nov 2012 17:52:30 GMT"),
-                     etag = <<"43433281b2f27731ccf53597645a3985">>,
+                     etag = <<"\"43433281b2f27731ccf53597645a3985\"">>,
                      size = 54321,
                      owner = Owner2,
                      storage_class = <<"STANDARD">>},


### PR DESCRIPTION
This addresses a number of S3 API compatibility issues found while running the ceph s3-tests suite. These changes resolve the following bucket test failures:
- s3tests.functional.test_s3.test_bucket_list_maxkeys_zero
- s3tests.functional.test_s3.test_bucket_list_maxkeys_invalid
- s3tests.functional.test_s3.test_bucket_list_maxkeys_unreadable
- s3tests.functional.test_s3.test_bucket_list_return_data
- s3tests.functional.test_s3.test_bucket_notexist
- s3tests.functional.test_s3.test_bucket_delete_notexist
- s3tests.functional.test_s3.test_bucket_create_delete
- s3tests.functional.test_s3.test_bucket_head
- s3tests.functional.test_s3.test_bucket_head_extended
- s3tests.functional.test_s3.test_bucket_acl_grant_nonexist_user
- s3tests.functional.test_s3.test_bucket_acl_grant_email_notexist

Additionally the following two tests are also no longer failing: 
- s3tests.functional.test_s3.test_object_write_to_nonexist_bucket
- s3tests.functional.test_s3.test_abort_multipart_upload

I have been executing the functional test suite using the following command line: 

```
S3TEST_CONF=s3-tests.conf ./virtualenv/bin/nosetests s3tests.functional.test_s3
```

I have patched [`test_s3.py`](https://gist.github.com/827494067944317b0db4) to avoid a few spurious test failures. _e.g._ The unmodified test suite asserts that the reason phrase for an HTTP 404 error be `Not Found`, but erlang instead uses `Object Not Found`. Since the common reason phrases are just suggestions and do not need to be strictly enforced I replaced `Not Found` with `Object Not Found`. Furthermore, I made some changes to ignore test success determination based on ceph-custom headers such as `x-rgw-object-count` and `x-rgw-bytes-used`. 
