### PR TITLE
Properly include riak-cs-ee dependencies in packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ xref: compile
 ## Packaging targets
 ##
 .PHONY: package
-export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE
+export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE RIAK_CS_EE_DEPS
 
 package.src: deps
 	mkdir -p package


### PR DESCRIPTION
The `rebar.config.script` defines extra dependencies to be
included when building the enterprise version of riak-cs.
These dependencies were not being included in the 1.3 packages.

This fix simply exports the variable used `RIAK_CS_EE_DEPS`
to the packaging steps so subsequent calls to rebar still
include all the enterprise settings.

Fixes: #557 and basho/node_package#48

I built this commit on Ubuntu:

```
buildbot@build-ubuntu-1204-64:~/dev/riak_cs/package/packages$ dpkg-deb -c riak-cs-ee_1.3.1.64.ge27cc6d-1_amd64.deb | grep riak_repl
drwxr-xr-x root/root         0 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/
drwxr-xr-x root/root         0 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/priv/
-rw-r--r-- root/root         6 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/priv/vsn.git
drwxr-xr-x root/root         0 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/ebin/
-rw-r--r-- root/root      5980 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/ebin/riak_repl_pb_api.beam
-rw-r--r-- root/root       255 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/ebin/riak_repl_pb_api.app
-rw-r--r-- root/root     11844 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/ebin/riak_repl_pb.beam
drwxr-xr-x root/root         0 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/include/
-rw-r--r-- root/root       660 2013-05-07 09:30 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.2/include/riak_repl_pb.hrl
```
