### PR TITLE
capitalization of x-amz-meta- header on multipart upload.

### DIFF
--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -232,7 +232,7 @@ new_manifest(Bucket, Key, ContentType, {_, _, _} = Owner, Opts) ->
     UUID = druuid:v4(),
     %% TODO: add object metadata here, e.g. content-disposition et al.
     %% TODO: add cluster_id ... which means calling new_manifest/11 not /9.
-    MetaData = case proplists:get_value(as_is_headers, Opts) of
+    MetaData = case proplists:get_value(meta_data, Opts) of
                    undefined -> [];
                    AsIsHdrs  -> AsIsHdrs
                end,

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -27,6 +27,7 @@
          error_response/5,
          list_bucket_response/5,
          list_all_my_buckets_response/3,
+         copy_object_response/3,
          no_such_upload_response/3,
          error_code_to_atom/1]).
 
@@ -235,6 +236,14 @@ list_bucket_response(User, Bucket, KeyObjPairs, RD, Ctx) ->
 user_to_xml_owner(?RCS_USER{canonical_id=CanonicalId, display_name=Name}) ->
     {'Owner', [{'ID', [CanonicalId]},
                {'DisplayName', [Name]}]}.
+
+copy_object_response(Manifest, RD, Ctx) ->
+    LastModified = riak_cs_wm_utils:to_iso_8601(Manifest?MANIFEST.created),
+    ETag = riak_cs_utils:etag_from_binary(Manifest?MANIFEST.content_md5),
+    XmlDoc = [{'CopyObjectResponse',
+               [{'LastModified', [LastModified]},
+                {'ETag', [ETag]}]}],
+    respond(200, export_xml(XmlDoc), RD, Ctx).
 
 export_xml(XmlDoc) ->
     unicode:characters_to_binary(

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -286,12 +286,9 @@ accept_body(RD, Ctx=#context{local_context=LocalCtx,
     #key_context{bucket=Bucket, key=KeyStr, manifest=Mfst} = LocalCtx,
     Acl = Mfst?MANIFEST.acl,
     NewAcl = Acl?ACL{creation_time = now()},
-    %% Remove the x-amz-meta- prefixed items in the dict
-    MD = [KV || {K, _V} = KV <- orddict:to_list(Mfst?MANIFEST.metadata),
-                not lists:prefix("x-amz-meta-", K)],
-    NewMD = orddict:to_list(riak_cs_wm_utils:extract_user_metadata(RD) ++ MD),
+    Metadata = riak_cs_wm_utils:extract_user_metadata(RD),
     case riak_cs_utils:set_object_acl(Bucket, list_to_binary(KeyStr),
-                                      Mfst?MANIFEST{metadata=NewMD}, NewAcl,
+                                      Mfst?MANIFEST{metadata=Metadata}, NewAcl,
                                       RiakcPid) of
         ok ->
             ETag = riak_cs_utils:etag_from_binary(Mfst?MANIFEST.content_md5),


### PR DESCRIPTION
I uploaded file with x-amz-meta- header on multipart upload. But the stored meta data was capitalised.
- putting meta: x-amz-meta-hoge:text
- stored meta: X-Amz-Meta-Hoge: text
## uploading file with MP

```
% s3cmd -c ~/Desktop/kk.cfg --add-header=x-amz-meta-hoge:text put VisualVM_135.dmg s3://test2
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
VisualVM_135.dmg -> s3://test2/VisualVM_135.dmg  [part 1 of 2, 15MB]
 15728640 of 15728640   100% in   33s   459.32 kB/s  done
VisualVM_135.dmg -> s3://test2/VisualVM_135.dmg  [part 2 of 2, 5MB]
 5890107 of 5890107   100% in   12s   456.68 kB/s  done
```
## tcpdump on the uploading

```
12:00:16.312 192.168.11.7:56360 -> xxx.xxx.xxx.xxx:8080 #1 HTTP 1.1 request: POST http://test2.s3.amazonaws.com/VisualVM_135.dmg?uploads
    Host: test2.s3.amazonaws.com
    Accept-Encoding: identity
    x-amz-meta-hoge: text
    content-length: 0
    content-type: application/octet-stream
    Authorization: AWS KTBG_FWRVG_SSK02MMP3:mPtrBDJZNpsMhLCPP3v7f1CJM+Q=
    x-amz-date: Fri, 22 Mar 2013 03:00:16 +0000
```
## getting uploaded file.

```
% s3curl.pl --id kk   -- -v -x xxx.xxx.xxx.xxx:8080 -X HEAD http://test2.s3.amazonaws.com/VisualVM_135.dmg
* About to connect() to proxy xxx.xxx.xxx.xxx port 8080 (#0)
*   Trying xxx.xxx.xxx.xxx...
* connected
* Connected to xxx.xxx.xxx.xxx (xxx.xxx.xxx.xxx) port 8080 (#0)
> HEAD http://test2.s3.amazonaws.com/VisualVM_135.dmg HTTP/1.1
> User-Agent: curl/7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
> Host: test2.s3.amazonaws.com
> Accept: */*
> Proxy-Connection: Keep-Alive
> Date: Fri, 22 Mar 2013 03:01:10 GMT
> Authorization: AWS KTBG_FWRVG_SSK02MMP3:2clrTjGX9d0HImwicmbgSVjyfmg=
>
< HTTP/1.1 200 OK
< X-Amz-Meta-Hoge: text
< Server: MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)
< Last-Modified: Fri, 22 Mar 2013 03:00:16 GMT
< ETag: "c77f589597f345cfa806289252cf1156"
< Date: Fri, 22 Mar 2013 03:01:10 GMT
< Content-Type: application/octet-stream
< Content-Length: 21618747
```
