### PR TITLE
Support for basic OpenStack API operations and Keystone authentication

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -163,11 +163,13 @@ riak_cs_gc.erl:.*: The pattern ..UUID, _... _. can never match the type ..$
 riak_cs_gc_d.erl:383: Function fetch_eligible_manifest_keys/2 will never be called
 riak_cs_gc_d.erl:387: Function eligible_manifest_keys/1 will never be called
 riak_cs_gc_d.erl:395: Function gc_index_query/2 will never be called
-^riak_cs_riakc_pool_worker.erl:48:
+^riak_cs_riakc_pool_worker.erl:54:
+riak_cs_storage_d.erl:346: Function fetch_user_list/1 will never be called
 riak_cs_storage_d.erl:384: Function fetch_user_list/1 will never be called
 riak_cs_wm_ping.erl:46: The pattern 'undefined' can never match the type pid()
 ############## All the others..........
 riak_cs_blockall_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_passthru_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
+riak_cs_s3_passthru_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
 riak_cs_s3_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
+riak_cs_keystone_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
 riak_cs_s3_policy.erl:26: Callback info about the riak_cs_policy behaviour is not available

--- a/include/oos_api.hrl
+++ b/include/oos_api.hrl
@@ -18,18 +18,16 @@
 %%
 %% ---------------------------------------------------------------------
 
--module(riak_cs_blockall_auth).
+-define(DEFAULT_OS_AUTH_URL, "http://localhost:35357/v2.0/").
+-define(DEFAULT_TOKENS_RESOURCE, "tokens/").
+-define(DEFAULT_S3_TOKENS_RESOURCE, "s3tokens/").
+-define(DEFAULT_OS_USERS_RESOURCE, "users/").
+-define(DEFAULT_OS_ADMIN_TOKEN, "ADMIN").
+-define(DEFAULT_OS_OPERATOR_ROLES, [<<"admin">>, <<"swiftoperator">>]).
 
--behavior(riak_cs_auth).
-
--include("riak_cs.hrl").
-
--export([identify/2,authenticate/4]).
-
--spec identify(term(), term()) -> {undefined, block_all}.
-identify(_RD,_Ctx) ->
-    {undefined, block_all}.
-
--spec authenticate(rcs_user(), term(), term(), term()) -> ok | {error, term()}.
-authenticate(_User, AuthData, _RD, _Ctx) ->
-    {error, AuthData}.
+-record(keystone_s3_auth_req_v1, {
+          access :: binary(),
+          signature :: binary(),
+          token :: binary()}).
+-type keystone_s3_auth_req() :: #keystone_s3_auth_req_v1{}.
+-define(KEYSTONE_S3_AUTH_REQ, #keystone_s3_auth_req_v1).

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -86,8 +86,10 @@
                   submodule :: atom(),
                   exports_fun :: function(),
                   auth_module :: atom(),
+                  response_module :: atom(),
                   policy_module :: atom(),
-                  local_context :: term()
+                  local_context :: term(),
+                  api :: atom()
                  }).
 
 -record(key_context, {context :: #context{},
@@ -399,6 +401,10 @@
 -define(DEFAULT_PING_TIMEOUT, 5000).
 -define(JSON_TYPE, "application/json").
 -define(XML_TYPE, "application/xml").
+-define(S3_API_MOD, riak_cs_s3_rewrite).
+-define(OOS_API_MOD, riak_cs_oos_rewrite).
+-define(S3_RESPONSE_MOD, riak_cs_s3_response).
+-define(OOS_RESPONSE_MOD, riak_cs_oos_response).
 
 %% Major categories of Erlang-triggered DTrace probes
 %%

--- a/include/riak_cs_api.hrl
+++ b/include/riak_cs_api.hrl
@@ -1,0 +1,29 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-record(list_buckets_response_v1, {
+          %% the user record
+          user :: rcs_user(),
+
+          %% the list of bucket records
+          buckets :: [cs_bucket()]
+         }).
+-type list_buckets_response() :: #list_buckets_response_v1{}.
+-define(LBRESP, #list_buckets_response_v1).

--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -63,6 +63,10 @@
                 {bucket_list_pool, {{bucket_list_pool_tuple}} }
                ]},
 
+              %% == API and Authentication ==
+             {rewrite_module, {{rewrite_module}} },
+             {auth_module, {{auth_module}} },
+
               %% == Rolling upgrade support ==
 
               %% Riak CS version number. This is used to selectively

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -26,6 +26,8 @@
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 {cs_version,        010300}.
+{rewrite_module,    riak_cs_s3_rewrite}.
+{auth_module,       riak_cs_s3_auth}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev1_vars.config
+++ b/rel/vars/dev1_vars.config
@@ -26,6 +26,8 @@
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 {cs_version,        010300}.
+{rewrite_module,    riak_cs_s3_rewrite}.
+{auth_module,       riak_cs_s3_auth}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev2_vars.config
+++ b/rel/vars/dev2_vars.config
@@ -26,6 +26,8 @@
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 {cs_version,        010300}.
+{rewrite_module,    riak_cs_s3_rewrite}.
+{auth_module,       riak_cs_s3_auth}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev3_vars.config
+++ b/rel/vars/dev3_vars.config
@@ -26,6 +26,8 @@
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 {cs_version,        010300}.
+{rewrite_module,    riak_cs_s3_rewrite}.
+{auth_module,       riak_cs_s3_auth}.
 
 %%
 %% etc/vm.args

--- a/rel/vars/dev4_vars.config
+++ b/rel/vars/dev4_vars.config
@@ -26,6 +26,8 @@
 {request_pool_tuple, "{128, 0}"}.
 {bucket_list_pool_tuple, "{5, 0}"}.
 {cs_version,        010300}.
+{rewrite_module,    riak_cs_s3_rewrite}.
+{auth_module,       riak_cs_s3_auth}.
 
 %%
 %% etc/vm.args

--- a/src/riak_cs_api.erl
+++ b/src/riak_cs_api.erl
@@ -1,0 +1,60 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_api).
+
+-export([list_buckets/1,
+         list_objects/5]).
+
+-include("riak_cs.hrl").
+-include("riak_cs_api.hrl").
+-include("list_objects.hrl").
+
+%% @doc Return a user's buckets.
+-spec list_buckets(rcs_user()) -> ?LBRESP{}.
+list_buckets(User=?RCS_USER{buckets=Buckets}) ->
+    ?LBRESP{user=User,
+            buckets=[Bucket || Bucket <- Buckets,
+                               Bucket?RCS_BUCKET.last_action /= deleted]}.
+
+-type options() :: [{atom(), 'undefined' | binary()}].
+-spec list_objects([string()], binary(), non_neg_integer(), options(), pid()) ->
+                          {ok, ?LORESP{}} | {error, term()}.
+list_objects([], _, _, _, _) ->
+    {error, no_such_bucket};
+list_objects(_UserBuckets, _Bucket, {error, _}=Error, _Options, _RiakPid) ->
+    Error;
+list_objects(_UserBuckets, Bucket, MaxKeys, Options, RiakPid) ->
+    ListKeysRequest = riak_cs_list_objects:new_request(Bucket,
+                                                       MaxKeys,
+                                                       Options),
+    BinPid = riak_cs_utils:pid_to_binary(self()),
+    CacheKey = << BinPid/binary, <<":">>/binary, Bucket/binary >>,
+    UseCache = riak_cs_list_objects_ets_cache:cache_enabled(),
+    case riak_cs_list_objects_fsm:start_link(RiakPid,
+                                             self(),
+                                             ListKeysRequest,
+                                             CacheKey,
+                                             UseCache) of
+        {ok, ListFSMPid} ->
+            riak_cs_list_objects_fsm:get_object_list(ListFSMPid);
+        {error, _}=Error ->
+            Error
+    end.

--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -174,11 +174,11 @@ handle_cast({get_block, ReplyPid, Bucket, Key, ClusterID, UUID, BlockNumber}, St
     {FullBucket, FullKey} = full_bkey(Bucket, Key, UUID, BlockNumber),
     StartTime = os:timestamp(),
     GetOptions = [{r, 1}, {notfound_ok, false}, {basic_quorum, false}],
-    LocalClusterID = riak_cs_utils:get_cluster_id(RiakcPid),
+    LocalClusterID = riak_cs_config:cluster_id(RiakcPid),
     %% don't use proxy get if it's a local get
     %% or proxy get is disabled
     UseProxyGet = ClusterID /= undefined
-                    andalso riak_cs_utils:proxy_get_active()
+                    andalso riak_cs_config:proxy_get_active()
                     andalso LocalClusterID /= ClusterID,
     Object =
         case UseProxyGet of

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -1,0 +1,281 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_config).
+
+-export([
+         admin_creds/0,
+         anonymous_user_creation/0,
+         api/0,
+         auth_bypass/0,
+         admin_auth_enabled/0,
+         auth_module/0,
+         cluster_id/1,
+         cs_version/0,
+         enforce_multipart_part_size/0,
+         get_env/3,
+         key_list_multiplier/0,
+         set_key_list_multiplier/1,
+         md5_chunk_size/0,
+         policy_module/0,
+         proxy_get_active/0,
+         response_module/0,
+         response_module/1,
+         riak_cs_stat/0,
+         set_md5_chunk_size/1,
+         use_t2b_compression/0
+        ]).
+
+%% OpenStack config
+-export([os_auth_url/0,
+         os_operator_roles/0,
+         os_admin_token/0,
+         os_s3_tokens_url/0,
+         os_tokens_url/0,
+         os_users_url/0]).
+
+-include("riak_cs.hrl").
+-include("oos_api.hrl").
+-include("list_objects.hrl").
+
+%% ===================================================================
+%% General config options
+%% ===================================================================
+
+%% @doc Return the value of the `anonymous_user_creation' application
+%% environment variable.
+-spec anonymous_user_creation() -> boolean().
+anonymous_user_creation() ->
+    get_env(riak_cs, anonymous_user_creation, false).
+
+%% @doc Return the credentials of the admin user
+-spec admin_creds() -> {ok, {string(), string()}} | {error, term()}.
+admin_creds() ->
+    admin_creds_response(
+      get_env(riak_cs, admin_key, undefined),
+      get_env(riak_cs, admin_secret, undefined)).
+
+-spec admin_creds_response(term(), term()) -> {ok, {term(), term()}} |
+                                              {error, atom()}.
+admin_creds_response(undefined, _) ->
+    _ = lager:warning("The admin user's key id"
+                      "has not been specified."),
+    {error, admin_key_undefined};
+admin_creds_response([], _) ->
+    _ = lager:warning("The admin user's key id"
+                      "has not been specified."),
+    {error, admin_key_undefined};
+admin_creds_response(_, undefined) ->
+    _ = lager:warning("The admin user's secret"
+                      "has not been specified."),
+    {error, admin_secret_undefined};
+admin_creds_response(_, []) ->
+    _ = lager:warning("The admin user's secret"
+                      "has not been specified."),
+    {error, admin_secret_undefined};
+admin_creds_response(Key, Secret) ->
+    {ok, {Key, Secret}}.
+
+%% @doc Get the active version of Riak CS to use in checks to
+%% determine if new features should be enabled.
+-spec cs_version() -> pos_integer() | undefined.
+cs_version() ->
+    get_env(riak_cs, cs_version, undefined).
+
+-spec api() -> s3 | oos.
+api() ->
+    api(application:get_env(riak_cs, rewrite_module)).
+
+-spec api({ok, atom()} | undefined) -> s3 | oos | undefined.
+api({ok, ?S3_API_MOD}) ->
+    s3;
+api({ok, ?OOS_API_MOD}) ->
+    oos;
+api(_) ->
+    undefined.
+
+-spec auth_bypass() -> boolean().
+auth_bypass() ->
+    get_env(riak_cs, auth_bypass, false).
+
+-spec admin_auth_enabled() -> boolean().
+admin_auth_enabled() ->
+    get_env(riak_cs, admin_auth_enabled, true).
+
+-spec auth_module() -> atom().
+auth_module() ->
+    get_env(riak_cs, auth_module, ?DEFAULT_AUTH_MODULE).
+
+-spec enforce_multipart_part_size() -> boolean().
+enforce_multipart_part_size() ->
+    get_env(riak_cs, enforce_multipart_part_size, true).
+
+-spec key_list_multiplier() -> float().
+key_list_multiplier() ->
+    get_env(riak_cs, key_list_multiplier, ?KEY_LIST_MULTIPLIER).
+
+-spec set_key_list_multiplier(float()) -> 'ok'.
+set_key_list_multiplier(Multiplier) ->
+    application:set_env(riak_cs, key_list_multiplier, Multiplier).
+
+-spec policy_module() -> atom().
+policy_module() ->
+    get_env(riak_cs, policy_module, ?DEFAULT_POLICY_MODULE).
+
+-spec response_module() -> atom().
+response_module() ->
+    response_module(api()).
+
+-spec response_module(atom()) -> atom().
+response_module(oos) ->
+    ?OOS_RESPONSE_MOD;
+response_module(_) ->
+    ?S3_RESPONSE_MOD.
+
+-spec use_t2b_compression() -> boolean().
+use_t2b_compression() ->
+    get_env(riak_cs, compress_terms, ?COMPRESS_TERMS).
+
+%% doc Return the current cluster ID. Used for repl
+%% After obtaining the clusterid the first time,
+%% store the value in app:set_env
+-spec cluster_id(pid()) -> binary().
+cluster_id(Pid) ->
+    case application:get_env(riak_cs, cluster_id) of
+        {ok, ClusterID} ->
+            ClusterID;
+        undefined ->
+            Timeout = case application:get_env(riak_cs, cluster_id_timeout) of
+                          {ok, Value} ->
+                              Value;
+                          undefined   ->
+                              ?DEFAULT_CLUSTER_ID_TIMEOUT
+                      end,
+            maybe_get_cluster_id(proxy_get_active(), Pid, Timeout)
+    end.
+
+%% @doc If `proxy_get' is enabled then attempt to determine the cluster id
+-spec maybe_get_cluster_id(boolean(), pid(), integer()) -> undefined | binary().
+maybe_get_cluster_id(true, Pid, Timeout) ->
+    try
+        case riak_repl_pb_api:get_clusterid(Pid, Timeout) of
+            {ok, ClusterID} ->
+                application:set_env(riak_cs, cluster_id, ClusterID),
+                ClusterID;
+            _ ->
+                _ = lager:debug("Unable to obtain cluster ID"),
+                undefined
+        end
+    catch _:_ ->
+            %% Disable `proxy_get' so we do not repeatedly have to
+            %% handle this same exception. This would happen if an OSS
+            %% install has `proxy_get' enabled.
+            application:set_env(riak_cs, proxy_get, disabled),
+            undefined
+    end;
+maybe_get_cluster_id(false, _, _) ->
+    undefined.
+
+%% @doc Return the configured md5 chunk size
+-spec md5_chunk_size() -> non_neg_integer().
+md5_chunk_size() ->
+    get_env(riak_cs, md5_chunk_size, ?DEFAULT_MD5_CHUNK_SIZE).
+
+-spec riak_cs_stat() -> boolean().
+riak_cs_stat() ->
+    get_env(riak_cs, riak_cs_stat, true).
+
+%% @doc Helper fun to set the md5 chunk size
+-spec set_md5_chunk_size(non_neg_integer()) -> ok | {error, invalid_value}.
+set_md5_chunk_size(Size) when is_integer(Size) andalso Size > 0 ->
+    application:set_env(riak_cs, md5_chunk_size, Size);
+set_md5_chunk_size(_) ->
+    {error, invalid_value}.
+
+%% doc Check app.config to see if repl proxy_get is enabled
+%% Defaults to false.
+proxy_get_active() ->
+    case application:get_env(riak_cs, proxy_get) of
+        {ok, enabled} ->
+            true;
+        {ok, disabled} ->
+            false;
+        {ok, _} ->
+            _ = lager:warning("proxy_get value in app.config is invalid"),
+            false;
+        undefined -> false
+    end.
+
+%% ===================================================================
+%% S3 config options
+%% ===================================================================
+
+%% ===================================================================
+%% OpenStack config options
+%% ===================================================================
+
+-spec os_auth_url() -> term().
+os_auth_url() ->
+    get_env(riak_cs, os_auth_url, ?DEFAULT_OS_AUTH_URL).
+
+-spec os_operator_roles() -> [term()].
+os_operator_roles() ->
+    ordsets:from_list(get_env(riak_cs,
+                              os_operator_roles,
+                              ?DEFAULT_OS_OPERATOR_ROLES)).
+
+-spec os_admin_token() -> term().
+os_admin_token() ->
+    get_env(riak_cs, os_admin_token, ?DEFAULT_OS_ADMIN_TOKEN).
+
+-spec os_s3_tokens_url() -> term().
+os_s3_tokens_url() ->
+    os_auth_url() ++
+        get_env(riak_cs,
+                os_s3_tokens_resource,
+                ?DEFAULT_S3_TOKENS_RESOURCE).
+
+-spec os_tokens_url() -> term().
+os_tokens_url() ->
+    os_auth_url() ++
+        get_env(riak_cs,
+                os_tokens_resource,
+                ?DEFAULT_TOKENS_RESOURCE).
+
+-spec os_users_url() -> term().
+os_users_url() ->
+    os_auth_url() ++
+        get_env(riak_cs,
+                os_users_resource,
+                ?DEFAULT_OS_USERS_RESOURCE).
+
+%% ===================================================================
+%% Wrapper for `application:get_env'
+%% ===================================================================
+
+%% @doc Get an application environment variable or return a default term.
+-spec get_env(atom(), atom(), term()) -> term().
+get_env(App, Key, Default) ->
+    case application:get_env(App, Key) of
+        {ok, Value} ->
+            Value;
+        _ ->
+            Default
+    end.

--- a/src/riak_cs_json.erl
+++ b/src/riak_cs_json.erl
@@ -1,0 +1,209 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc A collection functions for going to or from JSON to an erlang
+%% record type.
+
+-module(riak_cs_json).
+
+-include("riak_cs.hrl").
+-include("list_objects.hrl").
+-include("oos_api.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% Public API
+-export([from_json/1,
+         get/2,
+         to_json/1,
+         value_or_default/2]).
+
+-type attributes() :: [{atom(), string()}].
+-type external_node() :: {atom(), [string()]}.
+-type internal_node() :: {atom(), [internal_node() | external_node()]} |
+                         {atom(), attributes(), [internal_node() | external_node()]}.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec from_json(string()) -> {struct, term()} | [term()] | {error, decode_failed}.
+from_json(JsonString) ->
+    case catch mochijson2:decode(JsonString) of
+        {'EXIT', _} ->
+            {error, decode_failed};
+        Result ->
+            Result
+    end.
+
+-type match_spec() :: {index, non_neg_integer()} | {key, binary(), binary()}.
+-type path_query() :: {find, match_spec()}.
+-type path() :: [binary() | path_query()].
+-spec get({struct, term()} | [term()] | undefined, path()) -> term().
+get({struct, _}=Object, Path) ->
+    follow_path(Object, Path);
+get(Array, [{find, Query} | RestPath]) when is_list(Array) ->
+    follow_path(find(Array, Query), RestPath);
+get(_Array, [{find, _Query} | _RestPath]) ->
+    {error, invalid_path};
+get(undefined, _) ->
+    {error, not_found};
+get(not_found, _) ->
+    {error, not_found}.
+
+-spec to_json(term()) -> binary().
+to_json(?KEYSTONE_S3_AUTH_REQ{}=Req) ->
+    Inner = {struct, [{<<"access">>, Req?KEYSTONE_S3_AUTH_REQ.access},
+                      {<<"signature">>, Req?KEYSTONE_S3_AUTH_REQ.signature},
+                      {<<"token">>, Req?KEYSTONE_S3_AUTH_REQ.token}]},
+    iolist_to_binary(mochijson2:encode({struct, [{<<"credentials">>, Inner}]}));
+to_json(undefined) ->
+    [];
+to_json([]) ->
+    [].
+
+-spec value_or_default({ok, term()} | {error, term()}, term()) -> term().
+value_or_default({error, Reason}, Default) ->
+    _ = lager:debug("JSON error: ~p", [Reason]),
+    Default;
+value_or_default({ok, Value}, _) ->
+    Value.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+-spec follow_path(tuple() | [term()] | undefined, path()) ->
+                         {ok, term()} | {error, not_found}.
+follow_path(undefined, _) ->
+    {error, not_found};
+follow_path(Value, []) ->
+    {ok, Value};
+follow_path(JsonItems, [{find, Query}]) ->
+    follow_path(find(JsonItems, Query), []);
+follow_path(JsonItems, [{find, Query} | RestPath]) ->
+    get(find(JsonItems, Query), RestPath);
+follow_path({struct, JsonItems}, [Key]) when is_tuple(Key) ->
+    follow_path(target_tuple_values(Key, JsonItems), []);
+follow_path({struct, JsonItems}, [Key]) ->
+    follow_path(proplists:get_value(Key, JsonItems), []);
+follow_path({struct, JsonItems}, [Key | RestPath]) ->
+    Value = proplists:get_value(Key, JsonItems),
+    follow_path(Value, RestPath).
+
+-spec find([term()], match_spec()) -> undefined | {struct, term()}.
+find(Array, {key, Key, Value}) ->
+    lists:foldl(key_folder(Key, Value), not_found, Array);
+find(Array, {index, Index}) when Index =< length(Array) ->
+    lists:nth(Index, Array);
+find(_, {index, _}) ->
+    undefined.
+
+key_folder(Key, Value) ->
+    fun({struct, Items}=X, Acc) ->
+            case lists:keyfind(Key, 1, Items) of
+                {Key, Value} ->
+                    X;
+                _ ->
+                    Acc
+            end;
+       (_, Acc) ->
+            Acc
+    end.
+
+-spec target_tuple_values(tuple(), proplists:proplist()) -> tuple().
+target_tuple_values(Keys, JsonItems) ->
+    list_to_tuple(
+      [proplists:get_value(element(Index, Keys), JsonItems)
+       || Index <- lists:seq(1, tuple_size(Keys))]).
+
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+-ifdef(TEST).
+
+get_single_key_test() ->
+    Object1 = "{\"abc\":\"123\", \"def\":\"456\", \"ghi\":\"789\"}",
+    Object2 = "{\"test\":{\"abc\":\"123\", \"def\":\"456\", \"ghi\":\"789\"}}",
+    ?assertEqual({ok, <<"123">>}, get(from_json(Object1), [<<"abc">>])),
+    ?assertEqual({ok, <<"456">>}, get(from_json(Object1), [<<"def">>])),
+    ?assertEqual({ok, <<"789">>}, get(from_json(Object1), [<<"ghi">>])),
+    ?assertEqual({ok, <<"123">>}, get(from_json(Object2), [<<"test">>, <<"abc">>])),
+    ?assertEqual({ok, <<"456">>}, get(from_json(Object2), [<<"test">>, <<"def">>])),
+    ?assertEqual({ok, <<"789">>}, get(from_json(Object2), [<<"test">>, <<"ghi">>])),
+    ?assertEqual({error, not_found}, get(from_json(Object1), [<<"zzz">>])),
+    ?assertEqual({error, not_found}, get(from_json(Object2), [<<"test">>, <<"zzz">>])).
+
+get_array_test() ->
+    Array = "[\"abc\", \"123\", \"def\", \"456\", 7]",
+    ?assertEqual({ok, <<"abc">>}, get(from_json(Array), [{find, {index, 1}}])),
+    ?assertEqual({ok, <<"123">>}, get(from_json(Array), [{find, {index, 2}}])),
+    ?assertEqual({ok, <<"def">>}, get(from_json(Array), [{find, {index, 3}}])),
+    ?assertEqual({ok, <<"456">>}, get(from_json(Array), [{find, {index, 4}}])),
+    ?assertEqual({ok, 7}, get(from_json(Array), [{find, {index, 5}}])),
+    ?assertEqual({error, not_found}, get(from_json(Array), [{find, {index, 6}}])).
+
+get_multi_key_test() ->
+    Object1 = "{\"test\":{\"abc\":\"123\", \"def\":\"456\", \"ghi\":\"789\"}}",
+    Object2 = "{\"test\":{\"abc\":{\"123\":123,\"456\":456,\"789\":789},\"def\""
+        ":{\"123\":123,\"456\":456,\"789\":789},\"ghi\":{\"123\":123,\"456\""
+        ":456,\"789\":789}}}",
+    ?assertEqual({ok, {<<"123">>, <<"789">>}}, get(from_json(Object1), [<<"test">>, {<<"abc">>, <<"ghi">>}])),
+    ?assertEqual({ok, {123, 789}}, get(from_json(Object2), [<<"test">>, <<"abc">>, {<<"123">>, <<"789">>}])),
+    ?assertEqual({ok, {123, 789}}, get(from_json(Object2), [<<"test">>, <<"def">>, {<<"123">>, <<"789">>}])),
+    ?assertEqual({ok, {123, 789}}, get(from_json(Object2), [<<"test">>, <<"ghi">>, {<<"123">>, <<"789">>}])).
+
+get_embedded_key_from_array_test() ->
+    Object = "{\"test\":{\"objects\":[{\"key1\":\"a1\",\"key2\":\"a2\",\"key3\""
+        ":\"a3\"},{\"key1\":\"b1\",\"key2\":\"b2\",\"key3\":\"b3\"},{\"key1\""
+        ":\"c1\",\"key2\":\"c2\",\"key3\":\"c3\"}]}}",
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"a1">>}, {<<"key2">>, <<"a2">>}, {<<"key3">>, <<"a3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key1">>, <<"a1">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"a1">>}, {<<"key2">>, <<"a2">>}, {<<"key3">>, <<"a3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key2">>, <<"a2">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"a1">>}, {<<"key2">>, <<"a2">>}, {<<"key3">>, <<"a3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key3">>, <<"a3">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"b1">>}, {<<"key2">>, <<"b2">>}, {<<"key3">>, <<"b3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key1">>, <<"b1">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"b1">>}, {<<"key2">>, <<"b2">>}, {<<"key3">>, <<"b3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key2">>, <<"b2">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"b1">>}, {<<"key2">>, <<"b2">>}, {<<"key3">>, <<"b3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key3">>, <<"b3">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"c1">>}, {<<"key2">>, <<"c2">>}, {<<"key3">>, <<"c3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key1">>, <<"c1">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"c1">>}, {<<"key2">>, <<"c2">>}, {<<"key3">>, <<"c3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key2">>, <<"c2">>}}])),
+    ?assertEqual({ok, {struct, [{<<"key1">>, <<"c1">>}, {<<"key2">>, <<"c2">>}, {<<"key3">>, <<"c3">>}]}},
+                 get(from_json(Object),
+                     [<<"test">>, <<"objects">>, {find, {key, <<"key3">>, <<"c3">>}}])).
+
+
+-endif.

--- a/src/riak_cs_keystone_auth.erl
+++ b/src/riak_cs_keystone_auth.erl
@@ -1,0 +1,234 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_keystone_auth).
+
+-behavior(riak_cs_auth).
+
+-compile(export_all).
+
+-export([identify/2, authenticate/4]).
+
+-include("riak_cs.hrl").
+-include("s3_api.hrl").
+-include("oos_api.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-define(QS_KEYID, "AWSAccessKeyId").
+-define(QS_SIGNATURE, "Signature").
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec identify(#wm_reqdata{}, #context{}) -> failed | {string() | undefined , string()}.
+identify(RD, #context{api=s3}) ->
+    validate_token(s3, RD);
+identify(RD, #context{api=oos}) ->
+    validate_token(oos, wrq:get_req_header("x-auth-token", RD)).
+
+-spec authenticate(rcs_user(), {string(), term()}, #wm_reqdata{}, #context{}) ->
+                          ok | {error, invalid_authentication}.
+authenticate(_User, {_, TokenItems}, _RD, _Ctx) ->
+    %% @TODO Expand authentication check for non-operators who may
+    %% have access
+    %% @TODO Can we rely on role names along or must the service id
+    %% also be checked?
+
+    %% Verify that the set of user roles contains a valid
+    %% operator role
+    TokenRoles = riak_cs_json:value_or_default(
+                   riak_cs_json:get(TokenItems, [<<"access">>, <<"user">>, <<"roles">>]),
+                   undefined),
+    IsDisjoint = ordsets:is_disjoint(token_names(TokenRoles), riak_cs_config:os_operator_roles()),
+    case not IsDisjoint of
+        true ->
+            ok;
+        false ->
+            {error, invalid_authentication}
+    end.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+token_names(undefined) ->
+    ordsets:new();
+token_names(Roles) ->
+    ordsets:from_list(
+      [proplists:get_value(<<"name">>, Role, []) || {struct, Role} <- Roles]).
+
+-spec validate_token(s3 | oos, undefined | string()) -> failed | {term(), term()}.
+validate_token(_, undefined) ->
+    failed;
+validate_token(Api, AuthToken) ->
+    %% @TODO Check token cache
+    %% @TODO Ensure token is not in revoked tokens list
+
+    %% Request token info and determine tenant
+    %% Riak CS `key_id' is concatentation of the OS tenant_id and
+    %% user_id with a colon delimiter.
+    handle_token_info_response(
+      request_keystone_token_info(Api, AuthToken)).
+
+-spec request_keystone_token_info(s3 | oos, string() | {term(), term()}) -> term().
+request_keystone_token_info(oos, AuthToken) ->
+    RequestURI = riak_cs_config:os_tokens_url() ++ AuthToken,
+    RequestHeaders = [{"X-Auth-Token", riak_cs_config:os_admin_token()}],
+    httpc:request(get, {RequestURI, RequestHeaders}, [], []);
+request_keystone_token_info(s3, RD) ->
+    {KeyId, Signature}  = case wrq:get_req_header("authorization", RD) of
+                              undefined ->
+                                  {wrq:get_qs_value(?QS_KEYID, RD), wrq:get_qs_value(?QS_SIGNATURE, RD)};
+                              AuthHeader ->
+                                  parse_auth_header(AuthHeader)
+                          end,
+    RequestURI = riak_cs_config:os_s3_tokens_url(),
+    STS = base64url:encode_to_string(calculate_sts(RD)),
+    RequestBody = riak_cs_json:to_json(?KEYSTONE_S3_AUTH_REQ{
+                                           access=list_to_binary(KeyId),
+                                           signature=list_to_binary(Signature),
+                                           token=list_to_binary(STS)}),
+    RequestHeaders = [{"X-Auth-Token", riak_cs_config:os_admin_token()}],
+    httpc:request(post, {RequestURI, RequestHeaders, "application/json", RequestBody}, [], []).
+
+handle_token_info_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, TokenInfo}})
+  when _Status >= 200, _Status =< 299 ->
+    TokenResult = riak_cs_json:from_json(TokenInfo),
+    UserId = case riak_cs_json:value_or_default(
+               riak_cs_json:get(TokenResult, [<<"access">>, <<"user">>, <<"id">>]),
+               undefined) of
+                 undefined ->
+                     undefined;
+                 UserIdBin ->
+                     binary_to_list(UserIdBin)
+             end,
+    {Name, Email, TenantId} = riak_cs_oos_utils:extract_user_data(
+                                riak_cs_oos_utils:get_os_user_data(UserId)),
+    {TenantId, {{Name, Email, UserId}, TokenResult}};
+handle_token_info_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, _}}) ->
+    failed;
+handle_token_info_response({error, Reason}) ->
+    _ = lager:warning("Error occurred requesting token from keystone. Reason: ~p",
+                  [Reason]),
+    failed.
+
+parse_auth_header("AWS " ++ Key) ->
+    case string:tokens(Key, ":") of
+        [KeyId, KeyData] ->
+            {KeyId, KeyData};
+        _ -> {undefined, undefined}
+    end;
+parse_auth_header(_) ->
+    {undefined, undefined}.
+
+-spec calculate_sts(term()) -> binary().
+calculate_sts(RD) ->
+    Headers = riak_cs_wm_utils:normalize_headers(RD),
+    AmazonHeaders = riak_cs_wm_utils:extract_amazon_headers(Headers),
+    OriginalResource = riak_cs_s3_rewrite:original_resource(RD),
+    Resource = case OriginalResource of
+        undefined -> []; %% TODO: get noisy here?
+        {Path,QS} -> [Path, canonicalize_qs(lists:sort(QS))]
+    end,
+    Expires = wrq:get_qs_value("Expires", RD),
+    case Expires of
+        undefined ->
+            case proplists:is_defined("x-amz-date", Headers) of
+                true ->
+                    Date = "\n";
+                false ->
+                    Date = [wrq:get_req_header("date", RD), "\n"]
+            end;
+        _ ->
+            Date = Expires ++ "\n"
+    end,
+    case wrq:get_req_header("content-md5", RD) of
+        undefined ->
+            CMD5 = [];
+        CMD5 ->
+            ok
+    end,
+    case wrq:get_req_header("content-type", RD) of
+        undefined ->
+            ContentType = [];
+        ContentType ->
+            ok
+    end,
+    list_to_binary([atom_to_list(wrq:method(RD)), "\n",
+                    CMD5,
+                    "\n",
+                    ContentType,
+                    "\n",
+                    Date,
+                    AmazonHeaders,
+                    Resource]).
+
+canonicalize_qs(QS) ->
+    canonicalize_qs(QS, []).
+
+canonicalize_qs([], []) ->
+    [];
+canonicalize_qs([], Acc) ->
+    lists:flatten(["?", Acc]);
+canonicalize_qs([{K, []}|T], Acc) ->
+    case lists:member(K, ?SUBRESOURCES) of
+        true ->
+            canonicalize_qs(T, [K|Acc]);
+        false ->
+            canonicalize_qs(T)
+    end;
+canonicalize_qs([{K, V}|T], Acc) ->
+    case lists:member(K, ?SUBRESOURCES) of
+        true ->
+            canonicalize_qs(T, [[K, "=", V]|Acc]);
+        false ->
+            canonicalize_qs(T)
+    end.
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+tenant_id_test() ->
+    Token = "{\"access\":{\"token\":{\"expires\":\"2012-02-05T00:00:00\","
+            "\"id\":\"887665443383838\", \"tenant\":{\"id\":\"1\", \"name\""
+            ":\"customer-x\"}}, \"user\":{\"name\":\"joeuser\", \"tenantName\""
+            ":\"customer-x\", \"id\":\"1\", \"roles\":[{\"serviceId\":\"1\","
+            "\"id\":\"3\", \"name\":\"Member\"}], \"tenantId\":\"1\"}}}",
+    InvalidToken = "{\"access\":{\"token\":{\"expires\":\"2012-02-05T00:00:00\","
+        "\"id\":\"887665443383838\", \"tenant\":{\"id\":\"1\", \"name\""
+        ":\"customer-x\"}}, \"user\":{\"name\":\"joeuser\", \"tenantName\""
+        ":\"customer-x\", \"id\":\"1\", \"roles\":[{\"serviceId\":\"1\","
+        "\"id\":\"3\", \"name\":\"Member\"}]}}}",
+    ?assertEqual({ok, <<"1">>},
+                 riak_cs_json:get(riak_cs_json:from_json(Token),
+                                  [<<"access">>, <<"user">>, <<"tenantId">>])),
+    ?assertEqual({error, not_found},
+                 riak_cs_json:get(riak_cs_json:from_json(InvalidToken),
+                                  [<<"access">>, <<"user">>, <<"tenantId">>])).
+
+-endif.

--- a/src/riak_cs_list_objects_fsm.erl
+++ b/src/riak_cs_list_objects_fsm.erl
@@ -42,10 +42,6 @@
          get_object_list/1,
          get_internal_state/1]).
 
-%% Observability
--export([get_key_list_multiplier/0,
-         set_key_list_multiplier/1]).
-
 %% gen_fsm callbacks
 -export([init/1,
          prepare/2,
@@ -157,20 +153,6 @@
 -type tagged_item_list() :: list(tagged_item()).
 
 %%%===================================================================
-%%% Observability
-%%%===================================================================
-
--spec get_key_list_multiplier() -> float().
-get_key_list_multiplier() ->
-    riak_cs_utils:get_env(riak_cs, key_list_multiplier,
-                          ?KEY_LIST_MULTIPLIER).
-
--spec set_key_list_multiplier(float()) -> 'ok'.
-set_key_list_multiplier(Multiplier) ->
-    application:set_env(riak_cs, key_list_multiplier,
-                        Multiplier).
-
-%%%===================================================================
 %%% API
 %%%===================================================================
 
@@ -206,7 +188,7 @@ init([RiakcPid, CallerPid, Request, CacheKey, UseCache]) ->
     %% be two `start_link' arities, and one will use a default
     %% val from app.config and the other will explicitly
     %% take a val
-    KeyMultiplier = get_key_list_multiplier(),
+    KeyMultiplier = riak_cs_config:key_list_multiplier(),
 
     State = #state{riakc_pid=RiakcPid,
                    caller_pid=CallerPid,

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -178,7 +178,7 @@ make_special_error(Code, Message, RequestId, HostId) ->
                {'HostId', [HostId]}
               ]
              },
-    riak_cs_s3_response:export_xml([XmlDoc]).
+    riak_cs_xml:export_xml([XmlDoc]).
 
 list_multipart_uploads(Bucket, Caller, Opts) ->
     list_multipart_uploads(Bucket, Caller, Opts, nopid).
@@ -301,7 +301,7 @@ write_new_manifest(M, Opts, RiakcPidUnW) ->
                           AnAcl ->
                               AnAcl
                       end,
-                ClusterId = riak_cs_utils:get_cluster_id(?PID(RiakcPid)),
+                ClusterId = riak_cs_config:cluster_id(?PID(RiakcPid)),
                 M2 = M?MANIFEST{acl = Acl,
                                 cluster_id = ClusterId,
                                 write_start_time=os:timestamp()},
@@ -727,7 +727,7 @@ move_dead_parts_to_gc(Bucket, Key, PartsToDelete, RiakcPid) ->
     ok = riak_cs_gc:move_manifests_to_gc_bucket(PartDelMs, RiakcPid, false).
 
 enforce_part_size(PartsToKeep) ->
-    case riak_cs_utils:get_env(riak_cs, enforce_multipart_part_size, true) of
+    case riak_cs_config:enforce_multipart_part_size() of
         true ->
             eval_part_sizes([P?PART_MANIFEST.content_length || P <- PartsToKeep]);
         false ->

--- a/src/riak_cs_oos_rewrite.erl
+++ b/src/riak_cs_oos_rewrite.erl
@@ -1,0 +1,159 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_oos_rewrite).
+
+-export([rewrite/5, original_resource/1]).
+
+-include("riak_cs.hrl").
+
+-define(RCS_REWRITE_HEADER, "x-rcs-rewrite-path").
+-define(OOS_API_VSN_HEADER, "x-oos-api-version").
+-define(OOS_ACCOUNT_HEADER, "x-oos-account").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+-endif.
+
+%% @doc Function to rewrite headers prior to processing by webmachine.
+-spec rewrite(atom(), atom(), {integer(), integer()}, gb_tree(), string()) ->
+                     {gb_tree(), string()}.
+rewrite(Method, _Scheme, _Vsn, Headers, RawPath) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"rewrite">>),
+    {Path, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
+    {ApiVsn, Account, RestPath} = parse_path(Path),
+    RewrittenHeaders = rewrite_headers(Headers, RawPath, ApiVsn, Account),
+    {RewrittenHeaders, rewrite_path(ApiVsn, Method, RestPath, QueryString)}.
+
+-spec original_resource(term()) -> undefined | {string(), [{term(),term()}]}.
+original_resource(RD) ->
+    case wrq:get_req_header(?RCS_REWRITE_HEADER, RD) of
+        undefined -> undefined;
+        RawPath ->
+            {Path, QS, _} = mochiweb_util:urlsplit_path(RawPath),
+            {Path, mochiweb_util:parse_qs(QS)}
+    end.
+
+%% @doc Parse the path string into its component parts: the API version,
+%% the account identifier, and the remainder of the path information
+%% pertaining to the requested object storage operation.
+-spec parse_path(string()) -> {string(), string(), string()}.
+parse_path(Path) ->
+    [ApiVsn, Account | RestPath] = string:tokens(Path, "/"),
+    {ApiVsn, Account, "/" ++ string:join(RestPath, "/")}.
+
+%% @doc Add headers for the raw path, the API version, and the account.
+-spec rewrite_headers(gb_tree(), string(), string(), string()) -> gb_tree().
+rewrite_headers(Headers, RawPath, ApiVsn, Account) ->
+    UpdHdrs0 = mochiweb_headers:default(?RCS_REWRITE_HEADER, RawPath, Headers),
+    UpdHdrs1 = mochiweb_headers:enter(?OOS_API_VSN_HEADER, ApiVsn, UpdHdrs0),
+    mochiweb_headers:enter(?OOS_ACCOUNT_HEADER, Account, UpdHdrs1).
+
+%% @doc Internal function to handle rewriting the URL. Only `v1' of
+%% the API is supported since right now it is the only version that
+%% exists, but crash if another version is specfified.
+-spec rewrite_path(string(), atom(), string(), string()) -> string().
+rewrite_path("v1", Method, Path, QS) ->
+    rewrite_v1_path(Method, Path, QS).
+
+%% @doc Internal function to handle rewriting the URL
+-spec rewrite_v1_path(atom(),string(), string()) -> string().
+rewrite_v1_path(_Method, "/", _QS) ->
+    "/buckets";
+rewrite_v1_path(Method, Path, QS) ->
+    {Bucket, UpdPath} = separate_bucket_from_path(string:tokens(Path, [$/])),
+    rewrite_v1_path(Method, UpdPath, QS, Bucket).
+
+rewrite_v1_path(_Method, Path, _QS, "riak-cs") ->
+    "/riak-cs" ++ Path;
+rewrite_v1_path(_Method, Path, _QS, "usage") ->
+    "/usage" ++ Path;
+rewrite_v1_path(Method, "/", [], Bucket) when Method =/= 'GET' ->
+    lists:flatten(["/buckets/", Bucket]);
+rewrite_v1_path(_Method, "/", QS, Bucket) ->
+    lists:flatten(["/buckets/", Bucket, format_bucket_qs(QS)]);
+rewrite_v1_path(_Method, Path, QS, Bucket) ->
+    lists:flatten(["/buckets/",
+                   Bucket,
+                   "/objects/",
+                   mochiweb_util:quote_plus(string:strip(Path, left, $/)),
+                   QS
+                  ]).
+
+%% @doc Separate the bucket name from the rest of the raw path in the
+%% case where the bucket name is included in the path.
+-spec separate_bucket_from_path([string()]) -> {string(), term()}.
+separate_bucket_from_path([Bucket | []]) ->
+    {Bucket, "/"};
+separate_bucket_from_path([Bucket | RestPath]) ->
+    {Bucket, lists:flatten([["/", PathElement] || PathElement <- RestPath])}.
+
+%% @doc Format a bucket operation query string to conform the the
+%% rewrite rules.
+-spec format_bucket_qs(string()) -> string().
+format_bucket_qs([]) ->
+    "/objects";
+format_bucket_qs("delete") ->
+    "/objects";
+format_bucket_qs(QS) ->
+    ["/objects?", QS].
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+rewrite_path_test() ->
+    %% List Buckets URL
+    equal_paths("/buckets", rewrite_with(headers([]), "/v1/CF_xer7_34")),
+    %% Bucket Operations
+    equal_paths("/buckets/testbucket/objects", rewrite_with('GET', headers([]), "/v1/CF_xer7_34/testbucket")),
+    equal_paths("/buckets/testbucket", rewrite_with('HEAD', headers([]), "/v1/CF_xer7_34/testbucket")),
+    equal_paths("/buckets/testbucket", rewrite_with('PUT', headers([]), "/v1/CF_xer7_34/testbucket")),
+    equal_paths("/buckets/testbucket", rewrite_with('DELETE', headers([]), "/v1/CF_xer7_34/testbucket")),
+    %% Object Operations
+    equal_paths("/buckets/testbucket/objects/testobject", rewrite_with(headers([]), "/v1/CF_xer7_34/testbucket/testobject")).
+
+rewrite_header_test() ->
+    Path = "/v1/CF_xer7_34/testbucket?a=b",
+    {Headers, _} = rewrite_with(headers([]), Path),
+    ?assertEqual(Path, mochiweb_headers:get_value(?RCS_REWRITE_HEADER, Headers)),
+    ?assertEqual("v1", mochiweb_headers:get_value(?OOS_API_VSN_HEADER, Headers)),
+    ?assertEqual("CF_xer7_34", mochiweb_headers:get_value(?OOS_ACCOUNT_HEADER, Headers)).
+
+%% Helper function for eunit tests
+headers(HeadersList) ->
+    mochiweb_headers:make(HeadersList).
+
+equal_paths(EPath, {_RHeaders, RPath}) ->
+    ?assertEqual(EPath, RPath).
+
+
+rewrite_with(Headers, Path) ->
+    rewrite_with('GET', Headers, Path).
+
+rewrite_with(Method, Headers, Path) ->
+    Scheme = https,
+    Version = {1, 1},
+    rewrite(Method, Scheme, Version, Headers, Path).
+
+-endif.

--- a/src/riak_cs_oos_utils.erl
+++ b/src/riak_cs_oos_utils.erl
@@ -1,0 +1,121 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc A collection helper functions for interacting with OpenStack
+%% web services.
+
+-module(riak_cs_oos_utils).
+
+-include("oos_api.hrl").
+
+-export([get_os_user_data/1,
+         extract_user_data/1,
+         user_ec2_creds/2]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+get_os_user_data(undefined) ->
+    undefined;
+get_os_user_data(UserId) ->
+    %% GET /v2.0/users/<user-id>
+    RequestURI = riak_cs_config:os_users_url() ++ UserId,
+    RequestHeaders = [{"X-Auth-Token", riak_cs_config:os_admin_token()}],
+    Response = httpc:request(get, {RequestURI, RequestHeaders}, [], []),
+    handle_user_data_response(Response).
+
+-type undef_or_string() :: undefined | string().
+-spec extract_user_data(undefined | term()) -> {undef_or_string(),
+                                                undef_or_string(),
+                                                undef_or_string()}.
+extract_user_data(undefined) ->
+    {undefined, undefined, []};
+extract_user_data(UserData) ->
+    %% GET /v2.0/users/<user-id>/credentials/OS-EC2
+    %% If the user does not have ec2 credentials for the tenant, then set `key_secret'
+    %% to `undefined'.
+    Path = [<<"user">>, {<<"name">>, <<"email">>, <<"tenantId">>}],
+    user_binaries_to_lists(
+      riak_cs_json:value_or_default(
+        riak_cs_json:get(UserData, Path),
+        {undefined, undefined, []})).
+
+user_ec2_creds(undefined, _) ->
+    {undefined, []};
+user_ec2_creds(UserId, TenantId) ->
+    %% GET /v2.0/users/<user-id>
+    RequestURI = riak_cs_config:os_users_url() ++
+        UserId ++
+        "/credentials/OS-EC2",
+    RequestHeaders = [{"X-Auth-Token", riak_cs_config:os_admin_token()}],
+    Response = httpc:request(get, {RequestURI, RequestHeaders}, [], []),
+    handle_ec2_creds_response(Response, TenantId).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+user_binaries_to_lists({X, Y, Z}) ->
+    {binary_to_list(X), binary_to_list(Y), binary_to_list(Z)}.
+
+handle_user_data_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, UserInfo}})
+  when _Status >= 200, _Status =< 299 ->
+    riak_cs_json:from_json(UserInfo);
+handle_user_data_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, _}}) ->
+    %% @TODO Log error
+    undefined;
+handle_user_data_response({error, Reason}) ->
+    _ = lager:warning("Error occurred requesting user data from keystone. Reason: ~p",
+                  [Reason]),
+    undefined.
+
+handle_ec2_creds_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, CredsInfo}}, TenantId)
+  when _Status >= 200, _Status =< 299 ->
+    CredsResult = riak_cs_json:from_json(CredsInfo),
+    ec2_creds_for_tenant(CredsResult, TenantId);
+handle_ec2_creds_response({ok, {{_HTTPVer, _Status, _StatusLine}, _, _}}, _) ->
+    %% @TODO Log error
+    {undefined, []};
+handle_ec2_creds_response({error, Reason}, _) ->
+    _ = lager:warning("Error occurred requesting user EC2 credentials from keystone. Reason: ~p",
+                  [Reason]),
+    {undefined, []}.
+
+ec2_creds_for_tenant({error, decode_failed}, _) ->
+    {undefined, []};
+ec2_creds_for_tenant(Creds, TenantId) ->
+    TenantQuery = {find, {key, <<"tenant_id">>, list_to_binary(TenantId)}},
+    Path = [<<"credentials">>, TenantQuery, {<<"access">>, <<"secret">>}],
+    case Res=riak_cs_json:value_or_default(
+               riak_cs_json:get(Creds, Path), {undefined, []}) of
+        {undefined, []} ->
+            Res;
+        {KeyBin, SecretBin} ->
+            {binary_to_list(KeyBin), binary_to_list(SecretBin)}
+    end.
+
+%% ===================================================================
+%% Eunit tests
+%% ===================================================================
+
+-ifdef(TEST).
+
+-endif.

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -168,7 +168,7 @@ init({{Bucket, Key, ContentLength, ContentType,
                          riakc_pid=RiakPid,
                          make_new_manifest_p=MakeNewManifestP,
                          timeout=Timeout,
-                         md5_chunk_size=riak_cs_utils:md5_chunk_size()},
+                         md5_chunk_size=riak_cs_config:md5_chunk_size()},
      0}.
 
 %%--------------------------------------------------------------------
@@ -386,7 +386,7 @@ prepare(State=#state{bucket=Bucket,
     MaxBufferSize = (riak_cs_lfs_utils:put_fsm_buffer_size_factor() * BlockSize),
 
     %% for now, always populate cluster_id
-    ClusterID = riak_cs_utils:get_cluster_id(RiakPid),
+    ClusterID = riak_cs_config:cluster_id(RiakPid),
     Manifest =
         riak_cs_lfs_utils:new_manifest(Bucket,
                                          Key,

--- a/src/riak_cs_s3_passthru_auth.erl
+++ b/src/riak_cs_s3_passthru_auth.erl
@@ -18,7 +18,7 @@
 %%
 %% ---------------------------------------------------------------------
 
--module(riak_cs_passthru_auth).
+-module(riak_cs_s3_passthru_auth).
 
 -behavior(riak_cs_auth).
 
@@ -32,7 +32,7 @@ identify(RD,_Ctx) ->
         undefined -> {[], undefined};
         Key -> {Key, undefined}
     end.
-            
+
 
 -spec authenticate(rcs_user(), undefined, term(), term()) -> ok.
 authenticate(_User, _AuthData, _RD, _Ctx) ->

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -744,7 +744,7 @@ condition_({<<"aws:CurrentTime">>, Bin}) when is_binary(Bin) ->
 condition_({<<"aws:EpochTime">>, Int}) when is_integer(Int) andalso Int >= 0 ->
     {'aws:EpochTime', Int};
 condition_({<<"aws:SecureTransport">>, MaybeBool}) ->
-    case parse_bool(MaybeBool) of 
+    case parse_bool(MaybeBool) of
         {error, _} ->
             throw({error, malformed_policy_condition});
         {ok, Bool} ->
@@ -752,7 +752,7 @@ condition_({<<"aws:SecureTransport">>, MaybeBool}) ->
     end;
 condition_({<<"aws:SourceIp">>, Bin}) when is_binary(Bin)->
     case parse_ip(Bin) of
-        {error, _} -> 
+        {error, _} ->
             throw({error, malformed_policy_condition});
         IP ->
             {'aws:SourceIp', IP}
@@ -800,7 +800,7 @@ parse_bool(_) -> {error, notbool}.
 % <<"10.1.2.3/24">> -> {{10,1,2,3}, {255,255,255,0}}
 % "10.1.2.3/24 -> {{10,1,2,3}, {255,255,255,0}}
 %% NOTE: Returns false on a bad ip
--spec parse_ip(binary() | string()) -> {inet:ip_address(), inet:ip_address()} | false.
+-spec parse_ip(binary() | string()) -> {inet:ip_address(), inet:ip_address()} | {error, term()}.
 parse_ip(Bin) when is_binary(Bin) ->
     Str = binary_to_list(Bin),
     parse_ip(Str);
@@ -810,10 +810,10 @@ parse_ip(Str) when is_list(Str) ->
         {ok, IP} ->
             {IP, Netmask};
         Error ->
-            Error 
+            Error
     end.
 
--spec parse_tokenized_ip([string()]) -> {inet:ip_address(), inet:ip_address()}.
+-spec parse_tokenized_ip([string()]) -> {string(), inet:ip_address()}.
 parse_tokenized_ip([IP]) ->
     {IP, {255, 255, 255, 255}};
 parse_tokenized_ip([IP, PrefixSize]) ->

--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -36,7 +36,8 @@
                   admin_ip,
                   admin_port,
                   ssl,
-                  admin_ssl]).
+                  admin_ssl,
+                  {rewrite_module, riak_cs_s3_rewrite}]).
 
 -type startlink_err() :: {'already_started', pid()} | 'shutdown' | term().
 -type startlink_ret() :: {'ok', pid()} | 'ignore' | {'error', startlink_err()}.
@@ -157,7 +158,7 @@ object_web_config(Options) ->
      {ip, proplists:get_value(cs_ip, Options)},
      {port, proplists:get_value(cs_port, Options)},
      {nodelay, true},
-     {rewrite_module, riak_cs_s3_rewrite},
+     {rewrite_module, proplists:get_value(rewrite_module, Options)},
      {error_handler, riak_cs_wm_error_handler},
      {resource_module_option, submodule}] ++
         maybe_add_ssl_opts(proplists:get_value(ssl, Options)).

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -23,8 +23,7 @@
 -module(riak_cs_utils).
 
 %% Public API
--export([anonymous_user_creation/0,
-         etag_from_binary/1,
+-export([etag_from_binary/1,
          etag_from_binary_no_quotes/1,
          check_bucket_exists/2,
          chunked_md5/3,
@@ -32,19 +31,16 @@
          close_riak_connection/2,
          create_bucket/5,
          create_user/2,
-         cs_version/0,
+         create_user/4,
          delete_bucket/4,
          delete_object/3,
          encode_term/1,
          from_bucket_name/1,
-         get_admin_creds/0,
          get_buckets/1,
-         get_env/3,
          get_keys_and_manifests/3,
          has_tombstone/1,
          is_admin/1,
          map_keys_and_manifests/3,
-         md5_chunk_size/0,
          reduce_keys_and_manifests/2,
          get_object/3,
          get_manifests/3,
@@ -70,7 +66,6 @@
          set_bucket_acl/5,
          set_object_acl/5,
          set_bucket_policy/5,
-         set_md5_chunk_size/1,
          delete_bucket_policy/4,
          get_bucket_acl_policy/3,
          timestamp/1,
@@ -78,8 +73,6 @@
          to_bucket_name/2,
          update_key_secret/1,
          update_obj_value/2,
-         get_cluster_id/1,
-         proxy_get_active/0,
          pid_to_binary/1]).
 
 -include("riak_cs.hrl").
@@ -102,14 +95,10 @@
 %% Public API
 %% ===================================================================
 
-%% @doc Return the value of the `anonymous_user_creation' application
-%% environment variable.
--spec anonymous_user_creation() -> boolean().
-anonymous_user_creation() ->
-    EnvResponse = application:get_env(riak_cs, anonymous_user_creation),
-    handle_env_response(EnvResponse, false).
 
-%% @doc Convert the passed binary into a string where the numbers are represented in hexadecimal (lowercase and 0 prefilled).
+
+%% @doc Convert the passed binary into a string where the numbers are
+%% represented in hexadecimal (lowercase and 0 prefilled).
 -spec binary_to_hexlist(binary()) -> string().
 binary_to_hexlist(Bin) ->
     XBin =
@@ -136,7 +125,8 @@ etag_from_binary(Binary) ->
 etag_from_binary_no_quotes(Binary) ->
     binary_to_hexlist(Binary).
 
-%% @doc Convert the passed binary into a string where the numbers are represented in hexadecimal (lowercase and 0 prefilled).
+%% @doc Convert the passed binary into a string where the numbers are
+%% represented in hexadecimal (lowercase and 0 prefilled).
 -spec hexlist_to_binary(string()) -> binary().
 hexlist_to_binary(String) ->
     Bytes = length(String) div 2,
@@ -250,10 +240,16 @@ dash_char(Char) ->
 %% @doc Create a new Riak CS user
 -spec create_user(string(), string()) -> {ok, rcs_user()} | {error, term()}.
 create_user(Name, Email) ->
+    {KeyId, Secret} = generate_access_creds(Email),
+    create_user(Name, Email, KeyId, Secret).
+
+%% @doc Create a new Riak CS user
+-spec create_user(string(), string(), string(), string()) -> {ok, rcs_user()} | {error, term()}.
+create_user(Name, Email, KeyId, Secret) ->
     case validate_email(Email) of
         ok ->
-            User = user_record(Name, Email),
-            create_credentialed_user(get_admin_creds(), User);
+            User = user_record(Name, Email, KeyId, Secret),
+            create_credentialed_user(riak_cs_config:admin_creds(), User);
         {error, _Reason}=Error ->
             Error
     end.
@@ -268,27 +264,21 @@ create_credentialed_user({ok, AdminCreds}, User) ->
     {StIp, StPort, StSSL} = stanchion_data(),
     UserDoc = user_json(User),
     %% Make a call to the user request serialization service.
-    Result = velvet:create_user(StIp, StPort, "application/json", UserDoc, 
+    Result = velvet:create_user(StIp, StPort, "application/json", UserDoc,
         [{ssl, StSSL}, {auth_creds, AdminCreds}]),
     handle_create_user(Result, User).
 
 handle_create_user(ok, User) ->
     {ok, User};
 handle_create_user({error, {error_status, _, _, ErrorDoc}}, _User) ->
-    riak_cs_s3_response:error_response(ErrorDoc);
+    case riak_cs_config:api() of
+        s3 ->
+            riak_cs_s3_response:error_response(ErrorDoc);
+        oos ->
+            {error, ErrorDoc}
+    end;
 handle_create_user({error, _}=Error, _User) ->
     Error.
-
-%% @doc Get the active version of Riak CS to use in checks to
-%% determine if new features should be enabled.
--spec cs_version() -> pos_integer() | undefined.
-cs_version() ->
-    cs_version(application:get_env(riak_cs, cs_version)).
-
-cs_version({ok, Version}) ->
-    Version;
-cs_version(undefined) ->
-    undefined.
 
 %% @doc Delete a bucket
 -spec delete_bucket(rcs_user(), riakc_obj:riakc_obj(), binary(), pid()) ->
@@ -338,16 +328,12 @@ delete_object(Bucket, Key, RiakcPid) ->
 
 -spec encode_term(term()) -> binary().
 encode_term(Term) ->
-    case use_t2b_compression() of
+    case riak_cs_config:use_t2b_compression() of
         true ->
             term_to_binary(Term, [compressed]);
         false ->
             term_to_binary(Term)
     end.
-
--spec use_t2b_compression() -> boolean().
-use_t2b_compression() ->
-    get_env(riak_cs, compress_terms, ?COMPRESS_TERMS).
 
 %% Get the root bucket name for either a Riak CS object
 %% bucket or the data block bucket name.
@@ -395,16 +381,6 @@ stanchion_data() ->
             SSL = ?DEFAULT_STANCHION_SSL
     end,
     {IP, Port, SSL}.
-
-%% @doc Get an application environment variable or return a default term.
--spec get_env(atom(), atom(), term()) -> term().
-get_env(App, Key, Default) ->
-    case application:get_env(App, Key) of
-        {ok, Value} ->
-            Value;
-        _ ->
-            Default
-    end.
 
 %% @doc Return a list of keys for a bucket along
 %% with their associated objects.
@@ -484,15 +460,6 @@ map_keys_and_manifests(Object, _, _) ->
 %% work is done.
 reduce_keys_and_manifests(Acc, _) ->
     Acc.
-
-%% @doc Return the credentials of the admin user
--spec get_admin_creds() -> {ok, {string(), string()}} | {error, term()}.
-get_admin_creds() ->
-    KeyEnvResult = application:get_env(riak_cs, admin_key),
-    SecretEnvResult = application:get_env(riak_cs, admin_secret),
-    admin_creds_response(
-      handle_env_response(KeyEnvResult, undefined),
-      handle_env_response(SecretEnvResult, undefined)).
 
 %% @doc Get an object from Riak
 -spec get_object(binary(), binary(), pid()) ->
@@ -634,7 +601,7 @@ has_tombstone({MD, _V}) ->
 %% @doc Determine if the specified user account is a system admin.
 -spec is_admin(rcs_user()) -> boolean().
 is_admin(User) ->
-    is_admin(User, get_admin_creds()).
+    is_admin(User, riak_cs_config:admin_creds()).
 
 %% @doc Pretty-print a JSON string ... from riak_core's json_pp.erl
 json_pp_print(Str) when is_list(Str) ->
@@ -878,27 +845,6 @@ update_obj_value(Obj, Value) when is_binary(Value) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
-
--spec admin_creds_response(term(), term()) -> {ok, {term(), term()}} |
-                                              {error, atom()}.
-admin_creds_response(undefined, _) ->
-    _ = lager:warning("The admin user's key id"
-                      "has not been specified."),
-    {error, admin_key_undefined};
-admin_creds_response([], _) ->
-    _ = lager:warning("The admin user's key id"
-                      "has not been specified."),
-    {error, admin_key_undefined};
-admin_creds_response(_, undefined) ->
-    _ = lager:warning("The admin user's secret"
-                      "has not been specified."),
-    {error, admin_secret_undefined};
-admin_creds_response(_, []) ->
-    _ = lager:warning("The admin user's secret"
-                      "has not been specified."),
-    {error, admin_secret_undefined};
-admin_creds_response(Key, Secret) ->
-    {ok, {Key, Secret}}.
 
 %% @doc Generate a JSON document to use for a bucket
 %% ACL request.
@@ -1200,7 +1146,9 @@ generate_access_creds(UserId) ->
     {KeyId, Secret}.
 
 %% @doc Generate the canonical id for a user.
--spec generate_canonical_id(string(), string()) -> string().
+-spec generate_canonical_id(string(), undefined | string()) -> string().
+generate_canonical_id(_KeyID, undefined) ->
+    [];
 generate_canonical_id(KeyID, Secret) ->
     Bytes = 16,
     Id1 = crypto:md5(KeyID),
@@ -1230,12 +1178,6 @@ generate_secret(UserName, Key) ->
     base64url:encode_to_string(
       iolist_to_binary(<< SecretPart1:Bytes/binary,
                           SecretPart2:Bytes/binary >>)).
-
--spec handle_env_response(undefined | {ok, term()}, term()) -> term().
-handle_env_response(undefined, Default) ->
-    Default;
-handle_env_response({ok, Value}, _) ->
-    Value.
 
 %% @doc Determine if the specified user account is a system admin.
 -spec is_admin(rcs_user(), {ok, {string(), string()}} |
@@ -1291,7 +1233,7 @@ resolve_buckets([HeadUserRec | RestUserRecs], Buckets, _KeepDeleted) ->
                                   {error, term()}.
 serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatName, RiakPid) ->
     StartTime = os:timestamp(),
-    case get_admin_creds() of
+    case riak_cs_config:admin_creds() of
         {ok, AdminCreds} ->
             BucketFun = bucket_fun(BucketOp,
                                    Bucket,
@@ -1410,15 +1352,15 @@ update_user_record(User=#moss_user_v1{}) ->
 
 %% @doc Return a user record for the specified user name and
 %% email address.
--spec user_record(string(), string()) -> rcs_user().
-user_record(Name, Email) ->
-    user_record(Name, Email, []).
+-spec user_record(string(), string(), string(), string()) -> rcs_user().
+user_record(Name, Email, KeyId, Secret) ->
+    user_record(Name, Email, KeyId, Secret, []).
 
 %% @doc Return a user record for the specified user name and
 %% email address.
--spec user_record(string(), string(), [cs_bucket()]) -> rcs_user().
-user_record(Name, Email, Buckets) ->
-    {KeyId, Secret} = generate_access_creds(Email),
+-spec user_record(string(), string(), string(), string(), [cs_bucket()]) ->
+                         rcs_user().
+user_record(Name, Email, KeyId, Secret, Buckets) ->
     CanonicalId = generate_canonical_id(KeyId, Secret),
     DisplayName = display_name(Email),
     ?RCS_USER{name=Name,
@@ -1429,57 +1371,6 @@ user_record(Name, Email, Buckets) ->
                canonical_id=CanonicalId,
                buckets=Buckets}.
 
-%% doc Return the current cluster ID. Used for repl
-%% After obtaining the clusterid the first time,
-%% store the value in app:set_env
--spec get_cluster_id(pid()) -> binary().
-get_cluster_id(Pid) ->
-    case application:get_env(riak_cs, cluster_id) of
-        {ok, ClusterID} ->
-            ClusterID;
-        undefined ->
-            Timeout = case application:get_env(riak_cs,cluster_id_timeout) of
-                          {ok, Value} -> Value;
-                          undefined   -> ?DEFAULT_CLUSTER_ID_TIMEOUT
-                      end,
-            maybe_get_cluster_id(proxy_get_active(), Pid, Timeout)
-    end.
-
-%% @doc If `proxy_get' is enabled then attempt to determine the cluster id
--spec maybe_get_cluster_id(boolean(), pid(), integer()) -> undefined | binary().
-maybe_get_cluster_id(true, Pid, Timeout) ->
-    try
-        case riak_repl_pb_api:get_clusterid(Pid, Timeout) of
-            {ok, ClusterID} ->
-                application:set_env(riak_cs, cluster_id, ClusterID),
-                ClusterID;
-            _ ->
-                _ = lager:debug("Unable to obtain cluster ID"),
-                undefined
-        end
-    catch _:_ ->
-            %% Disable `proxy_get' so we do not repeatedly have to
-            %% handle this same exception. This would happen if an OSS
-            %% install has `proxy_get' enabled.
-            application:set_env(riak_cs, proxy_get, disabled),
-            undefined
-    end;
-maybe_get_cluster_id(false, _, _) ->
-    undefined.
-
-%% doc Check app.config to see if repl proxy_get is enabled
-%% Defaults to false.
-proxy_get_active() ->
-    case application:get_env(riak_cs, proxy_get) of
-        {ok, enabled} ->
-            true;
-        {ok, disabled} ->
-            false;
-        {ok, _} ->
-            _ = lager:warning("proxy_get value in app.config is invalid"),
-            false;
-        undefined -> false
-    end.
 
 %% @doc Convert a pid to a binary
 -spec pid_to_binary(pid()) -> binary().
@@ -1500,15 +1391,3 @@ chunked_md5(Data, Context, ChunkSize) ->
             UpdContext = crypto:md5_update(Context, Chunk),
             chunked_md5(RestData, UpdContext, ChunkSize)
     end.
-
-%% @doc Return the configured md5 chunk size
--spec md5_chunk_size() -> non_neg_integer().
-md5_chunk_size() ->
-    get_env(riak_cs, md5_chunk_size, ?DEFAULT_MD5_CHUNK_SIZE).
-
-%% @doc Helper fun to set the md5 chunk size
--spec set_md5_chunk_size(non_neg_integer()) -> ok | {error, invalid_value}.
-set_md5_chunk_size(Size) when is_integer(Size) andalso Size > 0 ->
-    application:set_env(riak_cs, md5_chunk_size, Size);
-set_md5_chunk_size(_) ->
-    {error, invalid_value}.

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -38,19 +38,19 @@ admin_api_dispatch_table() ->
 -spec object_api_dispatch_table() -> [dispatch_rule()].
 object_api_dispatch_table() ->
     base_resources() ++
-        one_three_resources(riak_cs_utils:cs_version()).
+        one_three_resources(riak_cs_config:cs_version()).
 
 -spec props(atom()) -> [term()].
 props(Mod) ->
-    [{auth_bypass, get_auth_bypass()},
-     {auth_module, get_auth_module()},
-     {policy_module, get_policy_module()},
+    [{auth_bypass, riak_cs_config:auth_bypass()},
+     {auth_module, riak_cs_config:auth_module()},
+     {policy_module, riak_cs_config:policy_module()},
      {submodule, Mod}].
 
 -spec stats_props() -> [term()].
 stats_props() ->
-    [{admin_auth_enabled, get_admin_auth_enabled()},
-     {auth_bypass, get_auth_bypass()}].
+    [{admin_auth_enabled, riak_cs_config:admin_auth_enabled()},
+     {auth_bypass, riak_cs_config:auth_bypass()}].
 
 -spec admin_resources([term()]) -> [dispatch_rule()].
 admin_resources(Props) ->
@@ -91,39 +91,3 @@ one_three_resources(_Version) ->
      {["buckets", bucket, "objects", object, "uploads", uploadId], riak_cs_wm_common, props(riak_cs_wm_object_upload_part)},
      {["buckets", bucket, "objects", object, "uploads"], riak_cs_wm_common, props(riak_cs_wm_object_upload)}
     ].
-
--spec get_auth_bypass() -> boolean().
-get_auth_bypass() ->
-    get_auth_bypass(application:get_env(riak_cs, auth_bypass)).
-
--spec get_admin_auth_enabled() -> boolean().
-get_admin_auth_enabled() ->
-    case application:get_env(riak_cs, admin_auth_enabled) of
-        {ok, false} ->
-            false;
-        _ ->
-            true
-    end.
-
--spec get_auth_module() -> atom().
-get_auth_module() ->
-    get_auth_module(application:get_env(riak_cs, auth_module)).
-
--spec get_policy_module() -> atom().
-get_policy_module() ->
-    case application:get_env(riak_cs, policy_module) of
-        undefined -> ?DEFAULT_POLICY_MODULE;
-        {ok, PolicyModule} -> PolicyModule
-    end.
-
--spec get_auth_bypass(undefined | {ok, boolean()}) -> boolean().
-get_auth_bypass(undefined) ->
-    false;
-get_auth_bypass({ok, AuthBypass}) ->
-    AuthBypass.
-
--spec get_auth_module(undefined | {ok, atom()}) -> atom().
-get_auth_module(undefined) ->
-    ?DEFAULT_AUTH_MODULE;
-get_auth_module({ok, AuthModule}) ->
-    AuthModule.

--- a/src/riak_cs_wm_bucket.erl
+++ b/src/riak_cs_wm_bucket.erl
@@ -103,6 +103,7 @@ handle_read_request(RD, Ctx=#context{user=User,
 accept_body(RD, Ctx=#context{user=User,
                              user_object=UserObj,
                              bucket=Bucket,
+                             response_module=ResponseMod,
                              riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_create">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
@@ -124,10 +125,10 @@ accept_body(RD, Ctx=#context{user=User,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
             {{halt, 200}, RD, Ctx};
         {error, Reason} ->
-            Code = riak_cs_s3_response:status_code(Reason),
+            Code = ResponseMod:status_code(Reason),
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_create">>,
                                               [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
-            riak_cs_s3_response:api_error(Reason, RD, Ctx)
+            ResponseMod:api_error(Reason, RD, Ctx)
     end.
 
 %% @doc Callback for deleting a bucket.
@@ -135,6 +136,7 @@ accept_body(RD, Ctx=#context{user=User,
                              {boolean() | {'halt', term()}, #wm_reqdata{}, #context{}}.
 delete_resource(RD, Ctx=#context{user=User,
                                  user_object=UserObj,
+                                 response_module=ResponseMod,
                                  bucket=Bucket,
                                  riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_delete">>,
@@ -148,8 +150,8 @@ delete_resource(RD, Ctx=#context{user=User,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
             {true, RD, Ctx};
         {error, Reason} ->
-            Code = riak_cs_s3_response:status_code(Reason),
+            Code = ResponseMod:status_code(Reason),
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_delete">>,
                                                [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
-            riak_cs_s3_response:api_error(Reason, RD, Ctx)
+            ResponseMod:api_error(Reason, RD, Ctx)
     end.

--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -108,7 +108,7 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
                         {'IsTruncated', ["false"]}   % TODO
                       ] ++ Us ++ Cs
                      },
-            Body = riak_cs_s3_response:export_xml([XmlDoc]),
+            Body = riak_cs_xml:export_xml([XmlDoc]),
             {Body, RD, Ctx};
         {error, Reason} ->
             riak_cs_s3_response:api_error(Reason, RD, Ctx)

--- a/src/riak_cs_wm_buckets.erl
+++ b/src/riak_cs_wm_buckets.erl
@@ -21,11 +21,11 @@
 -module(riak_cs_wm_buckets).
 
 -export([allowed_methods/0,
-         content_types_provided/2,
-         to_xml/2,
+         api_request/2,
          anon_ok/0]).
 
 -include("riak_cs.hrl").
+-include("riak_cs_api.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
 %% @doc Get the list of methods this resource supports.
@@ -33,19 +33,14 @@
 allowed_methods() ->
     ['GET'].
 
--spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
-content_types_provided(RD,Ctx) ->
-    {[{"application/xml", to_xml}], RD, Ctx}.
-
-%% @TODO This spec will need to be updated when we change this to
-%% allow streaming bodies.
--spec to_xml(#wm_reqdata{}, #context{}) -> {{'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
-to_xml(RD, Ctx=#context{start_time=StartTime,
-                        user=User}) ->
-    riak_cs_dtrace:dt_service_entry(?MODULE, <<"service_get_buckets">>, [], [riak_cs_wm_utils:extract_name(User)]),
-    Res = riak_cs_s3_response:list_all_my_buckets_response(User, RD, Ctx),
+-spec api_request(#wm_reqdata{}, #context{}) -> ?LBRESP{}.
+api_request(_RD, #context{user=User,
+                          start_time=StartTime}) ->
+    UserName = riak_cs_wm_utils:extract_name(User),
+    riak_cs_dtrace:dt_service_entry(?MODULE, <<"service_get_buckets">>, [], [UserName]),
+    Res = riak_cs_api:list_buckets(User),
     ok = riak_cs_stats:update_with_start(service_get_buckets, StartTime),
-    riak_cs_dtrace:dt_service_return(?MODULE, <<"service_get_buckets">>, [], [riak_cs_wm_utils:extract_name(User)]),
+    riak_cs_dtrace:dt_service_return(?MODULE, <<"service_get_buckets">>, [], [UserName]),
     Res.
 
 -spec anon_ok() -> boolean().

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -44,7 +44,8 @@
          finish_request/2]).
 
 -export([default_allowed_methods/0,
-         default_content_types/2,
+         default_content_types_accepted/2,
+         default_content_types_provided/2,
          default_generate_etag/2,
          default_last_modified/2,
          default_finish_request/2,
@@ -54,9 +55,11 @@
          default_valid_entity_length/2,
          default_validate_content_checksum/2,
          default_delete_resource/2,
-         default_anon_ok/0]).
+         default_anon_ok/0,
+         default_produce_body/2]).
 
 -include("riak_cs.hrl").
+-include("oos_api.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
 %% ===================================================================
@@ -71,15 +74,19 @@ init(Config) ->
     %% Check if authentication is disabled and set that in the context.
     AuthBypass = proplists:get_value(auth_bypass, Config),
     AuthModule = proplists:get_value(auth_module, Config),
+    Api = riak_cs_config:api(),
+    RespModule = riak_cs_config:response_module(Api),
     PolicyModule = proplists:get_value(policy_module, Config),
     Exports = orddict:from_list(Mod:module_info(exports)),
     ExportsFun = exports_fun(Exports),
     Ctx = #context{auth_bypass=AuthBypass,
                    auth_module=AuthModule,
+                   response_module=RespModule,
                    policy_module=PolicyModule,
                    exports_fun=ExportsFun,
                    start_time=os:timestamp(),
-                   submodule=Mod},
+                   submodule=Mod,
+                   api=Api},
     resource_call(Mod, init, [Ctx], ExportsFun).
 
 -spec service_available(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
@@ -113,7 +120,7 @@ malformed_request(RD, Ctx=#context{submodule=Mod,
     riak_cs_dtrace:dt_wm_return_bool_with_default({?MODULE, Mod},
                                                   <<"malformed_request">>,
                                                   Malformed,
-                                                 false),
+                                                  false),
     R.
 
 
@@ -132,9 +139,9 @@ valid_entity_length(RD, Ctx=#context{submodule=Mod, exports_fun=ExportsFun}) ->
 
 -type validate_checksum_response() :: {error, term()} |
                                       {halt, pos_integer()} |
-                                       boolean().
+                                      boolean().
 -spec validate_content_checksum(#wm_reqdata{}, #context{}) ->
-    {validate_checksum_response(), #wm_reqdata{}, #context{}}.
+                                       {validate_checksum_response(), #wm_reqdata{}, #context{}}.
 validate_content_checksum(RD, Ctx=#context{submodule=Mod, exports_fun=ExportsFun}) ->
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"validate_content_checksum">>),
     {Valid, _, _} = R = resource_call(Mod,
@@ -152,36 +159,26 @@ forbidden(RD, Ctx=#context{auth_module=AuthMod,
                            submodule=Mod,
                            riakc_pid=RiakPid,
                            exports_fun=ExportsFun}) ->
-    {UserKey, AuthData} = AuthMod:identify(RD, Ctx),
-    riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"forbidden">>, [], [riak_cs_wm_utils:extract_name(UserKey)]),
-    case riak_cs_utils:get_user(UserKey, RiakPid) of
-        {error, disconnected} ->
-            riak_cs_s3_response:api_error(econnrefused, RD, Ctx);
-        {error, _BinaryConstraint} when is_binary(_BinaryConstraint) ->
-            riak_cs_s3_response:api_error(unsatisfied_constraint, RD, Ctx);
-        {ok, {User, UserObj}} when User?RCS_USER.status =:= enabled ->
-            AuthResult = authenticate(User, UserObj, RD, Ctx, AuthData),
-            handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult);
-        {ok, {User, _UserObj}} when User?RCS_USER.status =/= enabled ->
-            AuthResult = {error, bad_auth},
-            handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult);
-        {error, NE} when NE =:= not_found;
-                NE =:= notfound;
-                NE =:= no_user_key ->
-            AuthResult = {error, NE},
-            handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult);
-        {error, R} ->
-            %% other failures, like Riak fetch timeout, be loud about
-            _ = lager:error("Retrieval of user record for ~p failed. Reason: ~p",
-                            [UserKey, R]),
-            AuthResult = {error, R},
-            handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult)
-    end.
-
--spec handle_auth_result(term(), #context{}, atom(), function(), term()) ->
-                         term().
-handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult) ->
-    AnonOk = resource_call(Mod, anon_ok, [], ExportsFun),
+    {AuthResult, AnonOk} =
+        case AuthMod:identify(RD, Ctx) of
+            {UserKey, AuthData} ->
+                riak_cs_dtrace:dt_wm_entry({?MODULE, Mod},
+                                           <<"forbidden">>,
+                                           [],
+                                           [riak_cs_wm_utils:extract_name(UserKey)]),
+                UserLookupResult = maybe_create_user(
+                                     riak_cs_utils:get_user(UserKey, RiakPid),
+                                     UserKey,
+                                     Ctx#context.api,
+                                     Ctx#context.auth_module,
+                                     AuthData,
+                                     RiakPid),
+                {authenticate(UserLookupResult, RD, Ctx, AuthData),
+                 resource_call(Mod, anon_ok, [], ExportsFun)};
+            failed ->
+                %% Identification failed, deny access
+                {{error, no_such_key}, false}
+        end,
     case post_authentication(AuthResult, RD, Ctx, fun authorize/2, AnonOk) of
         {false, _RD2, Ctx2} = FalseRet ->
             riak_cs_dtrace:dt_wm_return({?MODULE, Mod},
@@ -201,6 +198,31 @@ handle_auth_result(RD, Ctx, Mod, ExportsFun, AuthResult) ->
                                         <<"true">>]),
             Ret
     end.
+
+maybe_create_user({ok, {_, _}}=UserResult, _, _, _, _, _) ->
+    UserResult;
+maybe_create_user({error, NE}, KeyId, oos, _, {UserData, _}, RiakPid)
+  when NE =:= not_found;
+       NE =:= notfound;
+       NE =:= no_user_key ->
+    {Name, Email, UserId} = UserData,
+    {_, Secret} = riak_cs_oos_utils:user_ec2_creds(UserId, KeyId),
+    %% Attempt to create a Riak CS user to represent the OS tenant
+    _ = riak_cs_utils:create_user(Name, Email, KeyId, Secret),
+    riak_cs_utils:get_user(KeyId, RiakPid);
+maybe_create_user({error, NE}, KeyId, s3, riak_cs_keystone_auth, {UserData, _}, RiakPid)
+  when NE =:= not_found;
+       NE =:= notfound;
+       NE =:= no_user_key ->
+    {Name, Email, UserId} = UserData,
+    {_, Secret} = riak_cs_oos_utils:user_ec2_creds(UserId, KeyId),
+    %% Attempt to create a Riak CS user to represent the OS tenant
+    _ = riak_cs_utils:create_user(Name, Email, KeyId, Secret),
+    riak_cs_utils:get_user(KeyId, RiakPid);
+maybe_create_user({error, Reason}=Error, _, Api, _, _, _) ->
+    _ = lager:error("Retrieval of user record for ~p failed. Reason: ~p",
+                    [Api, Reason]),
+    Error.
 
 %% @doc Get the list of methods a resource supports.
 -spec allowed_methods(#wm_reqdata{}, #context{}) -> {[atom()], #wm_reqdata{}, #context{}}.
@@ -258,9 +280,8 @@ delete_resource(RD, Ctx=#context{submodule=Mod,exports_fun=ExportsFun}) ->
                   [RD,Ctx],
                   ExportsFun).
 
-
 -spec to_xml(#wm_reqdata{}, #context{}) ->
-    {binary() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
+                    {binary() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
 to_xml(RD, Ctx=#context{user=User,
                         submodule=Mod,
                         exports_fun=ExportsFun}) ->
@@ -273,10 +294,10 @@ to_xml(RD, Ctx=#context{user=User,
     Res.
 
 -spec to_json(#wm_reqdata{}, #context{}) ->
-    {binary() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
+                     {binary() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
 to_json(RD, Ctx=#context{user=User,
-                        submodule=Mod,
-                        exports_fun=ExportsFun}) ->
+                         submodule=Mod,
+                         exports_fun=ExportsFun}) ->
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"to_json">>),
     Res = resource_call(Mod,
                         to_json,
@@ -290,7 +311,7 @@ post_is_create(RD, Ctx=#context{submodule=Mod,
     resource_call(Mod, post_is_create, [RD, Ctx], ExportsFun).
 
 create_path(RD, Ctx=#context{submodule=Mod,
-                                exports_fun=ExportsFun}) ->
+                             exports_fun=ExportsFun}) ->
     resource_call(Mod, create_path, [RD, Ctx], ExportsFun).
 
 process_post(RD, Ctx=#context{submodule=Mod,
@@ -310,7 +331,7 @@ multiple_choices(RD, Ctx=#context{submodule=Mod,
     end.
 
 -spec accept_body(#wm_reqdata{}, #context{}) ->
-    {boolean() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
+                         {boolean() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
 accept_body(RD, Ctx=#context{submodule=Mod,exports_fun=ExportsFun,user=User}) ->
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"accept_body">>),
     Res = resource_call(Mod,
@@ -324,13 +345,17 @@ accept_body(RD, Ctx=#context{submodule=Mod,exports_fun=ExportsFun,user=User}) ->
 -spec produce_body(#wm_reqdata{}, #context{}) ->
                           {iolist()|binary(), #wm_reqdata{}, #context{}} |
                           {{known_length_stream, non_neg_integer(), {<<>>, function()}}, #wm_reqdata{}, #context{}}.
-produce_body(RD, Ctx=#context{submodule=Mod,exports_fun=ExportsFun}) ->
+produce_body(RD, Ctx=#context{user=User,
+                              submodule=Mod,
+                              exports_fun=ExportsFun}) ->
     %% TODO: add dt_wm_return w/ content length
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"produce_body">>),
-    resource_call(Mod,
-                  produce_body,
-                  [RD, Ctx],
-                  ExportsFun).
+    Res = resource_call(Mod,
+                        produce_body,
+                        [RD, Ctx],
+                        ExportsFun),
+    riak_cs_dtrace:dt_wm_return({?MODULE, Mod}, <<"produce_body">>, [], [riak_cs_wm_utils:extract_name(User)]),
+    Res.
 
 -spec finish_request(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 finish_request(RD, Ctx=#context{riakc_pid=undefined,
@@ -379,9 +404,11 @@ authorize(RD,Ctx=#context{submodule=Mod, exports_fun=ExportsFun}) ->
     end,
     R.
 
--spec authenticate(rcs_user(), riakc_obj:riakc_obj(), term(), term(), term()) ->
+-type user_lookup_result() :: {ok, {rcs_user(), riakc_obj:riakc_obj()}} | {error, term()}.
+-spec authenticate(user_lookup_result(), term(), term(), term()) ->
                           {ok, rcs_user(), riakc_obj:riakc_obj()} | {error, term()}.
-authenticate(User, UserObj, RD, Ctx=#context{auth_module=AuthMod, submodule=Mod}, AuthData) ->
+authenticate({ok, {User, UserObj}}, RD, Ctx=#context{auth_module=AuthMod, submodule=Mod}, AuthData)
+  when User?RCS_USER.status =:= enabled ->
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"authenticate">>, [], [atom_to_binary(AuthMod, latin1)]),
     case AuthMod:authenticate(User, AuthData, RD, Ctx) of
         ok ->
@@ -390,7 +417,13 @@ authenticate(User, UserObj, RD, Ctx=#context{auth_module=AuthMod, submodule=Mod}
         {error, _Reason} ->
             riak_cs_dtrace:dt_wm_return({?MODULE, Mod}, <<"authenticate">>, [0], [atom_to_binary(AuthMod, latin1)]),
             {error, bad_auth}
-    end.
+    end;
+authenticate({ok, {User, _UserObj}}, _RD, _Ctx, _AuthData)
+  when User?RCS_USER.status =/= enabled ->
+    %% {ok, _} -> %% disabled account, we are going to 403
+    {error, bad_auth};
+authenticate({error, _}=Error, _RD, _Ctx, _AuthData) ->
+    Error.
 
 -spec exports_fun(orddict:orddict()) -> function().
 exports_fun(Exports) ->
@@ -441,9 +474,9 @@ default(init) ->
 default(allowed_methods) ->
     default_allowed_methods;
 default(content_types_accepted) ->
-    default_content_types;
+    default_content_types_accepted;
 default(content_types_provided) ->
-    default_content_types;
+    default_content_types_provided;
 default(generate_etag) ->
     default_generate_etag;
 default(last_modified) ->
@@ -462,6 +495,8 @@ default(finish_request) ->
     default_finish_request;
 default(anon_ok) ->
     default_anon_ok;
+default(produce_body) ->
+    default_produce_body;
 default(_) ->
     undefined.
 
@@ -477,8 +512,17 @@ default_valid_entity_length(RD, Ctx) ->
 default_validate_content_checksum(RD, Ctx) ->
     {true, RD, Ctx}.
 
-default_content_types(RD, Ctx) ->
+default_content_types_accepted(RD, Ctx) ->
     {[], RD, Ctx}.
+
+-spec default_content_types_provided(#wm_reqdata{}, #context{}) ->
+                                            {[{string(), atom()}],
+                                             #wm_reqdata{},
+                                             #context{}}.
+default_content_types_provided(RD, Ctx=#context{api=oos}) ->
+    {[{"text/plain", produce_body}], RD, Ctx};
+default_content_types_provided(RD, Ctx) ->
+    {[{"application/xml", produce_body}], RD, Ctx}.
 
 default_generate_etag(RD, Ctx) ->
     {undefined, RD, Ctx}.
@@ -497,6 +541,18 @@ default_finish_request(RD, Ctx) ->
 
 default_anon_ok() ->
     true.
+
+default_produce_body(RD, Ctx=#context{submodule=Mod,
+                                       response_module=ResponseMod,
+                                       exports_fun=ExportsFun}) ->
+    try
+        ResponseMod:respond(
+          resource_call(Mod, api_request, [RD, Ctx], ExportsFun),
+          RD,
+          Ctx)
+    catch error:{badmatch, {error, Reason}} ->
+            ResponseMod:api_error(Reason, RD, Ctx)
+    end.
 
 %% @doc this function will be called by `post_authenticate/2` if the user successfully
 %% authenticates and the submodule does not provide an implementation

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -102,7 +102,7 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                         {'UploadId', [binary_to_list(base64url:encode(UploadId))]}
                        ]
                      },
-            Body = riak_cs_s3_response:export_xml([XmlDoc]),
+            Body = riak_cs_xml:export_xml([XmlDoc]),
             RD2 = wrq:set_resp_body(Body, RD),
             {true, RD2, Ctx};
         {error, Reason} ->

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -112,7 +112,7 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                                {'ETag', [binary_to_list(UploadId64)]}
                               ]
                              },
-                    XmlBody = riak_cs_s3_response:export_xml([XmlDoc]),
+                    XmlBody = riak_cs_xml:export_xml([XmlDoc]),
                     RD2 = wrq:set_resp_body(XmlBody, RD),
                     {true, RD2, Ctx};
                 {error, notfound} ->
@@ -317,7 +317,7 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
                        {'IsTruncated', ["false"]}   % TODO
                       ] ++ Us
                      },
-            Body = riak_cs_s3_response:export_xml([XmlDoc]),
+            Body = riak_cs_xml:export_xml([XmlDoc]),
             {Body, RD, Ctx};
         {error, notfound} ->
             riak_cs_s3_response:no_such_upload_response(UploadId, RD, Ctx);

--- a/src/riak_cs_wm_objects.erl
+++ b/src/riak_cs_wm_objects.erl
@@ -22,12 +22,14 @@
 
 -export([init/1,
          allowed_methods/0,
-         content_types_provided/2,
-         to_xml/2]).
+         api_request/2
+        ]).
 
 -export([authorize/2]).
 
 -include("riak_cs.hrl").
+-include("riak_cs_api.hrl").
+-include("list_objects.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
 -define(RIAKCPOOL, bucket_list_pool).
@@ -41,68 +43,28 @@ allowed_methods() ->
     %% TODO: POST (multi-delete)
     ['GET'].
 
--spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
-content_types_provided(RD,Ctx) ->
-    {[{"application/xml", to_xml}], RD, Ctx}.
-
-
 %% TODO: change to authorize/spec/cleanup unneeded cases
 %% TODO: requires update for multi-delete
 -spec authorize(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 authorize(RD, Ctx) ->
     riak_cs_wm_utils:bucket_access_authorize_helper(bucket, false, RD, Ctx).
 
--spec to_xml(#wm_reqdata{}, #context{}) ->
-                    {binary() | {'halt', non_neg_integer()}, #wm_reqdata{}, #context{}}.
-to_xml(RD, Ctx=#context{start_time=StartTime,
-                        user=User,
-                        bucket=Bucket,
-                        requested_perm='READ',
-                        riakc_pid=RiakPid}) ->
-    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"list_keys">>, [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    StrBucket = binary_to_list(Bucket),
-    case [B || B <- riak_cs_utils:get_buckets(User),
-               B?RCS_BUCKET.name =:= StrBucket] of
-        [] ->
-            CodeName = no_such_bucket,
-            Res = riak_cs_s3_response:api_error(CodeName, RD, Ctx),
-            Code = riak_cs_s3_response:status_code(CodeName),
-            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
-            Res;
-        [_BucketRecord] ->
-            MaxKeys = get_max_keys(RD),
-            case MaxKeys of
-                _ when is_integer(MaxKeys) ->
-                    Options = get_options(RD),
-                    ListKeysRequest = riak_cs_list_objects:new_request(Bucket,
-                                                                       MaxKeys,
-                                                                       Options),
-                    BinPid = riak_cs_utils:pid_to_binary(self()),
-                    CacheKey = << BinPid/binary, <<":">>/binary, Bucket/binary >>,
-                    UseCache = riak_cs_list_objects_ets_cache:cache_enabled(),
-                    case riak_cs_list_objects_fsm:start_link(RiakPid, self(),
-                                                             ListKeysRequest, CacheKey,
-                                                             UseCache) of
-                        {ok, ListFSMPid} ->
-                            {ok, ListObjectsResponse} = riak_cs_list_objects_fsm:get_object_list(ListFSMPid),
-                            Response = riak_cs_xml:to_xml(ListObjectsResponse),
-                            ok = riak_cs_stats:update_with_start(bucket_list_keys,
-                                                                 StartTime),
-                            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
-                            riak_cs_s3_response:respond(200, Response, RD, Ctx);
-                        {error, Reason} ->
-                            Code = riak_cs_s3_response:status_code(Reason),
-                            Response = riak_cs_s3_response:api_error(Reason, RD, Ctx),
-                            riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
-                            Response
-                    end;
-                Reason ->
-                    Code = riak_cs_s3_response:status_code(Reason),
-                    Response = riak_cs_s3_response:api_error(Reason, RD, Ctx),
-                    riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [Code], [riak_cs_wm_utils:extract_name(User), Bucket]),
-                    Response
-            end
-    end.
+-spec api_request(#wm_reqdata{}, #context{}) -> {ok, ?LORESP{}} | {error, term()}.
+api_request(RD, Ctx=#context{bucket=Bucket,
+                             user=User,
+                             start_time=StartTime}) ->
+    UserName = riak_cs_wm_utils:extract_name(User),
+    riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"list_keys">>, [], [UserName, Bucket]),
+    Res = riak_cs_api:list_objects(
+            [B || B <- riak_cs_utils:get_buckets(User),
+                  B?RCS_BUCKET.name =:= binary_to_list(Bucket)],
+            Ctx#context.bucket,
+            get_max_keys(RD),
+            get_options(RD),
+            Ctx#context.riakc_pid),
+    ok = riak_cs_stats:update_with_start(bucket_list_keys, StartTime),
+    riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [200], [UserName, Bucket]),
+    Res.
 
 -spec get_options(#wm_reqdata{}) -> [{atom(), 'undefined' | binary()}].
 get_options(RD) ->
@@ -115,7 +77,7 @@ get_option(Option, undefined) ->
 get_option(Option, Value) ->
     {Option, list_to_binary(Value)}.
 
--spec get_max_keys(#wm_reqdata{}) -> integer() | 'invalid_argument'.
+-spec get_max_keys(#wm_reqdata{}) -> non_neg_integer() | {error, 'invalid_argument'}.
 get_max_keys(RD) ->
     case wrq:get_qs_value("max-keys", RD) of
         undefined ->
@@ -125,6 +87,6 @@ get_max_keys(RD) ->
                 erlang:min(list_to_integer(StringKeys),
                            ?DEFAULT_LIST_OBJECTS_MAX_KEYS)
             catch _:_ ->
-                    invalid_argument
+                    {error, invalid_argument}
             end
     end.

--- a/src/riak_cs_wm_stats.erl
+++ b/src/riak_cs_wm_stats.erl
@@ -86,7 +86,7 @@ ping(RD, Ctx) ->
 
 service_available(RD, #ctx{path_tokens = []} = Ctx) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"service_available">>),
-    case riak_cs_utils:get_env(riak_cs, riak_cs_stat, true) of
+    case riak_cs_config:riak_cs_stat() of
         false ->
             {false, RD, Ctx};
         true ->
@@ -114,7 +114,7 @@ forbidden(RD, #ctx{auth_bypass = AuthBypass, riakc_pid = RiakPid} = Ctx) ->
     case riak_cs_wm_utils:validate_auth_header(RD, AuthBypass, RiakPid, undefined) of
         {ok, User, _UserObj} ->
             UserKeyId = User?RCS_USER.key_id,
-            case riak_cs_utils:get_admin_creds() of
+            case riak_cs_config:admin_creds() of
                 {ok, {Admin, _}} when Admin == UserKeyId ->
                     %% admin account is allowed
                     riak_cs_dtrace:dt_wm_return(?MODULE, <<"forbidden">>,

--- a/src/riak_cs_wm_usage.erl
+++ b/src/riak_cs_wm_usage.erl
@@ -258,7 +258,7 @@ forbidden(RD, Ctx, User, false) ->
             AccessRD = riak_cs_access_log_handler:set_user(User, RD),
             {false, AccessRD, Ctx};
         false ->
-            case riak_cs_utils:get_admin_creds() of
+            case riak_cs_config:admin_creds() of
                 {ok, {Admin, _}} when Admin == User?RCS_USER.key_id ->
                     %% admin can access anyone's stats
                     {false, RD, Ctx};
@@ -321,7 +321,7 @@ produce_xml(RD, #ctx{body=undefined}=Ctx) ->
     Storage = maybe_storage(RD, Ctx),
     Doc = [{?KEY_USAGE, [{?KEY_ACCESS, xml_access(Access)},
                          {?KEY_STORAGE, xml_storage(Storage)}]}],
-    Body = case riak_cs_s3_response:export_xml(Doc) of
+    Body = case riak_cs_xml:export_xml(Doc) of
                {error, Bin, _}         -> Bin;
                {incomplete, Bin, _}    -> Bin;
                Bin when is_binary(Bin) -> Bin
@@ -477,7 +477,7 @@ xml_error_msg(Message) when is_binary(Message) ->
     xml_error_msg(binary_to_list(Message));
 xml_error_msg(Message) ->
     Doc = [{?KEY_ERROR, [{?KEY_MESSAGE, [Message]}]}],
-    riak_cs_s3_response:export_xml(Doc).
+    riak_cs_xml:export_xml(Doc).
 
 %% @doc Produce a datetime tuple from a ISO8601 string
 -spec datetime(binary()|string()) -> {ok, calendar:datetime()} | error.

--- a/src/riak_cs_wm_users.erl
+++ b/src/riak_cs_wm_users.erl
@@ -108,7 +108,7 @@ forbidden(RD, Ctx, undefined, false) ->
     riak_cs_wm_utils:deny_access(RD, Ctx);
 forbidden(RD, Ctx, User, false) ->
     UserKeyId = User?RCS_USER.key_id,
-    case riak_cs_utils:get_admin_creds() of
+    case riak_cs_config:admin_creds() of
         {ok, {Admin, _}} when Admin == UserKeyId ->
             %% admin account is allowed
             {false, RD, Ctx};
@@ -147,7 +147,7 @@ wait_for_users(Format, RiakPid, ReqId, Boundary, Status) ->
 
 %% @doc Compile a multipart entity for a set of user documents.
 users_doc(UserDocs, xml, Boundary) ->
-    XmlDoc = riak_cs_s3_response:export_xml([{'Users', UserDocs}]),
+    XmlDoc = riak_cs_xml:export_xml([{'Users', UserDocs}]),
     ["\r\n--",
      Boundary,
      "\r\nContent-Type: ", ?XML_TYPE, "\r\n\r\n",

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -233,20 +233,23 @@ ensure_doc(KeyCtx, _) ->
 
 %% @doc Produce an access-denied error message from a webmachine
 %% resource's `forbidden/2' function.
+deny_access(RD, Ctx=#context{response_module=ResponseMod}) ->
+    ResponseMod:api_error(access_denied, RD, Ctx);
 deny_access(RD, Ctx) ->
     riak_cs_s3_response:api_error(access_denied, RD, Ctx).
 
 %% @doc Prodice an invalid-access-keyid error message from a
 %% webmachine resource's `forbidden/2' function.
-deny_invalid_key(RD, Ctx) ->
-    riak_cs_s3_response:api_error(invalid_access_key_id, RD, Ctx).
+deny_invalid_key(RD, Ctx=#context{response_module=ResponseMod}) ->
+    ResponseMod:api_error(invalid_access_key_id, RD, Ctx).
 
 %% @doc In the case is a user is authorized to perform an operation on
 %% a bucket but is not the owner of that bucket this function can be used
 %% to switch to the owner's record if it can be retrieved
 -spec shift_to_owner(#wm_reqdata{}, #context{}, string(), pid()) ->
                             {boolean(), #wm_reqdata{}, #context{}}.
-shift_to_owner(RD, Ctx=#context{}, OwnerId, RiakPid) when RiakPid /= undefined ->
+shift_to_owner(RD, Ctx=#context{response_module=ResponseMod}, OwnerId, RiakPid)
+  when RiakPid /= undefined ->
     case riak_cs_utils:get_user(OwnerId, RiakPid) of
         {ok, {Owner, OwnerObject}} when Owner?RCS_USER.status =:= enabled ->
             AccessRD = riak_cs_access_log_handler:set_user(Owner, RD),
@@ -255,7 +258,7 @@ shift_to_owner(RD, Ctx=#context{}, OwnerId, RiakPid) when RiakPid /= undefined -
         {ok, _} ->
             riak_cs_wm_utils:deny_access(RD, Ctx);
         {error, _} ->
-            riak_cs_s3_response:api_error(bucket_owner_unavailable, RD, Ctx)
+            ResponseMod:api_error(bucket_owner_unavailable, RD, Ctx)
     end.
 
 streaming_get(FsmPid, StartTime, UserName, BFile_str) ->
@@ -449,9 +452,11 @@ bucket_access_authorize_helper(AccessType, Deletable, RD, Ctx) ->
       PermCtx).
 
 handle_bucket_acl_policy_response({error, notfound}, _, _, RD, Ctx) ->
-    riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
+    ResponseMod = Ctx#context.response_module,
+    ResponseMod:api_error(no_such_bucket, RD, Ctx);
 handle_bucket_acl_policy_response({error, Reason}, _, _, RD, Ctx) ->
-    riak_cs_s3_response:api_error(Reason, RD, Ctx);
+    ResponseMod = Ctx#context.response_module,
+    ResponseMod:api_error(Reason, RD, Ctx);
 handle_bucket_acl_policy_response({Acl, Policy}, AccessType, DeleteEligible, RD, Ctx) ->
     #context{bucket=Bucket,
              riakc_pid=RiakPid,
@@ -515,6 +520,7 @@ handle_policy_eval_result(_, true, OwnerId, RD, Ctx) ->
     shift_to_owner(RD, Ctx, OwnerId, Ctx#context.riakc_pid);
 handle_policy_eval_result(User, _, _, RD, Ctx) ->
     #context{riakc_pid=RiakPid,
+             response_module=ResponseMod,
              user=User,
              bucket=Bucket} = Ctx,
     %% log bad requests against the actors that make them
@@ -525,7 +531,7 @@ handle_policy_eval_result(User, _, _, RD, Ctx) ->
         {ok, _} ->
             riak_cs_wm_utils:deny_access(AccessRD, Ctx);
         {error, Reason} ->
-            riak_cs_s3_response:api_error(Reason, RD, Ctx)
+            ResponseMod:api_error(Reason, RD, Ctx)
     end.
 
 -spec is_acl_request(atom()) -> boolean().
@@ -550,6 +556,7 @@ object_access_authorize_helper(AccessType, Deletable, RD, Ctx) ->
 object_access_authorize_helper(AccessType, Deletable, SkipAcl,
                                RD, #context{policy_module=PolicyMod,
                                             local_context=LocalCtx,
+                                            response_module=ResponseMod,
                                             riakc_pid=RiakPid}=Ctx)
   when ( AccessType =:= object_acl orelse
          AccessType =:= object_part orelse
@@ -562,11 +569,11 @@ object_access_authorize_helper(AccessType, Deletable, SkipAcl,
         {error, multiple_bucket_owners=E} ->
             %% We want to bail out early if there are siblings when
             %% retrieving the bucket policy
-            riak_cs_s3_response:api_error(E, RD, Ctx);
+            ResponseMod:api_error(E, RD, Ctx);
         {error, notfound} ->
             %% The call to `check_bucket_exists' returned `notfound'
             %% so we can assume to bucket does not exist.
-            riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
+            ResponseMod:api_error(no_such_bucket, RD, Ctx);
         Policy ->
             check_object_authorization(AccessType, Deletable, SkipAcl, Policy, RD, Ctx)
     end.
@@ -583,8 +590,8 @@ check_object_authorization(AccessType, Deletable, SkipAcl, Policy,
     ObjectAcl = extract_object_acl(Manifest),
     Access = PolicyMod:reqdata_to_access(RD, AccessType, CanonicalId),
     Acl = case SkipAcl of
-	      true -> true;
-	      false -> riak_cs_acl:object_access(Bucket,
+              true -> true;
+              false -> riak_cs_acl:object_access(Bucket,
                                              ObjectAcl,
                                              RequestedAccess,
                                              CanonicalId,

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -24,6 +24,7 @@
 -module(riak_cs_xml).
 
 -include("riak_cs.hrl").
+-include("riak_cs_api.hrl").
 -include("list_objects.hrl").
 
 -ifdef(TEST).
@@ -31,7 +32,8 @@
 -endif.
 
 %% Public API
--export([to_xml/1]).
+-export([export_xml/1,
+         to_xml/1]).
 
 -define(XML_SCHEMA_INSTANCE, "http://www.w3.org/2001/XMLSchema-instance").
 
@@ -44,6 +46,13 @@
 %% Public API
 %% ===================================================================
 
+%% This function is temporary and should be removed once all XML
+%% handling has been moved into this module.
+%% @TODO Remove this asap!
+export_xml(XmlDoc) ->
+    unicode:characters_to_binary(
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
+
 -spec to_xml(term()) -> binary().
 to_xml(undefined) ->
     [];
@@ -53,6 +62,8 @@ to_xml(?ACL{}=Acl) ->
     acl_to_xml(Acl);
 to_xml(#acl_v1{}=Acl) ->
     acl_to_xml(Acl);
+to_xml(?LBRESP{}=ListBucketsResp) ->
+    list_buckets_response_to_xml(ListBucketsResp);
 to_xml(?LORESP{}=ListObjsResp) ->
     list_objects_response_to_xml(ListObjsResp).
 
@@ -101,6 +112,29 @@ list_objects_response_to_xml(Resp) ->
         KeyContents ++ CommonPrefixes,
     export_xml([make_internal_node('ListBucketResult', [{'xmlns', ?S3_XMLNS}],
                                    Contents)]).
+
+list_buckets_response_to_xml(Resp) ->
+    BucketsContent =
+        make_internal_node('Buckets',
+                           [bucket_to_xml(B?RCS_BUCKET.name,
+                                          B?RCS_BUCKET.creation_date) ||
+                               B <- Resp?LBRESP.buckets]),
+    UserContent = user_to_xml_owner(Resp?LBRESP.user),
+    Contents = [UserContent] ++ [BucketsContent],
+    export_xml([make_internal_node('ListAllMyBucketsResult',
+                                   [{'xmlns', ?S3_XMLNS}],
+                                   Contents)]).
+
+bucket_to_xml(Name, CreationDate) when is_binary(Name) ->
+    bucket_to_xml(binary_to_list(Name), CreationDate);
+bucket_to_xml(Name, CreationDate) ->
+    make_internal_node('Bucket',
+                       [make_external_node('Name', Name),
+                        make_external_node('CreationDate', CreationDate)]).
+
+user_to_xml_owner(?RCS_USER{canonical_id=CanonicalId, display_name=Name}) ->
+    make_internal_node('Owner', [make_external_node('ID', CanonicalId),
+                                 make_external_node('DisplayName', Name)]).
 
 key_content_to_xml(KeyContent) ->
     Contents =
@@ -173,11 +207,6 @@ make_owner(#list_objects_owner_v1{id=Id, display_name=Name}) ->
     Content = [make_external_node('ID', Id),
                make_external_node('DisplayName', Name)],
     make_internal_node('Owner', Content).
-
--spec export_xml([internal_node()]) -> binary().
-export_xml(XmlDoc) ->
-    unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
 
 -spec format_value(atom() | integer() | binary() | list()) -> string().
 format_value(undefined) ->

--- a/test/riak_cs_utils_test.erl
+++ b/test/riak_cs_utils_test.erl
@@ -243,7 +243,10 @@ nonexistent_deletes() ->
 
 bucket_resolution_test() ->
     %% @TODO Replace or augment this with eqc testing.
-    UserRecord = riak_cs_utils:user_record("uncle fester", "fester@tester.com"),
+    UserRecord = riak_cs_utils:user_record("uncle fester",
+                                           "fester@tester.com",
+                                           "festersquest",
+                                           "wasthebest"),
     BucketList1 = [riak_cs_utils:bucket_record(<<"bucket1">>, create),
                    riak_cs_utils:bucket_record(<<"bucket2">>, create),
                    riak_cs_utils:bucket_record(<<"bucket3">>, create)],


### PR DESCRIPTION
This PR addresses issues #373 and #374. It includes the following:
- Add rewrite rules for basic bucket and object operations from
  OpenStack Object Storage API
- Add authentication module for Keystone authentication service
- Make URL rewrite module configurable
- Refactoring to further decouple API requests and responses from core
  object store functionality.
- Add helper module for JSON processing
- Refactor XML handling code
- Isolate configuration functions into riak_cs_config module

This result of this PR does not indicate that Riak CS is completely ready to be
dropped-in to an OpenStack deployment, but it is a big step in that
direction. Only the basic object storage API operations are
implemented and error responses may not be correct since they are not
well documented in the OpenStack API documentation. There is also not yet
support for checking for revoked PKI tokens or token caching of any
kind.

There are a number of more general refactoring steps included in these changes and I am interested in any feedback on them, especially if it is something that could be improved upon. Some of the refactoring effort is incomplete and this is largely intentional so that the focus of this effort did not become entirely lost.

I have added a number of entries to the repo wiki that should help
with understanding and testing these changes.  See the [API and authentication](https://github.com/basho/riak_cs/wiki#api-and-authentication)
and the [OpenStack integration](https://github.com/basho/riak_cs/wiki#openstack-integration) sections specfically.

Additionally here are a few other links that may be of use:
- [Openstack Object Storage API docs](http://docs.openstack.org/api/openstack-object-storage/1.0/content/index.html)
- [OpenStack Identity developer docs](http://docs.openstack.org/api/openstack-identity-service/2.0/content/index.html)
- [OpenStack API quick reference](http://api.openstack.org/api-ref.html)
- [Blog post](http://blog.chmouel.com/2011/11/24/swift-and-keystone-middleware-part1/) on Swift and Keystone
