### PR TITLE
Support reformat indexes in multibackend

### DIFF
--- a/src/riak_cs_kv_multi_backend.erl
+++ b/src/riak_cs_kv_multi_backend.erl
@@ -38,7 +38,11 @@
          fold_objects/4,
          is_empty/1,
          status/1,
-         callback/3]).
+         callback/3,
+         fix_index/3,
+         set_legacy_indexes/2,
+         mark_indexes_fixed/2,
+         fixed_index_status/1]).
 
 -ifdef(TEST).
 -ifdef(TEST_IN_RIAK_KV).
@@ -47,7 +51,7 @@
 -endif.
 
 -define(API_VERSION, 1).
--define(CAPABILITIES, [async_fold]).
+-define(CAPABILITIES, [async_fold, index_reformat]).
 
 -record (state, {backends :: [{atom(), atom(), term()}],
                  bprefix_list :: [{binary(), atom()}],
@@ -118,12 +122,12 @@ capabilities(State) ->
     %% Expose ?CAPABILITIES plus the intersection of all child
     %% backends. (This backend creates a shim for any backends that
     %% don't support async_fold.)
-    F = fun({_, Mod, ModState}, Acc) ->
+    F = fun(Mod, ModState) ->
                 {ok, S1} = Mod:capabilities(ModState),
-                S2 = ordsets:from_list(S1),
-                ordsets:intersection(Acc, S2)
+                ordsets:from_list(S1)
         end,
-    Caps1 = lists:foldl(F, ordsets:new(), State#state.backends),
+    AllCaps = [F(Mod, ModState) || {_, Mod, ModState} <- State#state.backends],
+    Caps1 = ordsets:intersection(AllCaps),
     Caps2 = ordsets:to_list(Caps1),
 
     Capabilities = lists:usort(?CAPABILITIES ++ Caps2),
@@ -339,7 +343,12 @@ is_empty(#state{backends=Backends}) ->
 -spec status(state()) -> [{atom(), term()}].
 status(#state{backends=Backends}) ->
     %% @TODO Reexamine how this is handled
-    [{N, Mod:status(ModState)} || {N, Mod, ModState} <- Backends].
+    %% all backend mods return a proplist from Mod:status/1
+    %% So as to tag the backend with its mod, without
+    %% breaking this API list of two tuples return,
+    %% add the tuple {mod, Mod} to the status for each
+    %% backend.
+    [{N, [{mod, Mod} | Mod:status(ModState)]} || {N, Mod, ModState} <- Backends].
 
 %% @doc Register an asynchronous callback
 -spec callback(reference(), any(), state()) -> {ok, state()}.
@@ -348,6 +357,90 @@ callback(Ref, Msg, #state{backends=Backends}=State) ->
     %% filter out if they need it.
     _ = [Mod:callback(Ref, Msg, ModState) || {_N, Mod, ModState} <- Backends],
     {ok, State}.
+
+set_legacy_indexes(State=#state{backends=Backends}, WriteLegacy) ->
+    NewBackends = [{I, Mod, maybe_set_legacy_indexes(Mod, ModState, WriteLegacy)} ||
+                      {I, Mod, ModState} <- Backends],
+    State#state{backends=NewBackends}.
+
+maybe_set_legacy_indexes(Mod, ModState, WriteLegacy) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> Mod:set_legacy_indexes(ModState, WriteLegacy);
+        false -> ModState
+    end.
+
+mark_indexes_fixed(State=#state{backends=Backends}, ForUpgrade) ->
+    NewBackends = mark_indexes_fixed(Backends, [], ForUpgrade),
+    {ok, State#state{backends=NewBackends}}.
+
+mark_indexes_fixed([], NewBackends, _) ->
+    lists:reverse(NewBackends);
+mark_indexes_fixed([{I, Mod, ModState} | Backends], NewBackends, ForUpgrade) ->
+    Res = maybe_mark_indexes_fixed(Mod, ModState, ForUpgrade),
+    case Res of
+        {error, Reason} ->
+            {error, Reason};
+        {ok, NewModState} ->
+            mark_indexes_fixed(Backends, [{I, Mod, NewModState} | NewBackends], ForUpgrade)
+    end.
+
+maybe_mark_indexes_fixed(Mod, ModState, ForUpgrade) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> Mod:mark_indexes_fixed(ModState, ForUpgrade);
+        false -> {ok, ModState}
+    end.
+
+fix_index(BKeys, ForUpgrade, State) ->
+    % Group keys per bucket 
+    PerBucket = lists:foldl(fun(BK={B,_},D) -> dict:append(B,BK,D) end, dict:new(), BKeys),
+    Result = 
+        dict:fold(
+            fun(Bucket, StorageKey, Acc = {Success, Ignore, Errors}) ->
+                {_, Mod,  ModState} = Backend = get_backend(Bucket, State),
+                case backend_can_index_reformat(Mod, ModState) of
+                    true -> 
+                            {S, I, E} = backend_fix_index(Backend, Bucket, 
+                                                          StorageKey, ForUpgrade),
+                            {Success + S, Ignore + I, Errors + E};
+                    false -> 
+                            Acc
+                end
+            end, {0, 0, 0}, PerBucket),
+    {reply, Result, State}.
+
+backend_fix_index({_, Mod, ModState}, Bucket, StorageKey, ForUpgrade) ->
+    case Mod:fix_index(StorageKey, ForUpgrade, ModState) of
+        {reply, Reply, _UpModState} -> 
+            Reply;
+        {error, Reason} ->
+           lager:error("Failed to fix index for bucket ~p, key ~p, backend ~p: ~p",
+                       [Bucket, StorageKey, Mod, Reason]),
+            {0, 0, length(StorageKey)}
+    end.
+
+-spec fixed_index_status(state()) -> boolean().
+fixed_index_status(#state{backends=Backends}) ->
+    lists:foldl(fun({_N, Mod, ModState}, Acc) ->
+                        Status = Mod:status(ModState),
+                        case fixed_index_status(Mod, ModState, Status) of
+                            undefined -> Acc;
+                            Res ->
+                                case Acc of
+                                    undefined -> Res;
+                                    _ -> Res andalso Acc
+                                end
+                        end
+                end,
+                undefined,
+                Backends).
+
+fixed_index_status(Mod, ModState, Status) ->
+    case backend_can_index_reformat(Mod, ModState) of
+        true -> proplists:get_value(fixed_indexes, Status);
+        false -> undefined
+    end.
+
+
 
 %% ===================================================================
 %% Internal functions
@@ -436,29 +529,45 @@ backend_fold_fun(ModFun, FoldFun, Opts, AsyncFold) ->
             %% Get the backend capabilities to determine
             %% if it supports asynchronous folding.
             {ok, ModCaps} = Module:capabilities(SubState),
-            case AsyncFold andalso
-                lists:member(async_fold, ModCaps) of
-                true ->
-                    AsyncWork =
-                        fun(Acc1) ->
-                                Module:ModFun(FoldFun,
-                                              Acc1,
-                                              Opts,
-                                              SubState)
-                        end,
-                    {Acc, [AsyncWork | WorkList]};
-                false ->
-                    Result = Module:ModFun(FoldFun,
-                                           Acc,
-                                           Opts,
-                                           SubState),
-                    case Result of
-                        {ok, Acc1} ->
-                            {Acc1, WorkList};
-                        {error, Reason} ->
-                            throw({error, {Module, Reason}})
-                    end
+            DoAsync = AsyncFold andalso lists:member(async_fold, ModCaps),
+            Indexes = lists:keyfind(index, 1, Opts),
+            case Indexes of
+                {index, incorrect_format, _ForUpgrade} ->
+                    case lists:member(index_reformat, ModCaps) of
+                        true -> backend_fold_fun(Module, ModFun, SubState, FoldFun,
+                                                 Opts, {Acc, WorkList}, DoAsync);
+                        false -> {Acc, WorkList}
+                    end;
+                _ ->
+                    backend_fold_fun(Module,
+                                     ModFun,
+                                     SubState,
+                                     FoldFun,
+                                     Opts,
+                                     {Acc, WorkList},
+                                     DoAsync)
             end
+    end.
+
+backend_fold_fun(Module, ModFun, SubState, FoldFun, Opts, {Acc, WorkList}, true) ->
+    AsyncWork =
+        fun(Acc1) ->
+                Module:ModFun(FoldFun,
+                              Acc1,
+                              Opts,
+                              SubState)
+        end,
+    {Acc, [AsyncWork | WorkList]};
+backend_fold_fun(Module, ModFun, SubState, FoldFun, Opts, {Acc, WorkList}, false) ->
+    Result = Module:ModFun(FoldFun,
+                           Acc,
+                           Opts,
+                           SubState),
+    case Result of
+        {ok, Acc1} ->
+            {Acc1, WorkList};
+        {error, Reason} ->
+            throw({error, {Module, Reason}})
     end.
 
 async_fold_fun() ->
@@ -510,6 +619,10 @@ match_bucket_prefix(Bucket, [{Prefix, Name}|BPrefixList]) ->
             match_bucket_prefix(Bucket, BPrefixList)
     end.
 
+
+backend_can_index_reformat(Mod, ModState) ->
+    {ok, Caps} = Mod:capabilities(ModState),
+    lists:member(index_reformat, Caps).
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_cs_kv_multi_backend.erl
+++ b/src/riak_cs_kv_multi_backend.erl
@@ -413,7 +413,7 @@ backend_fix_index({_, Mod, ModState}, Bucket, StorageKey, ForUpgrade) ->
         {reply, Reply, _UpModState} -> 
             Reply;
         {error, Reason} ->
-           lager:error("Failed to fix index for bucket ~p, key ~p, backend ~p: ~p",
+           _ = lager:error("Failed to fix index for bucket ~p, key ~p, backend ~p: ~p",
                        [Bucket, StorageKey, Mod, Reason]),
             {0, 0, length(StorageKey)}
     end.

--- a/xref.ignore-warnings
+++ b/xref.ignore-warnings
@@ -3,9 +3,9 @@ src/riak_cs_storage.erl:67: Warning object_size_map/3 calls undefined function r
 Warning map_keys_and_manifests/3 calls undefined function riak_object:get_values/1
 Warning map_keys_and_manifests/3 calls undefined function riak_object:key/1
 ######## kv backends calling into kv/core code
-src/riak_cs_kv_multi_backend.erl:369: Warning get_backend_bucketprops/2 calls undefined function riak_core_bucket:get_bucket/1
-src/riak_cs_kv_multi_backend.erl:142: Warning start/2 calls undefined function app_helper:get_prop_or_env/3
-src/riak_cs_kv_multi_backend.erl:142: Warning start/2 calls undefined function app_helper:get_prop_or_env/4
+src/riak_cs_kv_multi_backend.erl:462: Warning get_backend_bucketprops/2 calls undefined function riak_core_bucket:get_bucket/1
+src/riak_cs_kv_multi_backend.erl:146: Warning start/2 calls undefined function app_helper:get_prop_or_env/4
+src/riak_cs_kv_multi_backend.erl:146: Warning start/2 calls undefined function app_helper:get_prop_or_env/3
 src/riak_kv_fs2_backend.erl:89: Warning start/2 calls undefined function app_helper:get_prop_or_env/3
 src/riak_kv_fs2_backend.erl:89: Warning start/2 calls undefined function riak:stop/1
 src/riak_cs_block_server.erl:172: Warning handle_cast/2 calls undefined function riak_repl_pb_api:get/5


### PR DESCRIPTION
Fixes #572
## Background
- [Original Riak issue](basho/riak_kv#499)
- [The main Riak kv fix](basho/riak_kv#504) (the squashed PR is basho/riak_kv#516)

The changes that were made to the multi backend in Riak KV were not ported
to the Riak CS specific multi backend. This PR addresses that.
## The fix

See the first commit (135a10ee2584b4531b452daf92c3d06333abf3c4) message for details about how this patch was applied.
## Testing
1. Convince yourself that the current implementation (develop branch) is broken: Run Riak 1.3.1
   and try the `riak-admin reformat-indexes` call. Note that it breaks because
   the Riak CS multibackend doesn't support the command.
2. For this test, you'll run this branch of Riak CS the whole time. First,
   start a new cluster/node with Riak 1.3.0 or earlier. Write some data into it with Riak
   CS. Move the datadir, upgrade the node to 1.3.1 and then copy the data dir back in.
   Start the node and now see if you can succesfully run the `riak-admin reformat-indexes`
   command.
