### PR TITLE
Compress terms before writing to Riak

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -9,6 +9,7 @@
 -define(PART_MANIFEST, #part_manifest_v1).
 -define(PART_MANIFEST_RECNAME, part_manifest_v1).
 -define(MULTIPART_DESCR, #multipart_descr_v1).
+-define(COMPRESS_TERMS, false).
 -define(PART_DESCR, #part_descr_v1).
 
 -record(moss_user, {

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -186,7 +186,7 @@ mark_manifests(RiakObject, Bucket, Key, UUIDsToMark, ManiFunction, RiakcPid) ->
     Manifests = riak_cs_utils:manifests_from_riak_object(RiakObject),
     Marked = ManiFunction(Manifests, UUIDsToMark),
     UpdObj0 = riak_cs_utils:update_obj_value(RiakObject,
-                                             term_to_binary(Marked)),
+                                             riak_cs_utils:encode_term(Marked)),
     UpdObj = riak_cs_manifest_fsm:update_md_with_multipart_2i(
                UpdObj0, Marked, Bucket, Key),
 
@@ -209,7 +209,7 @@ move_manifests_to_gc_bucket(Manifests, RiakcPid, AddLeewayP) ->
         {error, notfound} ->
             %% There was no previous value, so we'll
             %% create a new riak object and write it
-            riakc_obj:new(?GC_BUCKET, Key, term_to_binary(ManifestSet));
+            riakc_obj:new(?GC_BUCKET, Key, riak_cs_utils:encode_term(ManifestSet));
         {ok, PreviousObject} ->
             %% There is a value currently stored here,
             %% so resolve all the siblings and add the
@@ -217,7 +217,7 @@ move_manifests_to_gc_bucket(Manifests, RiakcPid, AddLeewayP) ->
             %% value back to riak
             Resolved = decode_and_merge_siblings(PreviousObject, ManifestSet),
             riak_cs_utils:update_obj_value(PreviousObject,
-                                           term_to_binary(Resolved))
+                                           riak_cs_utils:encode_term(Resolved))
     end,
 
     %% Create a set from the list of manifests

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -274,7 +274,7 @@ get_and_delete(RiakcPid, UUID, Bucket, Key) ->
                 _ ->
                     ObjectToWrite0 =
                         riak_cs_utils:update_obj_value(
-                          RiakObject, term_to_binary(UpdatedManifests)),
+                          RiakObject, riak_cs_utils:encode_term(UpdatedManifests)),
                     ObjectToWrite = update_md_with_multipart_2i(
                                       ObjectToWrite0, UpdatedManifests, Bucket, Key),
                     riak_cs_utils:put(RiakcPid, ObjectToWrite)
@@ -298,7 +298,7 @@ get_and_update(RiakcPid, WrappedManifests, Bucket, Key) ->
             %% operate on NewManiAdded and save it to Riak when it is
             %% finished.
             ObjectToWrite0 = riak_cs_utils:update_obj_value(
-                               RiakObject, term_to_binary(NewManiAdded)),
+                               RiakObject, riak_cs_utils:encode_term(NewManiAdded)),
             ObjectToWrite = update_md_with_multipart_2i(
                               ObjectToWrite0, NewManiAdded, Bucket, Key),
             {Result, NewRiakObject} =
@@ -314,7 +314,7 @@ get_and_update(RiakcPid, WrappedManifests, Bucket, Key) ->
             {Result, NewRiakObject, Manifests};
         {error, notfound} ->
             ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
-            ObjectToWrite0 = riakc_obj:new(ManifestBucket, Key, term_to_binary(WrappedManifests)),
+            ObjectToWrite0 = riakc_obj:new(ManifestBucket, Key, riak_cs_utils:encode_term(WrappedManifests)),
             ObjectToWrite = update_md_with_multipart_2i(
                               ObjectToWrite0, WrappedManifests, Bucket, Key),
             PutResult = riak_cs_utils:put(RiakcPid, ObjectToWrite),
@@ -331,7 +331,7 @@ update_from_previous_read(RiakcPid, RiakObject, Bucket, Key,
     Resolved = riak_cs_manifest_resolution:resolve([PreviousManifests,
             NewManifests]),
     NewRiakObject0 = riak_cs_utils:update_obj_value(RiakObject,
-                                                    term_to_binary(Resolved)),
+                                                    riak_cs_utils:encode_term(Resolved)),
     NewRiakObject = update_md_with_multipart_2i(NewRiakObject0, Resolved,
                                                 Bucket, Key),
     %% TODO:

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -20,6 +20,7 @@
          cs_version/0,
          delete_bucket/4,
          delete_object/3,
+         encode_term/1,
          from_bucket_name/1,
          get_admin_creds/0,
          get_buckets/1,
@@ -259,6 +260,10 @@ delete_object(Bucket, Key, RiakcPid) ->
         Else ->
             Else
     end.
+
+-spec encode_term(term()) -> binary().
+encode_term(Term) ->
+    term_to_binary(Term, [compressed]).
 
 %% @private
 maybe_gc_active_manifests({ok, RiakObject, Manifests}, Bucket, Key, StartTime, RiakcPid) ->
@@ -673,7 +678,7 @@ riak_connection(Pool) ->
 save_user(User, UserObj, RiakPid) ->
     %% Metadata is currently never updated so if there
     %% are siblings all copies should be the same
-    UpdUserObj = update_obj_value(UserObj, term_to_binary(User)),
+    UpdUserObj = update_obj_value(UserObj, riak_cs_utils:encode_term(User)),
     riakc_pb_socket:put(RiakPid, UpdUserObj).
 
 %% @doc Set the ACL for a bucket. Existing ACLs are only

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -263,7 +263,16 @@ delete_object(Bucket, Key, RiakcPid) ->
 
 -spec encode_term(term()) -> binary().
 encode_term(Term) ->
-    term_to_binary(Term, [compressed]).
+    case use_t2b_compression() of
+        true ->
+            term_to_binary(Term, [compressed]);
+        false ->
+            term_to_binary(Term)
+    end.
+
+-spec use_t2b_compression() -> boolean().
+use_t2b_compression() ->
+    get_env(riak_cs, compress_terms, ?COMPRESS_TERMS).
 
 %% @private
 maybe_gc_active_manifests({ok, RiakObject, Manifests}, Bucket, Key, StartTime, RiakcPid) ->


### PR DESCRIPTION
I was doing some multipart upload testing an was seeing max object sizes (from Riak stats) relatively quickly get over 2MB (if you bang on the same file name over and over again). This change uses the `compression` option with `erlang:term_to_binary/2` before writing thing to Riak. This is transparently decompressed by `binary_to_term/1`. After the change, max file size dropped by approx. a factor of 4, sometimes more. I also combined all our uses of t2b (for persistence) into one place, so we could change it there later if need be.
