### PR TITLE
Address some dialyzer warnings

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -152,13 +152,20 @@
   xmerl_ucs:from_utf8/1
   xmerl_ucs:to_utf8/1
   xmerl_xpath:string/2
-############# stuff dialyzer has stumped us on - mostly unused code where 
+############# stuff dialyzer has stumped us on - mostly unused code where
 ############# we've gone in and added a throw / log to be sure
 riak_cs_mp_utils.erl:522: The pattern <Bucket, OwnerStr> can never match since previous clauses completely covered the type <_,'undefined' | {_,_,_}>
 ^riak_cs_lfs_utils.erl:119:
 riak_cs_gc.erl:.*: The pattern ..UUID, _... _. can never match the type ..$
+############# Due to inadequate specs with our riak-erlang-client tag
+riak_cs_gc_d.erl:369: Function fetch_eligible_manifest_keys/2 will never be called
+riak_cs_gc_d.erl:373: Function eligible_manifest_keys/1 will never be called
+riak_cs_gc_d.erl:381: Function gc_index_query/2 will never be called
+^riak_cs_riakc_pool_worker.erl:33:
+riak_cs_storage_d.erl:332: Function fetch_user_list/1 will never be called
+riak_cs_wm_ping.erl:46: The pattern 'undefined' can never match the type pid()
 ############## All the others..........
 riak_cs_blockall_auth.erl:9: Callback info about the riak_cs_auth behaviour is not available
 riak_cs_passthru_auth.erl:9: Callback info about the riak_cs_auth behaviour is not available
 riak_cs_s3_auth.erl:9: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_s3_policy.erl:11: Callback info about the riak_cs_policy behaviour is not available
+riak_cs_s3_policy.erl:12: Callback info about the riak_cs_policy behaviour is not available

--- a/include/s3_api.hrl
+++ b/include/s3_api.hrl
@@ -94,7 +94,7 @@
           provider = aws :: aws,
           service  = s3  :: s3,
           region         :: string(),
-          id             :: string(),
+          id             :: binary(),
           path           :: string()
          }).
 

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -185,7 +185,7 @@ policy_from_json(JSON) ->
                          E;
                       [] ->
                          {error, malformed_policy_missing};
-                      
+
                       Stmts ->
                          case {Version, ID} of
                              {undefined, <<"undefined">>} ->
@@ -350,7 +350,7 @@ eval_statement(#access_v1{method=M, target=T, req=Req, bucket=B, key=K} = _Acces
             Match = lists:all(fun(Cond) -> eval_condition(Req, Cond) end, Conds),
             case {E, Match} of
                 {allow, true} -> true;
-                {deny, true} -> false;  
+                {deny, true} -> false;
                 {_, false} -> undefined %% matches nothing
             end
     end.
@@ -561,7 +561,7 @@ int_to_prefix(0) -> 0.
 -spec statement_from_pairs(list(), #statement{})-> #statement{}.
 statement_from_pairs([], Stmt) ->
     case Stmt#statement.principal of
-        undefined ->
+        [] ->
             %% TODO: there're a lot to do: S3 describes the
             %% details of error, in xml. with <Code>, <Message> and <Detail>
             throw({error, malformed_policy_missing});
@@ -705,7 +705,7 @@ print_arns(#arn_v1{region=R, id=ID, path=Path} = _ARN) ->
     StringPath = unicode:characters_to_list(Path),
     StringID   = binary_to_list(ID),
     list_to_binary(string:join(["arn", "aws", "s3", R, StringID, StringPath], ":"));
-                        
+
 print_arns(ARNs) when is_list(ARNs)->
     PrintARN = fun(ARN) -> print_arns(ARN) end,
     lists:map(PrintARN, ARNs).

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -1490,7 +1490,7 @@ pid_to_binary(Pid) ->
 
 %% @doc Rapid calls to `md5_update' with largish data blocks (e.g. 1MB)
 %% can lead to erlang scheduler collapse
--spec chunked_md5(binary(), binary(), non_neg_integer()) -> {binary(), binary()}.
+-spec chunked_md5(binary(), binary(), non_neg_integer()) -> binary().
 chunked_md5(<<>>, Context, _ChunkSize) ->
     Context;
 chunked_md5(Data, Context, ChunkSize) ->


### PR DESCRIPTION
Most of these popped up when we switched to the `1.3.1.1` tag of `riak-erlang-client`. More recent versions have better specs. 
