### PR TITLE
Object deleted while updating behavior changes

### DIFF
--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -39,6 +39,9 @@
          move_manifests_to_gc_bucket/3,
          timestamp/0]).
 
+%% export for repl debugging and testing
+-export([get_active_manifests/3]).
+
 %%%===================================================================
 %%% Public API
 %%%===================================================================
@@ -128,12 +131,22 @@ gc_manifests(Manifests, RiakObject, Bucket, Key, RiakcPid) ->
       [binary()] | no_return().
 gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs) ->
     UUID = M?MANIFEST.uuid,
-    check(gc_specific_manifests([UUID], RiakObject, Bucket, Key, RiakcPid), [UUID | UUIDs]).
+    check(gc_specific_manifests_to_delete([UUID], RiakObject, Bucket, Key, RiakcPid), [UUID | UUIDs]).
 
 check({ok, _}, Val) -> 
     Val;
 check({error, _}=Error, _Val) -> 
     Error.
+
+-spec gc_specific_manifests_to_delete(UUIDsToMark :: [binary()],
+                   RiakObject :: riakc_obj:riakc_obj(),
+                   Bucket :: binary(),
+                   Key :: binary(),
+                   RiakcPid :: pid()) ->
+    {error, term()} | {ok, riakc_obj:riakc_obj()}.
+gc_specific_manifests_to_delete(UUIDsToMark, RiakObject, Bucket, Key, RiakcPid) ->
+    MarkedResult = mark_as_deleted(UUIDsToMark, RiakObject, Bucket, Key, RiakcPid),
+    handle_mark_as_pending_delete(MarkedResult, Bucket, Key, UUIDsToMark, RiakcPid).
 
 %% @private
 -spec gc_specific_manifests(UUIDsToMark :: [binary()],
@@ -238,6 +251,16 @@ timestamp() ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+%% @doc Mark a list of manifests as `pending_delete' based upon the
+%% UUIDs specified, and also add {deleted, true} to the props member
+%% to signify an actual delete, and not an overwrite.
+-spec mark_as_deleted([binary()], riakc_obj:riakc_obj(), binary(), binary(), pid()) ->
+    {ok, riakc_obj:riakc_obj()} | {error, term()}.
+mark_as_deleted(UUIDsToMark, RiakObject, Bucket, Key, RiakcPid) ->
+    mark_manifests(RiakObject, Bucket, Key, UUIDsToMark,
+                   fun riak_cs_manifest_utils:mark_deleted/2,
+                   RiakcPid).
 
 %% @doc Mark a list of manifests as `pending_delete' based upon the
 %% UUIDs specified.

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -34,7 +34,9 @@
          active_manifests/1,
          active_and_writing_manifests/1,
          overwritten_UUIDs/1,
+         deleted_while_writing/1,
          mark_pending_delete/2,
+         mark_deleted/2,
          mark_scheduled_delete/2,
          manifests_to_gc/2,
          prune/1,
@@ -58,10 +60,20 @@ new_dict(UUID, Manifest) ->
 %% from an orddict of manifests.
 -spec active_manifest(orddict:orddict()) -> {ok, lfs_manifest()} | {error, no_active_manifest}.
 active_manifest(Dict) ->
-    case lists:foldl(fun most_recent_active_manifest/2, no_active_manifest, orddict_values(Dict)) of
-        no_active_manifest ->
+    live_manifest(lists:foldl(fun most_recent_active_manifest/2, 
+            {no_active_manifest, undefined}, orddict_values(Dict))). 
+
+%% @doc Ensure the manifest hasn't been deleted during upload.
+-spec live_manifest(tuple()) -> {ok, lfs_manifest()} | {error, no_active_manifest}.
+live_manifest({no_active_manifest, _}) ->
+    {error, no_active_manifest};
+live_manifest({Manifest, undefined}) ->
+    {ok, Manifest};
+live_manifest({Manifest, DeleteTime}) ->
+    case DeleteTime > Manifest?MANIFEST.write_start_time of
+        true ->
             {error, no_active_manifest};
-        Manifest ->
+        false ->
             {ok, Manifest}
     end.
 
@@ -139,6 +151,24 @@ handle_leeway_elaped_time(true, UUID, Acc) ->
     [UUID | Acc];
 handle_leeway_elaped_time(false, _UUID, Acc) ->
     Acc.
+
+%% @doc Return `Dict' with the manifests in
+%% `UUIDsToMark' with their state changed to
+%% `pending_delete' and {deleted, true} added to props.
+-spec mark_deleted(orddict:orddict(), list(binary())) ->
+    orddict:orddict().
+mark_deleted(Dict, UUIDsToMark) ->
+    MapFun = fun(K, V) ->
+            case lists:member(K, UUIDsToMark) of
+                true ->
+                    V?MANIFEST{state=pending_delete,
+                               delete_marked_time=os:timestamp(),
+                               props=[{deleted, true} | V?MANIFEST.props]};
+                false ->
+                    V
+            end
+    end,
+    orddict:map(MapFun, Dict).
 
 %% @doc Return `Dict' with the manifests in
 %% `UUIDsToMark' with their state changed to
@@ -307,18 +337,91 @@ orddict_values(OrdDict) ->
 manifest_is_active(?MANIFEST{state=active}) -> true;
 manifest_is_active(_Manifest) -> false.
 
-%% NOTE: This is a foldl function, initial acc = no_active_manifest
-most_recent_active_manifest(Manifest=?MANIFEST{state=active}, no_active_manifest) ->
-    Manifest;
-most_recent_active_manifest(_Manfest, no_active_manifest) ->
-    no_active_manifest;
-most_recent_active_manifest(Man1=?MANIFEST{state=active}, Man2=?MANIFEST{state=active}) ->
-    case Man1?MANIFEST.write_start_time > Man2?MANIFEST.write_start_time of
-        true -> Man1;
-        false -> Man2
-    end;
-most_recent_active_manifest(Man1=?MANIFEST{state=active}, _Man2) -> Man1;
-most_recent_active_manifest(_Man1, Man2=?MANIFEST{state=active}) -> Man2.
+-spec delete_time(lfs_manifest()) -> erlang:timestamp() | undefined.
+delete_time(Manifest) ->
+    case proplists:is_defined(deleted, Manifest?MANIFEST.props) of
+        true ->
+            Manifest?MANIFEST.delete_marked_time;
+        false ->
+            undefined
+    end.
+
+%% @doc Return all active manifests that have timestamps before the latest deletion
+%% This happens when a manifest is still uploading while it is deleted. The upload 
+%% is allowed to complete, but is not visible afterwards.
+-spec deleted_while_writing(orddict:orddict()) -> [binary()].
+deleted_while_writing(Manifests) ->
+    ManifestList = orddict_values(Manifests),
+    DeleteTime = latest_delete_time(ManifestList),
+    find_deleted_active_manifests(ManifestList, DeleteTime).
+
+-spec find_deleted_active_manifests([lfs_manifest()], term()) -> [lfs_manifest()].
+find_deleted_active_manifests(_Manifests, undefined) ->
+    [];
+find_deleted_active_manifests(Manifests, DeleteTime) ->
+    [M?MANIFEST.uuid || M <- Manifests, M?MANIFEST.state =:= active, 
+                        M?MANIFEST.write_start_time < DeleteTime].
+
+-spec latest_delete_time([lfs_manifest()]) -> term() | undefined.
+latest_delete_time(Manifests) ->
+    lists:foldl(fun(M, Acc) ->
+                    DeleteTime = delete_time(M),
+                    later(DeleteTime, Acc)
+                end, undefined, Manifests).
+
+%% @doc Return the later of two times, accounting for undefined
+-spec later(undefined | erlang:timestamp(), undefined | erlang:timestamp()) -> 
+    undefined | erlang:timestamp().
+later(undefined, undefined) ->
+    undefined;
+later(undefined, DeleteTime2) ->
+    DeleteTime2;
+later(DeleteTime1, undefined) ->
+    DeleteTime1;
+later(DeleteTime1, DeleteTime2) ->
+    case DeleteTime1 > DeleteTime2 of
+        true ->
+            DeleteTime1;
+        false ->
+            DeleteTime2
+    end.
+
+%% NOTE: This is a foldl function, initial acc = {no_active_manifest, undefined}
+%% Return the most recent active manifest as well as the most recent manifest delete time
+-spec most_recent_active_manifest(lfs_manifest(), {
+    no_active_manifest | lfs_manifest(), undefined | erlang:timestamp()}) -> 
+        {no_active_manifest | lfs_manifest(), erlang:timestamp() | undefined}.
+most_recent_active_manifest(Manifest=?MANIFEST{state=scheduled_delete}, 
+                            {MostRecent, undefined}) -> 
+    {MostRecent, delete_time(Manifest)};
+most_recent_active_manifest(Manifest=?MANIFEST{state=scheduled_delete}, 
+                            {MostRecent, DeleteTime}) -> 
+    Dt=delete_time(Manifest), 
+    {MostRecent, later(Dt, DeleteTime)};
+most_recent_active_manifest(Manifest=?MANIFEST{state=pending_delete}, 
+                            {MostRecent, undefined}) -> 
+    {MostRecent, delete_time(Manifest)};
+most_recent_active_manifest(Manifest=?MANIFEST{state=pending_delete}, 
+                           {MostRecent, DeleteTime}) -> 
+    Dt=delete_time(Manifest), 
+    {MostRecent, later(Dt, DeleteTime)};
+most_recent_active_manifest(Manifest=?MANIFEST{state=active}, 
+                            {no_active_manifest, undefined}) ->
+    {Manifest, undefined};
+most_recent_active_manifest(Man1=?MANIFEST{state=active}, 
+                            {Man2=?MANIFEST{state=active}, DeleteTime}) 
+    when Man1?MANIFEST.write_start_time > Man2?MANIFEST.write_start_time ->
+        {Man1, DeleteTime};
+most_recent_active_manifest(_Man1=?MANIFEST{state=active}, 
+                            {Man2=?MANIFEST{state=active}, DeleteTime}) ->
+    {Man2, DeleteTime};
+most_recent_active_manifest(Man1=?MANIFEST{state=active}, 
+                            {no_active_manifest, DeleteTime}) -> 
+    {Man1, DeleteTime};
+most_recent_active_manifest(_Man1, {Man2=?MANIFEST{state=active}, DeleteTime}) -> 
+    {Man2, DeleteTime};
+most_recent_active_manifest(_Manifest, {MostRecent, DeleteTime}) ->
+    {MostRecent, DeleteTime}.
 
 -spec needs_pruning(lfs_manifest(), erlang:timestamp()) -> boolean().
 needs_pruning(?MANIFEST{state=scheduled_delete,

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -813,7 +813,7 @@ parse_ip(Str) when is_list(Str) ->
             Error 
     end.
 
--spec parse_tokenized_ip([string()]) -> {inet:ip_address(), inet:ip_address()}.
+-spec parse_tokenized_ip([string()]) -> {string(), inet:ip_address()}.
 parse_tokenized_ip([IP]) ->
     {IP, {255, 255, 255, 255}};
 parse_tokenized_ip([IP, PrefixSize]) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -515,10 +515,15 @@ get_manifests(RiakcPid, Bucket, Key) ->
     case get_manifests_raw(RiakcPid, Bucket, Key) of
         {ok, Object} ->
             Manifests = manifests_from_riak_object(Object),
+            _  = gc_deleted_while_writing_manifests(Object, Manifests, Bucket, Key, RiakcPid),
             {ok, Object, Manifests};
         {error, _Reason}=Error ->
             Error
     end.
+
+gc_deleted_while_writing_manifests(Object, Manifests, Bucket, Key, RiakcPid) ->
+    UUIDs = riak_cs_manifest_utils:deleted_while_writing(Manifests),
+    riak_cs_gc:gc_specific_manifests(UUIDs, Object, Bucket, Key, RiakcPid).
 
 -spec manifests_from_riak_object(riakc_obj:riakc_obj()) -> orddict:orddict().
 manifests_from_riak_object(RiakObject) ->

--- a/test/riak_cs_gen.erl
+++ b/test/riak_cs_gen.erl
@@ -39,7 +39,9 @@
          bounded_uuid/0,
          manifest_state/0,
          datetime/0,
-         md5_chunk_size/0]).
+         md5_chunk_size/0,
+         timestamp/0,
+         props/0]).
 
 %%====================================================================
 %% Generators
@@ -85,8 +87,14 @@ datetime() ->
     {{choose(1,5000), choose(1,12), choose(1,28)},
      {choose(0, 23), choose(0, 59), choose(0, 59)}}.
 
+timestamp() ->
+    {choose(0, 5000), choose(0, 999999), choose(0, 999999)}.
+
 md5_chunk_size() ->
     oneof([2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]).
+
+props() ->
+    oneof([[], [{deleted, true}]]).
 
 %%====================================================================
 %% Helpers

--- a/test/riak_cs_manifest_utils_eqc.erl
+++ b/test/riak_cs_manifest_utils_eqc.erl
@@ -30,7 +30,7 @@
 -compile(export_all).
 
 %% eqc property
--export([prop_choose_active_commutative/0]).
+-export([prop_active_manifests/0]).
 
 %% helpers
 -export([test/0, test/1]).
@@ -51,7 +51,7 @@ eqc_test_() ->
        fun cleanup/1,
        [%% Run the quickcheck tests
         {timeout, 300,
-            ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT((prop_choose_active_commutative())))))}
+            ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT((prop_active_manifests())))))}
        ]
       }
      ]
@@ -68,23 +68,30 @@ cleanup(_) ->
 %% eqc property
 %% ====================================================================
 
-prop_choose_active_commutative() ->
+prop_active_manifests() ->
     ?FORALL(Manifests, eqc_gen:resize(50, manifests()),
         begin
             AlteredManifests = lists:map(fun(M) -> M?MANIFEST{uuid=druuid:v4()} end, Manifests),
             AsDict = orddict:from_list([{M?MANIFEST.uuid, M} || M <- AlteredManifests]),
+            ToGcUUIDs = lists:sort(riak_cs_manifest_utils:deleted_while_writing(AsDict)),
             Active = riak_cs_manifest_utils:active_manifest(AsDict),
             case Active of
                 {error, no_active_manifest} ->
-                    %% if no manifest is returned then there should
-                    %% not be an active manifest in the list _at_ _all_
-                    [] == lists:filter(fun(?MANIFEST{state=State}) ->
-                                State == active end,
-                            Manifests);
+                    %% If no manifest is returned then there should
+                    %% not be an active manifest in the list, unless
+                    %% the manifest has a write_start_time < delete_marked_time of
+                    %% some other deleted manifest's delete_marked_time.
+                    ActiveManis = lists:filter(fun(?MANIFEST{state=State}) ->
+                                              State == active 
+                                          end, AlteredManifests),
+                    ActiveUUIDs = lists:sort([M?MANIFEST.uuid || M <- ActiveManis]),
+                    ActiveUUIDs =:= ToGcUUIDs;
                 {ok, AMani} ->
-                    %% if a manifest is returned,
-                    %% its state should be active
-                    AMani?MANIFEST.state == active
+                    %% if a manifest is returned it's state should be active
+                    %% and it should have a write_start_time > delete_marked_time
+                    %% than the latest delete_marked_time of a deleted manifest.
+                    ?assertEqual(AMani?MANIFEST.state, active),
+                    false =:= lists:member(AMani?MANIFEST.uuid, ToGcUUIDs)
             end
         end).
 
@@ -104,17 +111,21 @@ process_manifest(Manifest=?MANIFEST{state=State}) ->
     case State of
         writing ->
             Manifest?MANIFEST{last_block_written_time=erlang:now(),
-                                     write_blocks_remaining=blocks_set()};
+                              write_blocks_remaining=blocks_set()};
         active ->
             %% this clause isn't
             %% needed but it makes
             %% things more clear imho
-            Manifest?MANIFEST{last_block_deleted_time=erlang:now()};
+            Manifest?MANIFEST{last_block_deleted_time=erlang:now(),
+                              write_start_time=riak_cs_gen:timestamp()};
         pending_delete ->
             Manifest?MANIFEST{last_block_deleted_time=erlang:now(),
-                                     delete_blocks_remaining=blocks_set()};
+                              delete_blocks_remaining=blocks_set(),
+                              delete_marked_time=riak_cs_gen:timestamp(),
+                              props=riak_cs_gen:props()};
         scheduled_delete ->
-            Manifest?MANIFEST{delete_marked_time=erlang:now()}
+            Manifest?MANIFEST{delete_marked_time=riak_cs_gen:timestamp(),
+                              props=riak_cs_gen:props()}
     end.
 
 manifests() ->
@@ -131,6 +142,6 @@ test() ->
     test(100).
 
 test(Iterations) ->
-    eqc:quickcheck(eqc:numtests(Iterations, prop_choose_active_commutative())).
+    eqc:quickcheck(eqc:numtests(Iterations, prop_active_manifests())).
 
 -endif. %EQC


### PR DESCRIPTION
When a manifest is deleted directly by a user and not overwritten to
enter the pending delete_state, it is marked as `{deleted, true}`
inside #MANIFEST.props. When an uploading manifest completes, the
writing manifest will become the most recent active manifest.

When a user goes to read the key, the following occurs:
- If there is an existing manifest in the pending_delete or
  scheduled_delete state with {deleted, true} in props, and the
  delete_marked_time of that manifest is greater than the
  write_start_time of the most recent active manifest, then not_found
  is returned.
- If there is no existing manifest with {deleted, true} in props,
  then the most recent active manifest is returned.
- If there is an existing manifest with {deleted, true} in props,
  but the delete_marked_time is less than the write_start_time of
  the most recent active manifest, then the most recent active
  manifest is returned.

Do not show active manifests on read time if a delete occurred after writing started #533

fix riak_cs_manifest_utils:most_recent_active_manifest/2

gc active manifests that were in writing state when a deletion occured
and have since completed. #533

return a list of UUIDs not Manifests from riak_cs_manifest_utils:find_deleted_active_manifests/2

quickcheck property for the active manifest

add type specs and fix a bug in the active manifest handling found by quickcheck

fix spec with hint from dialyzer

fix dialyzer error

remove accidental .swp checkin

use a guard instead of case statement and shorten some clauses
