### PR TITLE
Bump lager version and add diagnostics

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -260,6 +260,12 @@
         %%       until sometime later.
         %% 'undefined' is for backward compatibility with v3 manifests
         %% written with Riak CS 1.2.2 or earlier.
+        %% Currently, the 'dead' property can be in props indicating
+        %% that this manifest was deleted while in the writing state.
+        %% The 'deleted' property may also exist on manifests in the
+        %% pending_delete and scheduled_delete states. This indicates
+        %% that the manifest was actually deleted by a user and not
+        %% due to an upload.
         props = [] :: 'undefined' | proplists:proplist(),
 
         %% cluster_id: A couple of uses, both short- and longer-term

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -260,12 +260,6 @@
         %%       until sometime later.
         %% 'undefined' is for backward compatibility with v3 manifests
         %% written with Riak CS 1.2.2 or earlier.
-        %% Currently, the 'dead' property can be in props indicating
-        %% that this manifest was deleted while in the writing state.
-        %% The 'deleted' property may also exist on manifests in the
-        %% pending_delete and scheduled_delete states. This indicates
-        %% that the manifest was actually deleted by a user and not
-        %% due to an upload.
         props = [] :: 'undefined' | proplists:proplist(),
 
         %% cluster_id: A couple of uses, both short- and longer-term

--- a/rebar.config
+++ b/rebar.config
@@ -29,11 +29,11 @@
         {node_package, "1.2.2", {git, "git://github.com/basho/node_package", {tag, "1.2.2"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.0"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.3.1.1"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "1.2.2"}}},
+        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0rc2"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}},
         {sext, ".*", {git, "git://github.com/esl/sext", {tag, "0.4.1"}}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", {tag, "1.3.0"}}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", {tag, "1.3.0-lager2.0"}}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.1p1"}}}

--- a/src/riak_cs_diags.erl
+++ b/src/riak_cs_diags.erl
@@ -1,0 +1,132 @@
+-module(riak_cs_diags).
+-behaviour(gen_server).
+
+-include("riak_cs.hrl").
+
+%% API
+-export([start_link/0,
+         print_manifests/2,
+         print_manifest/3]).
+
+-define(INDENT_LEVEL, 4).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {}).
+
+-spec start_link() -> {ok, pid()} | {error, term()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec print_manifests(binary() | string(), binary() | string()) -> string().
+print_manifests(Bucket, Key) when is_list(Bucket), is_list(Key) ->
+    print_manifests(list_to_binary(Bucket), list_to_binary(Key));
+print_manifests(Bucket, Key) ->
+    Manifests = gen_server:call(?MODULE, {get_manifests, Bucket, Key}),
+    Rows = manifest_rows(orddict_values(Manifests)),
+    table:print(manifest_table_spec(), Rows).
+
+-spec print_manifest(binary() | string(), binary() | string(), binary() | string()) -> string().
+print_manifest(Bucket, Key, Uuid) when is_list(Bucket), is_list(Key) ->
+    print_manifest(list_to_binary(Bucket), list_to_binary(Key), Uuid);
+print_manifest(Bucket, Key, Uuid) when is_list(Uuid) ->
+    print_manifest(Bucket, Key, mochihex:to_bin(Uuid));
+print_manifest(Bucket, Key, Uuid) ->
+    Manifests = gen_server:call(?MODULE, {get_manifests, Bucket, Key}),
+    {ok, Manifest} = orddict:find(Uuid, Manifests),
+    io:format("\n~s", [pr(Manifest)]).
+
+-spec pr(tuple()) -> iolist().
+pr(Record) ->
+    pr(Record, 0).
+
+-spec pr(tuple(), non_neg_integer()) -> iolist().
+pr(Record, Indent) ->
+    {'$lager_record', RecordName, Zipped} = lager:pr(Record, ?MODULE), 
+    ["\n", spaces(Indent), "#", atom_to_list(RecordName),
+     "\n", spaces(Indent), "--------------------\n", 
+     [print_field(Field, Indent) || Field <- Zipped]].
+
+print_field({_, undefined}, _) ->
+    "";
+print_field({uuid, Uuid}, Indent) when is_binary(Uuid) ->
+    print_field({uuid, mochihex:to_hex(Uuid)}, Indent);
+print_field({content_md5, Value}, Indent) when is_binary(Value) ->
+    print_field({content_md5, mochihex:to_hex(Value)}, Indent);
+print_field({upload_id, Value}, Indent) when is_binary(Value) ->
+    print_field({upload_id, mochihex:to_hex(Value)}, Indent);
+print_field({part_id, Value}, Indent) when is_binary(Value) ->
+    print_field({part_id, mochihex:to_hex(Value)}, Indent);
+print_field({acl, Value}, Indent) ->
+    io_lib:format("~s~s = ~s\n\n", [spaces(Indent), acl, pr(Value, Indent + 1)]);
+print_field({props, Props}, Indent) ->
+    io_lib:format("~s~s = ~s\n\n", [spaces(Indent), multipart, 
+                                    print_multipart_manifest(Props, Indent)]);
+print_field({parts, Parts}, Indent) ->
+    io_lib:format("~s~s = ~s\n\n", [spaces(Indent), parts, 
+                                  [pr(P, Indent + 1) ||  P <- Parts]]);
+print_field({Key, Value}, Indent) ->
+    io_lib:format("~s~s = ~p\n", [spaces(Indent), Key, Value]).
+
+orddict_values(Dict) ->
+    [Val || {_, Val} <- orddict:to_list(Dict)].
+
+spaces(Num) ->
+    [" " || _ <- lists:seq(1, Num*?INDENT_LEVEL)].
+
+%% ====================================================================
+%% Table Specifications and Record to Row conversions
+%% ====================================================================
+manifest_table_spec() ->
+    [{state, 20}, {deleted, 8},  {mp, 6}, {created, 28}, {uuid, 36}, 
+     {write_start_time, 23}, {delete_marked_time, 23}].
+
+manifest_rows(Manifests) ->
+    [ [M?MANIFEST.state, deleted(M?MANIFEST.props),
+       riak_cs_mp_utils:is_multipart_manifest(M), 
+       M?MANIFEST.created, mochihex:to_hex(M?MANIFEST.uuid),
+       M?MANIFEST.write_start_time, M?MANIFEST.delete_marked_time] || M <- Manifests].
+
+print_multipart_manifest(Props, Indent) ->
+    case lists:keyfind(multipart, 1, Props) of
+        {multipart, MpManifest} -> 
+            pr(MpManifest, Indent + 1);
+        _ ->
+            ""
+    end.
+
+deleted(Props) ->
+    lists:keymember(deleted, 1, Props).
+
+%% ====================================================================
+%% gen_server callbacks
+%% ====================================================================
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({get_manifests, Bucket, Key}, _From, State) ->
+    {ok, Pid} = riak_cs_utils:riak_connection(),
+    try
+        {ok, _, Manifests} = riak_cs_utils:get_manifests(Pid, Bucket, Key),
+        {reply, Manifests, State}
+    catch _:_=E ->
+        {reply, {error, E}, State}
+    after
+        riak_cs_utils:close_riak_connection(Pid)
+    end.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+

--- a/src/riak_cs_diags.erl
+++ b/src/riak_cs_diags.erl
@@ -20,7 +20,7 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec print_manifests(binary() | string(), binary() | string()) -> string().
+-spec print_manifests(_, _) -> ok.
 print_manifests(Bucket, Key) when is_list(Bucket), is_list(Key) ->
     print_manifests(list_to_binary(Bucket), list_to_binary(Key));
 print_manifests(Bucket, Key) ->
@@ -28,7 +28,7 @@ print_manifests(Bucket, Key) ->
     Rows = manifest_rows(orddict_values(Manifests)),
     table:print(manifest_table_spec(), Rows).
 
--spec print_manifest(binary() | string(), binary() | string(), binary() | string()) -> string().
+-spec print_manifest(_, _, _) -> ok.
 print_manifest(Bucket, Key, Uuid) when is_list(Bucket), is_list(Key) ->
     print_manifest(list_to_binary(Bucket), list_to_binary(Key), Uuid);
 print_manifest(Bucket, Key, Uuid) when is_list(Uuid) ->

--- a/src/riak_cs_diags.erl
+++ b/src/riak_cs_diags.erl
@@ -20,7 +20,7 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec print_manifests(_, _) -> ok.
+-spec print_manifests(binary() | string(), binary() | string()) -> ok.
 print_manifests(Bucket, Key) when is_list(Bucket), is_list(Key) ->
     print_manifests(list_to_binary(Bucket), list_to_binary(Key));
 print_manifests(Bucket, Key) ->
@@ -28,7 +28,7 @@ print_manifests(Bucket, Key) ->
     Rows = manifest_rows(orddict_values(Manifests)),
     table:print(manifest_table_spec(), Rows).
 
--spec print_manifest(_, _, _) -> ok.
+-spec print_manifest(binary() | string(), binary() | string(), binary() | string()) -> ok.
 print_manifest(Bucket, Key, Uuid) when is_list(Bucket), is_list(Key) ->
     print_manifest(list_to_binary(Bucket), list_to_binary(Key), Uuid);
 print_manifest(Bucket, Key, Uuid) when is_list(Uuid) ->

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -54,7 +54,8 @@
          upload_part/6, upload_part/7,
          upload_part_1blob/2,
          upload_part_finished/7, upload_part_finished/8,
-         user_rec_to_3tuple/1
+         user_rec_to_3tuple/1,
+         is_multipart_manifest/1
         ]).
 -export([get_mp_manifest/1]).
 

--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -89,6 +89,8 @@ process_specs() ->
     PutFsmSup = {riak_cs_put_fsm_sup,
                  {riak_cs_put_fsm_sup, start_link, []},
                  permanent, 5000, worker, dynamic},
+    DiagsSup = {riak_cs_diags, {riak_cs_diags, start_link, []},
+                   permanent, 5000, worker, dynamic},
     [Archiver,
      Storage,
      GC,
@@ -96,7 +98,8 @@ process_specs() ->
      ListObjectsETSCacheSup,
      DeleteFsmSup,
      GetFsmSup,
-     PutFsmSup].
+     PutFsmSup,
+     DiagsSup].
 
 -spec get_option_val({atom(), term()} | atom()) -> {atom(), term()}.
 get_option_val({Option, Default}) ->

--- a/src/table.erl
+++ b/src/table.erl
@@ -1,0 +1,84 @@
+-module(table).
+
+%% API
+-export([print/2,
+         create_table/2]).
+
+-spec print(list(), list()) -> ok.
+print(Spec, Rows) ->
+    Table = create_table(Spec, Rows),
+    io:format("~s", [Table]).
+
+-spec create_table(list(), list()) -> iolist().
+create_table(Spec, Rows) ->
+    Length = get_row_length(Spec),
+    create_table(Spec, Rows, Length, []).
+
+-spec create_table(list(), list(), non_neg_integer(), iolist()) -> iolist().
+create_table(Spec, Rows, Length, []) ->
+    FirstThreeRows = [vertical_border(Length), titles(Spec), vertical_border(Length)],
+    create_table(Spec, Rows, Length, FirstThreeRows);
+create_table(_Spec, [], Length, IoList) when length(IoList) =:= 2 ->
+    BottomBorder = vertical_border(Length),
+    %% There are no more rows to print so return the table
+    lists:reverse([BottomBorder | IoList]);
+create_table(_Spec, [], _Length, IoList) ->
+    lists:reverse(IoList);
+create_table(Spec, [Row | Rows], Length, IoList) ->
+    create_table(Spec, Rows, Length, [row(Spec, Row) | IoList]).
+
+-spec get_row_length(list(tuple())) -> non_neg_integer().
+get_row_length(Spec) ->
+    lists:foldl(fun({_Name, Size}, Total) ->
+                    Total + Size + 2 
+                end, 0, Spec) + 2.
+
+-spec row(list(), list(string())) -> iolist().
+row(Spec, Row) ->
+    ["| " | lists:reverse(
+        ["\n" | lists:foldl(fun({{_, Size}, Str}, Acc) ->
+                                [align(Str, Size) | Acc]
+                            end, [], lists:zip(Spec, Row))])].
+
+-spec titles(list()) -> iolist().
+titles(Spec) ->
+    [ "| " | lists:reverse(
+        ["\n" | lists:foldl(fun({Title, Size}, TitleRow) ->
+                               [align(atom_to_list(Title), Size) | TitleRow]
+                            end, [], Spec)])].
+
+-spec align(string(), non_neg_integer()) -> iolist().
+align(undefined, Size) ->
+    align("", Size);
+align(Str, Size) when is_integer(Str) ->
+    align(integer_to_list(Str), Size);
+align(Str, Size) when is_binary(Str) ->
+    align(binary_to_list(Str), Size);
+align(Str, Size) when is_atom(Str) ->
+    align(atom_to_list(Str), Size);
+align(Str, Size) when is_list(Str), length(Str) > Size -> 
+    Truncated = lists:sublist(Str, Size),
+    Truncated ++ " |"; 
+align(Str, Size) when is_list(Str), length(Str) =:= Size ->
+    Str ++ " |";
+align(Str, Size) when is_list(Str) ->
+    StrLen = length(Str),
+    LeftSpaces = (Size - StrLen) div 2,
+    RightSpaces = Size - StrLen - LeftSpaces,
+    spaces(LeftSpaces) ++ Str ++ spaces(RightSpaces) ++ " |";
+align(Term, Size) ->
+    Str = lists:flatten(io_lib:format("~p", [Term])),
+    align(Str, Size).
+
+-spec vertical_border(non_neg_integer()) -> string().
+vertical_border(Length) ->
+    lists:reverse(["\n" | char_seq(Length, $-)]).
+
+-spec spaces(non_neg_integer()) -> string().
+spaces(Length) ->
+    char_seq(Length, $\s).
+
+-spec char_seq(non_neg_integer(), char()) -> string().
+char_seq(Length, Char) ->
+    [Char || _ <- lists:seq(1, Length)].
+


### PR DESCRIPTION
start of a diagnostics module for running systems

start of a table module and table of manifests

working tables and one for manifests

more useful manifest tables

bump lager to 2.0 and use a velvet tag that supports lager 2.0

pretty print manifests now

remove "dead" column from manifest table
