### PR TITLE
multipart upload got 477 using aws-sdk-ruby.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ test-client: test-clojure test-python test-erlang
 
 test-python: test-boto
 
+test-ruby:
+	@bundle --gemfile client_tests/ruby/Gemfile --path vendor
+	@cd client_tests/ruby && bundle exec rake spec
+
 test-boto:
 	env CS_HTTP_PORT=${CS_HTTP_PORT} python client_tests/python/boto_test.py
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ distclean: clean
 test: all
 	@./rebar skip_deps=true eunit
 
-test-client: test-clojure test-python test-erlang
+test-client: test-clojure test-python test-erlang test-ruby
 
 test-python: test-boto
 

--- a/client_tests/ruby/.gitignore
+++ b/client_tests/ruby/.gitignore
@@ -1,2 +1,4 @@
 Gemfile.lock
 conf/s3.yml
+vendor/
+.bundle/

--- a/client_tests/ruby/Gemfile
+++ b/client_tests/ruby/Gemfile
@@ -1,8 +1,9 @@
 source "https://rubygems.org"
 
-gem "aws-sdk", "~>1.7.1"
+gem "aws-sdk", "~>1.8.5"
 gem "uuid", "~>2.3.6"
 gem "rake", "~>10.0.2"
+gem "httparty", "~>0.10.2"
 
 group :test do
   gem "rspec", "~>2.11.0"

--- a/client_tests/ruby/README.md
+++ b/client_tests/ruby/README.md
@@ -1,6 +1,5 @@
 # howto run
 
-* edit conf/s3.yml to your RiakCS
 * prepare rake
 
 ```

--- a/client_tests/ruby/conf/s3.yml.sample
+++ b/client_tests/ruby/conf/s3.yml.sample
@@ -1,6 +1,0 @@
-s3:
-  access_key_id:  "your-aws-access-key-id"
-  secret_access_key: "your-aws-secret-access-key"
-  proxy_uri: "http://33.33.33.10:8080"
-  use_ssl: false
-  max_retries: 0

--- a/client_tests/ruby/spec/helper.rb
+++ b/client_tests/ruby/spec/helper.rb
@@ -1,0 +1,25 @@
+require 'httparty'
+require 'json'
+require 'uuid'
+
+def create_user(name)
+  response = HTTParty.put("http://localhost:8080/riak-cs/user",
+                          :body => {
+                            :name => name,
+                            :email => "#{name}@example.com"}.to_json,
+                          :headers => {
+                            "Content-Type" => "application/json"})
+  json_body = JSON.parse(response.body)
+  return json_body['key_id'], json_body['key_secret']
+end
+
+def s3_conf
+  key_id, key_secret = create_user(UUID::generate)
+  {
+    access_key_id: key_id,
+    secret_access_key: key_secret,
+    proxy_uri: "http://localhost:8080",
+    use_ssl: false,
+    max_retries: 0
+  }
+end

--- a/client_tests/ruby/spec/helper.rb
+++ b/client_tests/ruby/spec/helper.rb
@@ -1,6 +1,7 @@
 require 'httparty'
 require 'json'
 require 'uuid'
+require 'tempfile'
 
 def create_user(name)
   response = HTTParty.put("http://localhost:8080/riak-cs/user",
@@ -20,6 +21,13 @@ def s3_conf
     secret_access_key: key_secret,
     proxy_uri: "http://localhost:8080",
     use_ssl: false,
+    http_read_timeout: 2000,
     max_retries: 0
   }
+end
+
+def new_mb_temp_file(size)
+    temp = Tempfile.new 'riakcs-test'
+    (size*1024*1024).times {|i| temp.write 0}
+    temp
 end

--- a/client_tests/ruby/spec/helper.rb
+++ b/client_tests/ruby/spec/helper.rb
@@ -4,7 +4,7 @@ require 'uuid'
 require 'tempfile'
 
 def create_user(name)
-  response = HTTParty.put("http://localhost:8080/riak-cs/user",
+  response = HTTParty.put("#{cs_uri}/riak-cs/user",
                           :body => {
                             :name => name,
                             :email => "#{name}@example.com"}.to_json,
@@ -19,11 +19,19 @@ def s3_conf
   {
     access_key_id: key_id,
     secret_access_key: key_secret,
-    proxy_uri: "http://localhost:8080",
+    proxy_uri: cs_uri,
     use_ssl: false,
     http_read_timeout: 2000,
     max_retries: 0
   }
+end
+
+def cs_uri
+  "http://localhost:#{cs_port}"
+end
+
+def cs_port
+  ENV['CS_HTTP_PORT'] || 8080
 end
 
 def new_mb_temp_file(size)

--- a/client_tests/ruby/spec/s3_spec.rb
+++ b/client_tests/ruby/spec/s3_spec.rb
@@ -103,5 +103,17 @@ describe AWS::S3 do
 
       s3.buckets[bucket_name].objects[object_name].acl.grants.include?(grant_public_read).should == true
     end
+
+    it "should be able to put object using multipart upload" do
+      s3.buckets.create(bucket_name).should be_kind_of(AWS::S3::Bucket)
+
+      temp = new_mb_temp_file 6 # making 6MB file
+      s3.buckets[bucket_name].objects[object_name].write(
+                                    :file => temp.path,
+                                    :multipart_threshold => 1024 * 1024,
+                                   )
+      s3.buckets[bucket_name].objects[object_name].exists?.should == true
+      temp.close
+    end
   end
 end

--- a/client_tests/ruby/spec/s3_spec.rb
+++ b/client_tests/ruby/spec/s3_spec.rb
@@ -21,6 +21,7 @@
 require 'aws-sdk'
 require 'uuid'
 require 'yaml'
+require 'helper'
 
 class AWS::S3::AccessControlList::Grant
   def  ==(other)
@@ -29,7 +30,7 @@ class AWS::S3::AccessControlList::Grant
 end
 
 describe AWS::S3 do
-  let(:s3) { AWS::S3.new(YAML::load_file('conf/s3.yml')['s3']) }
+  let(:s3) { AWS::S3.new( s3_conf ) }
   let(:bucket_name) { "aws-sdk-test-" + UUID::generate }
   let(:object_name) { "key-" + UUID::generate }
   let(:grant_public_read) {

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -197,7 +197,7 @@ content_types_accepted(RD, Ctx) ->
 
 parse_body(Body) ->
     try
-        {ParsedData, _Rest} = xmerl_scan:string(Body, []),
+        {ParsedData, _Rest} = xmerl_scan:string(re:replace(Body, "&quot;", "", [global, {return, list}]), []),
         #xmlElement{name='CompleteMultipartUpload'} = ParsedData,
         Nums = [list_to_integer(T#xmlText.value) ||
                    T <- xmerl_xpath:string("//CompleteMultipartUpload/Part/PartNumber/text()", ParsedData)],


### PR DESCRIPTION
RiakCS respond 477 when I upload file using multipart upload with aws-sdk-ruby.
## to reproduce

```
git checkout bugfix/kaz-update-ruby-test
make test-ruby
```
## stack trace

```
/Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/core/client.rb:339:in `return_or_raise': AWS::Errors::Base
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/core/client.rb:440:in `client_request'
        from (eval):3:in `complete_multipart_upload'
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/s3/multipart_upload.rb:244:in `complete'
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/s3/multipart_upload.rb:267:in `close'
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/s3/s3_object.rb:713:in `multipart_upload'
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/s3/s3_object.rb:1629:in `write_with_multipart'
        from /Users/kazuhiro/.rbenv/versions/1.9.3-p194/lib/ruby/gems/1.9.1/gems/aws-sdk-1.8.5/lib/aws/s3/s3_object.rb:604:in `write'
        from hoge.rb:16:in `<main>'
```
## code

``` ruby
!#/usr/bin/env ruby

require 'aws-sdk'

s3client = AWS::S3.new(
  access_key_id:  "your-id",
  secret_access_key: "your-secret-key",
  proxy_uri: "http://localhost:8080",
  use_ssl: false,
  max_retries: 0,
)
bucket = s3client.buckets.create 'simple-bucket-xxxxxxxxxxxxxxxxxxxxxxxx'
bucket.objects['multi'].write(:file => 'Rakefile', :multipart_threshold => 100)
puts bucket.objects['multi'].read
```
- [http trace log](https://gist.github.com/ksauzz/9129d0b3c9aee48172cc#file-error-md)
