### PR TITLE
php-tests: fixed to work with aws-sdk-php-2.3.x.

### DIFF
--- a/client_tests/php/.gitignore
+++ b/client_tests/php/.gitignore
@@ -1,4 +1,3 @@
-test_services.json
 phpunit
 composer.lock
 vendor

--- a/client_tests/php/composer.json
+++ b/client_tests/php/composer.json
@@ -3,7 +3,7 @@
       "bin-dir": "."
     },
     "require": {
-        "aws/aws-sdk-php": "2.*"
+        "aws/aws-sdk-php": "2.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"

--- a/client_tests/php/test_services.json
+++ b/client_tests/php/test_services.json
@@ -3,11 +3,11 @@
     "services" : {
         "default_settings" : {
             "params" : {
-                "key"    : "your-aws-access-key-id",
-                "secret" : "your-aws-secret-access-key",
+                "key"    : "key_id",
+                "secret" : "key_secret",
                 "region" : "us-east-1",
                 "base_url" : "http://s3.amazonaws.com",
-                // "curl.options": {"CURLOPT_PROXY" : "33.33.33.10:8080"},
+                "curl.options": {"CURLOPT_PROXY" : "localhost:8080"},
                 "scheme" : "http"
             }
         }

--- a/client_tests/php/tests/S3ClientTest.php
+++ b/client_tests/php/tests/S3ClientTest.php
@@ -38,9 +38,9 @@ class S3ClientTest extends \Guzzle\Tests\GuzzleTestCase
     {
         if ( ! $this->client->doesBucketExist($this->bucket)) { return; }
 
-        $objectKeys = $this->client->listObjects(array('Bucket' => $this->bucket))['Contents'];
-        foreach ($objectKeys as $key) {
-            $this->client->deleteObject(array('Bucket' => $this->bucket, 'Key' => $key['Key']));
+        $objects = $this->client->getIterator('ListObjects', array('Bucket' => $this->bucket));
+        foreach ($objects as $object) {
+            $this->client->deleteObject(array('Bucket' => $this->bucket, 'Key' => $object['Key']));
         }
         $this->client->deleteBucket(array('Bucket' => $this->bucket));
     }

--- a/client_tests/php/tests/bootstrap.php
+++ b/client_tests/php/tests/bootstrap.php
@@ -21,5 +21,31 @@ under the License.
 ---------------------------------------------------------------------
 */
 require_once 'vendor/autoload.php';
-Guzzle\Tests\GuzzleTestCase::setServiceBuilder(Aws\Common\Aws::factory($_SERVER['CONFIG']));
+use Guzzle\Http\Client;
+
+function newServiceBuilder() {
+    $user = creat_user();
+    return Aws\Common\Aws::factory($_SERVER['CONFIG'], array(
+        'key' => $user['key_id'],
+        'secret' => $user['key_secret'],
+        'curl.options' => array('CURLOPT_PROXY' => 'localhost:' . cs_port())
+    ));
+}
+
+function creat_user() {
+    $name = uniqid('riakcs-');
+    $client = new Client('http://localhost:' . cs_port());
+    $request = $client->put('/riak-cs/user',
+                    array('Content-Type' => 'application/json'),
+                    "{\"name\":\"{$name}\", \"email\":\"{$name}@example.com\"}");
+    return $request->send()->json();
+}
+
+function cs_port() {
+    return getenv('CS_HTTP_PORT') ? getenv('CS_HTTP_PORT') : 8080;
+}
+
+
+Guzzle\Tests\GuzzleTestCase::setServiceBuilder(newServiceBuilder());
+
 ?>


### PR DESCRIPTION
php tests failed with aws-sdk-php-2.2.x or later. so I changed bad codes about list objects and fixed the sdk version in composer.json.

related issue #540.

In addition, I also added riak_test automation, so I'd like to add php-test to `make client-test` after merging #539.
