### PR TITLE
make error out in not finding git@github.com:basho/riak_repl_pb_api.git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ package.src: deps
 	mkdir -p package
 	rm -rf package/$(PKG_ID)
 	git archive --format=tar --prefix=$(PKG_ID)/ $(PKG_REVISION)| (cd package && tar -xf -)
+	cp rebar.config.script package/$(PKG_ID)
 	make -C package/$(PKG_ID) deps
 	for dep in package/$(PKG_ID)/deps/*; do \
              echo "Processing dep: $${dep}"; \

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,13 @@
-case os:getenv("RIAK_CS_EE_DEPS") of
+
+UseEEDeps = case os:getenv("RIAK_CS_EE_DEPS") of
+                false ->
+                    false;
+                [] ->
+                    false;
+                _ ->
+                    true
+            end,
+case UseEEDeps of
     false ->
         Bytes = "%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
@@ -26,7 +35,7 @@ case os:getenv("RIAK_CS_EE_DEPS") of
 {solaris_pkgname, \"BASHOriak-cs\"}.",
         file:write_file("pkg.vars.config", Bytes),
         CONFIG;
-    _ ->
+    true ->
         case lists:keysearch(deps, 1, CONFIG) of
             {value, {deps, Deps}} ->
                 Bytes = "%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-


### PR DESCRIPTION
hi, when I issue make it fails at  not able to get the git@github.com:basho/riak_repl_pb_api.git

From rebar.config.script, it says the repo is under solaris_pkgname line 59
  {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.2"}}}

Comment that out, build is successful. So does that repo has impact on functionality? Or it is it just unimportant?
