### PR TITLE
Old object shows up after delete the latest

### DIFF
--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -341,7 +341,7 @@ delete_bucket(User, UserObj, Bucket, RiakPid) ->
 delete_object(Bucket, Key, RiakcPid) ->
     StartTime = os:timestamp(),
     DoIt = fun() ->
-                   maybe_gc_active_manifests(
+                   maybe_gc_active_and_writing_manifests(
                      get_manifests(RiakcPid, Bucket, Key), Bucket, Key, StartTime, RiakcPid)
            end,
     case DoIt() of
@@ -370,13 +370,13 @@ use_t2b_compression() ->
     get_env(riak_cs, compress_terms, ?COMPRESS_TERMS).
 
 %% @private
-maybe_gc_active_manifests({ok, RiakObject, Manifests}, Bucket, Key, StartTime, RiakcPid) ->
-    R = riak_cs_gc:gc_active_manifests(Manifests, RiakObject, Bucket, Key, RiakcPid),
+maybe_gc_active_and_writing_manifests({ok, RiakObject, Manifests}, Bucket, Key, StartTime, RiakcPid) ->
+    R = riak_cs_gc:gc_active_and_writing_manifests(Manifests, RiakObject, Bucket, Key, RiakcPid),
     ok = riak_cs_stats:update_with_start(object_delete, StartTime),
     R;
-maybe_gc_active_manifests({error, notfound}, _Bucket, _Key, _StartTime, _RiakcPid) ->
+maybe_gc_active_and_writing_manifests({error, notfound}, _Bucket, _Key, _StartTime, _RiakcPid) ->
     {ok, []};
-maybe_gc_active_manifests({error, _Reason}=Error, _Bucket, _Key, _StartTime, _RiakcPid) ->
+maybe_gc_active_and_writing_manifests({error, _Reason}=Error, _Bucket, _Key, _StartTime, _RiakcPid) ->
     Error.
 
 


### PR DESCRIPTION
```
$ git show  --decorate | head -6
commit 41c81d4f10c59034ae1ba22ec5a4af1b303efb91 (HEAD, origin/develop, origin/HEAD, develop)
Merge: ff790c2 c404aa1
Author: Kelly McLaughlin <kelly@basho.com>
Date:   Thu Mar 21 09:46:21 2013 -0600

    Merge branch 'feature/configurable-pb-connect-timeout' into develop
```

First, put twice:

```
$ s3cmd la


$ echo "OLD" > data.local/1
$ s3cmd put data.local/1 s3://test
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
data.local/1 -> s3://test/1  [1 of 1]
 4 of 4   100% in    0s   286.16 B/s  done
$ s3cmd get s3://test/1 -
s3://test/1 -> <stdout>  [1 of 1]
OLD
 4 of 4   100% in    0s   216.59 B/s  done
$ echo "NEW" > data.local/1
$ s3cmd put data.local/1 s3://test
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
data.local/1 -> s3://test/1  [1 of 1]
 4 of 4   100% in    0s   230.60 B/s  done
$ s3cmd get s3://test/1 -
s3://test/1 -> <stdout>  [1 of 1]
NEW
 4 of 4   100% in    0s   236.07 B/s  done
```

After del it, old object shows up:

```
$ s3cmd del s3://test/1
File s3://test/1 deleted
$ s3cmd get s3://test/1 -
s3://test/1 -> <stdout>  [1 of 1]
OLD
 4 of 4   100% in    0s   413.61 B/s  done
```

One more del, object disappears:

```
$ s3cmd del s3://test/1
File s3://test/1 deleted
$ s3cmd la


```
