### PR TITLE
Fixed default StorageClass from 'regular' to 'standard' per API spec

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -354,7 +354,7 @@
     owner_key_id :: string(),
 
     %% storage class: no real options here
-    storage_class = regular,
+    storage_class = standard,
 
     %% Time that the upload was initiated
     initiated :: string() %% conflict of func vs. type: riak_cs_wm_utils:iso_8601_datetime()


### PR DESCRIPTION
The API spec defines the possible options of StorageClass:

> StorageClass  
> The class of storage (STANDARD or REDUCED_REDUDANCY) that will be used to store the object when the multipart upload is complete.

This pull changes the default from REGULAR to STANDARD.
