### PR TITLE
clojure test fails: dependency error and NumberFormatException

### DIFF
--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,11 +1,9 @@
 (defproject java-s3-tests/java-s3-tests "0.0.1"
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.amazonaws/aws-java-sdk "1.3.11"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [com.reiddraper/clj-aws-s3 "0.4.0"]
-                 [commons-codec/commons-codec "1.6"]
-                 [clj-http "0.4.3"]
-                 [cheshire "4.0.0"]]
-  :profiles {:dev {:dependencies [[midje "1.4.0"]]}}
+                 [clj-http "0.7.1"]
+                 [cheshire "5.1.0"]]
+  :profiles {:dev {:dependencies [[midje "1.5.1"]]}}
   :min-lein-version "2.0.0"
-  :plugins [[lein-midje "2.0.1"]]
+  :plugins [[lein-midje "3.0.1"]]
   :description "integration tests for Riak CS using the offical Java SDK")

--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,6 +1,6 @@
 (defproject java-s3-tests/java-s3-tests "0.0.1"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.reiddraper/clj-aws-s3 "0.4.0"]
+                 [com.reiddraper/clj-aws-s3 "0.4.1"]
                  [clj-http "0.7.1"]
                  [cheshire "5.1.0"]]
   :profiles {:dev {:dependencies [[midje "1.5.1"]]}}

--- a/client_tests/clojure/clj-s3/src/java_s3_tests/core.clj
+++ b/client_tests/clojure/clj-s3/src/java_s3_tests/core.clj
@@ -1,21 +1,17 @@
-(comment 
----------------------------------------------------------------------
-Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;; Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;;
+;; This file is provided to you under the Apache License,
+;; Version 2.0 (the "License"); you may not use this file
+;; except in compliance with the License.  You may obtain
+;; a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
 
-This file is provided to you under the Apache License,
-Version 2.0 (the "License"); you may not use this file
-except in compliance with the License.  You may obtain
-a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
----------------------------------------------------------------------
-)         
 (ns java-s3-tests.core)

--- a/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
+++ b/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
@@ -1,22 +1,19 @@
-(comment
----------------------------------------------------------------------
-Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;; Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;;
+;; This file is provided to you under the Apache License,
+;; Version 2.0 (the "License"); you may not use this file
+;; except in compliance with the License.  You may obtain
+;; a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
 
-This file is provided to you under the Apache License,
-Version 2.0 (the "License"); you may not use this file
-except in compliance with the License.  You may obtain
-a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
----------------------------------------------------------------------
-)
 (ns java-s3-tests.user-creation
   (:require [cheshire.core :as cheshire])
   (:require [clj-http.client :as http]))

--- a/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
+++ b/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
@@ -1,23 +1,19 @@
-(comment 
----------------------------------------------------------------------
-Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;; Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;;
+;; This file is provided to you under the Apache License,
+;; Version 2.0 (the "License"); you may not use this file
+;; except in compliance with the License.  You may obtain
+;; a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
 
-This file is provided to you under the Apache License,
-Version 2.0 (the "License"); you may not use this file
-except in compliance with the License.  You may obtain
-a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
----------------------------------------------------------------------
-)
 (ns java-s3-tests.test.client
   (:import java.security.MessageDigest
            org.apache.commons.codec.binary.Hex


### PR DESCRIPTION
Depends on https://github.com/reiddraper/clj-aws-s3/pull/1.

`make test-clojure` fails:

```
Could not find metadata org.codehaus.jackson:jackson-mapper-asl/maven-metadata.xml in local (/home/shino/.m2/repository)
Could not transfer metadata org.codehaus.jackson:jackson-mapper-asl/maven-metadata.xml from/to central (http://repo1.maven.org/maven2/): Checksum validation failed, expected c09b3634e82c52c906ef592e967ab609fbbcec62 but is 2a14c1a0b7c1ced8a9f78d8f68380ba3904829a2
Failure to find org.codehaus.jackson:jackson-mapper-asl/maven-metadata.xml in https://clojars.org/repo/ was cached in the local repository, resolution will not be reattempted until the update interval of clojars has elapsed or updates are forced
This could be due to a typo in :dependencies or network issues.
Could not resolve dependencies
make: *** [test-clojure] Error 1
```

By updating AWS SDK to the latest (1.4.1), this error goes away and `lein deps` runs successfully, but no facts are found:

```
$ make test-clojure
No facts were checked. Is that what you wanted?
```

In REPL, a compiling error can be seen:

```
user=> (use 'java-s3-tests.core)
CompilerException java.lang.NumberFormatException: Invalid number: 2007-2013, compiling:(java_s3_tests/core.clj:3:24)
```

So change license comments from `comment` form to semicolons.

I don't familiar with Clojure/Leiningen, please tell me if there is better way or inappropriate change.
