### PR TITLE
Repin riakc and riak_repl_pb_api deps so they are compatible.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 {deps, [
         {node_package, "1.2.0", {git, "git://github.com/basho/node_package", {tag, "1.2.0"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", "43bd3308d351c3bd7949fefb14bb2d87dc039e58"}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.3"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.1.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "1.2.2"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}},
         {sext, ".*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
@@ -37,5 +37,5 @@
         {poolboy, ".*", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", "4ee4934de744e3df95185aafe058dd5ab7980bff"}},
-        {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git",{tag, "0.2.1"}}}
+        {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.2"}}}
        ]}.


### PR DESCRIPTION
This PR is to compensate for some miscommunication and bad release process from related repos.

New dependency tags and their transitive deps:
- `riakc = 1.3.1.1` (based off `1.3` release branch)
- `riak_repl_pb_api = 0.2.2`
- `riak_pb = 1.3.0`
- `protobuffs = 0.8.0`
