### PR TITLE
Gracefully handle Riak disconnects

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -164,7 +164,7 @@ riak_cs_gc_d.erl:383: Function fetch_eligible_manifest_keys/2 will never be call
 riak_cs_gc_d.erl:387: Function eligible_manifest_keys/1 will never be called
 riak_cs_gc_d.erl:395: Function gc_index_query/2 will never be called
 ^riak_cs_riakc_pool_worker.erl:48:
-riak_cs_storage_d.erl:346: Function fetch_user_list/1 will never be called
+riak_cs_storage_d.erl:384: Function fetch_user_list/1 will never be called
 riak_cs_wm_ping.erl:46: The pattern 'undefined' can never match the type pid()
 ############## All the others..........
 riak_cs_blockall_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available

--- a/src/riak_cs_riakc_pool_worker.erl
+++ b/src/riak_cs_riakc_pool_worker.erl
@@ -45,13 +45,15 @@ riak_host_port() ->
 -spec start_link(term()) -> {ok, pid()} | {error, term()}.
 start_link(_Args) ->
     {Host, Port} = riak_host_port(),
-    case application:get_env(riak_cs, riakc_connect_timeout) of
-        {ok, Timeout} ->
-            ok;
+    Timeout = case application:get_env(riak_cs, riakc_connect_timeout) of
+        {ok, ConfigValue} ->
+            ConfigValue;
         undefined ->
-            Timeout = 10000
+            10000
     end,
-    riakc_pb_socket:start_link(Host, Port, [{connect_timeout, Timeout}]).
+    StartOptions = [{connect_timeout, Timeout},
+                    {auto_reconnect, true}],
+    riakc_pb_socket:start_link(Host, Port, StartOptions).
 
 stop(undefined) ->
     ok;

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -134,6 +134,7 @@ status_code(admin_secret_undefined) -> 503;
 status_code(bucket_owner_unavailable) -> 503;
 status_code(multiple_bucket_owners) -> 503;
 status_code(econnrefused) -> 503;
+status_code(unsatisfied_constraint) -> 503;
 status_code(malformed_policy_json) -> 400;
 status_code(malformed_policy_missing) -> 400;
 status_code(malformed_policy_resource) -> 400;

--- a/src/riak_cs_storage_d.erl
+++ b/src/riak_cs_storage_d.erl
@@ -36,6 +36,7 @@
 %% gen_fsm callbacks
 -export([init/1,
 
+         prepare/2,
          idle/2, idle/3,
          calculating/2, calculating/3,
          paused/2, paused/3,
@@ -61,8 +62,15 @@
           batch_count=0, %% count of users processed so far
           batch_skips=0, %% count of users skipped so far
           batch=[],      %% users left to process in this batch
-          recalc         %% recalculate a user's storage for this period?
+          recalc,        %% recalculate a user's storage for this period?
+
+          bucket_property_read_retries=0  %% the number of times we've tried to read
+                                          %% bucket properties and received
+                                          %% `{error, disconnected}'
+
          }).
+
+-type state() :: #state{}.
 
 %%%===================================================================
 %%% API
@@ -128,13 +136,12 @@ resume_batch() ->
 
 %% @doc Read the storage schedule and go to idle.
 init([]) ->
-    Schedule = read_storage_schedule(),
-    SchedState = schedule_next(#state{schedule=Schedule},
-                               calendar:universal_time()),
-    ok = rts:check_bucket_props(?STORAGE_BUCKET),
-    {ok, idle, SchedState}.
+    {ok, prepare, #state{}, 0}.
 
 %% Asynchronous events
+
+prepare(timeout, State) ->
+    try_prepare(State).
 
 %% @doc Transitions out of idle are all synchronous events
 idle(_, State) ->
@@ -259,6 +266,37 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+-spec try_prepare(state()) -> {next_state, atom(), state()} |
+                              {next_state, atom(), state(), pos_integer()}.
+try_prepare(State=#state{bucket_property_read_retries=Retries}) ->
+    Schedule = read_storage_schedule(),
+    case rts:check_bucket_props(?STORAGE_BUCKET) of
+        {error, disconnected} ->
+            _ = lager:info("Unable to verify bucket properties for "
+                           "storage daemon. Riak "
+                           "currently disconnected. "
+                           "Retrying in 5 seconds."),
+            NewState = State#state{bucket_property_read_retries=Retries+1},
+            {next_state, prepare, NewState, timer:seconds(5)};
+        ok ->
+            _ = maybe_log_checked_bucket_properties(State),
+            SchedState = schedule_next(State#state{schedule=Schedule,
+                                                   %% reset the bucket property
+                                                   %% retry time
+                                                   bucket_property_read_retries=0},
+                                       calendar:universal_time()),
+            {next_state, idle, SchedState}
+    end.
+
+-spec maybe_log_checked_bucket_properties(state()) -> ok.
+maybe_log_checked_bucket_properties(#state{bucket_property_read_retries=N})
+        when N =/= 0 ->
+    _ = lager:info("Storage daemon successfully read bucket properties, "
+                   "continuing"),
+    ok;
+maybe_log_checked_bucket_properties(_State) ->
+    ok.
 
 %% @doc The schedule will contain all valid times found in the
 %% configuration, and will be sorted in day order.

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -152,6 +152,8 @@ handle_validation_response({ok, User, UserObj}, RD, Ctx, Next, _, _) ->
     %% given keyid and signature matched, proceed
     Next(RD, Ctx#context{user=User,
                          user_object=UserObj});
+handle_validation_response({error, disconnected}, RD, Ctx, _Next, _, _Bool) ->
+    {{halt, 503}, RD, Ctx};
 handle_validation_response({error, Reason}, RD, Ctx, Next, _, true) ->
     %% no keyid was given, proceed anonymously
     _ = lager:debug("No user key: ~p", [Reason]),


### PR DESCRIPTION
Previously, Riak CS would not start if it was unable to connect
to Riak. Furthermore, it would eventually crash if it was disconnected to Riak.
This was due to the fact that the `poolboy` workers would die and poolboy would
not try and restart them. This leads to the `poolboy` supervisor eventually
crashing and then it bubbles up to the `riak_cs_sup` crashing. The main
change here is that we pass the `auto_reconnect` option into
`riakc_pb_socket`, which allows it to return from `start_link` even if
it can't connect to Riak. Attempts to use `riakc_pb_socket` when it's in
this state will return `{error, disconnected}`. I've tried to handle as
many of the cases where this might happen, and return 503 to the end
user. There are cases where we might be far enough in the response
(headers already sent over the wire), where for now I just Let It Crash.
Originally, I had thought about adding a 'health' thread that would
monitor Riak availability, for the purposes of informing the deployer
via log messages. However, for now, I think the log messages are clear
enough when Riak gets disconnected that it should be obvious. The sudden
spike in 503 responses should also be a pretty good indicator. Other smaller
changes are detailed below.
- Allow `riak_cs_storage_d` to start even if it can't immediately connect to
  Riak
- Refactor `riak_cs_wm_common:forbidden/2` to handle disconnected Riak
  when retrieving the user record

---

Fixes #262 

---
## Testing!

Here are some ideas for testing, beyond the usual bits:
- Start Riak CS when Riak is not running
- Start Riak CS when it's configured to talk to the wrong Riak port
- Kill/stop Riak while Riak CS is running, verify that requests start seeing 503 errors (I _think_ I eliminated all the cases where they'd see, 403, so it's a bug if you see 403).
- Verify that things that working again when Riak comes back to life
