### PR TITLE
Updated object metadata can be lost during manifest resolution

### DIFF
--- a/src/riak_cs_manifest_resolution.erl
+++ b/src/riak_cs_manifest_resolution.erl
@@ -93,14 +93,13 @@ resolve_manifests(_, _,
 resolve_manifests(_, _,
                   ?MANIFEST{state = active,acl=A1Acl} = A,
                   ?MANIFEST{state = active,acl=A2Acl} = B) ->
-    ACL = case A1Acl?ACL.creation_time >= A2Acl?ACL.creation_time of
-              true ->
-                  A1Acl;
-              false ->
-                  A2Acl
-          end,
     Props = resolve_props(A, B),
-    A?MANIFEST{acl=ACL, props = Props};
+    case A1Acl?ACL.creation_time >= A2Acl?ACL.creation_time of
+        true ->
+            A?MANIFEST{props = Props};
+        false ->
+            B?MANIFEST{props = Props}
+    end;
 
 resolve_manifests(_, _,
                   ?MANIFEST{state = pending_delete} = A,


### PR DESCRIPTION
A copy operation of an object to itself to update the object's
metadata can result in the updated metadata being lost during manifest
conflict resolution. In the case that there are two manifests in the
active state the ACL creation time is used as conflict resolution
criteria. Currently, the most recent ACL and the resolved manifest
properties are set in the manifest record that is given as the first
parameter to the resolution function and other fields of the manifest
record are ignored. Therefore, if the most recent active manifest is
given as the second parameter and includes an updated value for its
manifest metadata field, that updated metadata is lost. This change
makes sure all fields of the active manifest with the most recent ACL
are preserved.
