### PR TITLE
Update xref ignores

### DIFF
--- a/xref.ignore-warnings
+++ b/xref.ignore-warnings
@@ -1,17 +1,17 @@
 ######## mapreduce functions calling into a riak_kv environment / code path
 src/riak_cs_storage.erl:67: Warning object_size_map/3 calls undefined function riak_object:get_values/1
-src/riak_cs_utils.erl:377: Warning map_keys_and_manifests/3 calls undefined function riak_object:get_values/1
-src/riak_cs_utils.erl:377: Warning map_keys_and_manifests/3 calls undefined function riak_object:key/1
+src/riak_cs_utils.erl:476: Warning map_keys_and_manifests/3 calls undefined function riak_object:get_values/1
+src/riak_cs_utils.erl:476: Warning map_keys_and_manifests/3 calls undefined function riak_object:key/1
 ######## kv backends calling into kv/core code
 src/riak_cs_kv_multi_backend.erl:369: Warning get_backend_bucketprops/2 calls undefined function riak_core_bucket:get_bucket/1
 src/riak_cs_kv_multi_backend.erl:142: Warning start/2 calls undefined function app_helper:get_prop_or_env/3
 src/riak_cs_kv_multi_backend.erl:142: Warning start/2 calls undefined function app_helper:get_prop_or_env/4
 src/riak_kv_fs2_backend.erl:89: Warning start/2 calls undefined function app_helper:get_prop_or_env/3
 src/riak_kv_fs2_backend.erl:89: Warning start/2 calls undefined function riak:stop/1
-######## testing code 
+######## testing code
 src/riak_cs_manifest_fsm.erl:141: Warning init/1 calls undefined function riakc_pb_socket_fake:start_link/0
 src/riak_cs_manifest_fsm.erl:141: Warning init/1 calls undefined function riakc_pb_socket_fake:start_link/0
 src/riak_cs_get_fsm.erl:101: Warning init/1 calls undefined function riak_cs_dummy_reader:get_manifest/1
 src/riak_cs_get_fsm.erl:101: Warning init/1 calls undefined function riak_cs_dummy_reader:start_link/1
-######## optional vm features 
+######## optional vm features
 src/riak_cs_sup.erl:45: Warning init/1 calls undefined function dtrace:init/0


### PR DESCRIPTION
`make xref` should just return

```
==> riak_cs (xref)
ERROR: xref failed while processing /Users/reid/Documents/repos/basho/riak_cs: rebar_abort
```
