### PR TITLE
Can't do multi-part uploads with query string authentication

### DIFF
--- a/src/riak_cs_s3_auth.erl
+++ b/src/riak_cs_s3_auth.erl
@@ -126,6 +126,7 @@ calculate_signature(KeyData, RD) ->
            Date,
            AmazonHeaders,
            Resource],
+    lager:debug("STS: ~p", [STS]),
     base64:encode_to_string(
       crypto:sha_mac(KeyData, STS)).
 

--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -167,10 +167,10 @@ format_object_qs({SubResources, QueryParams}) ->
 -spec format_object_qs(subresources(), query_params(), string(), string()) -> string().
 format_object_qs(SubResources, QueryParams, [], []) ->
     [format_subresources(SubResources), format_query_params(QueryParams)];
-format_object_qs(_SubResources, _QueryParams, UploadId, []) ->
-    ["/uploads/", UploadId];
-format_object_qs(_SubResources, _QueryParams, UploadId, PartNum) ->
-    ["/uploads/", UploadId, "?partNumber=", PartNum].
+format_object_qs(_SubResources, QueryParams, UploadId, []) ->
+    ["/uploads/", UploadId, format_query_params(QueryParams)];
+format_object_qs(_SubResources, QueryParams, UploadId, PartNum) ->
+    ["/uploads/", UploadId, format_query_params([{"partNumber", PartNum} | QueryParams])].
 
 %% @doc Format a string that expresses the subresource request
 %% that can be appended to the URL.
@@ -355,6 +355,26 @@ rewrite_path_test() ->
     equal_paths("/buckets/testbucket/objects/testobject/uploads/2?partNumber=1",
                 rewrite_with(headers([{"host", "testbucket." ++ ?ROOT_HOST}]),
                              "/testobject?partNumber=1&uploadId=2")),
+    equal_paths("/buckets/testbucket/objects/testobject/uploads/2?AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR"
+                "&Expires=1364406757&Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D",
+                rewrite_with(headers([]),
+                             "/testbucket/testobject?Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D"
+                             "&Expires=1364406757&AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR&uploadId=2")),
+    equal_paths("/buckets/testbucket/objects/testobject/uploads/2?AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR"
+                "&Expires=1364406757&Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D",
+                rewrite_with(headers([{"host", "testbucket." ++ ?ROOT_HOST}]),
+                             "/testobject?Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D"
+                             "&Expires=1364406757&AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR&uploadId=2")),
+    equal_paths("/buckets/testbucket/objects/testobject/uploads/2?AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR"
+                "&Expires=1364406757&Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D&partNumber=1",
+                rewrite_with(headers([]),
+                             "/testbucket/testobject?Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D"
+                             "&Expires=1364406757&AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR&partNumber=1&uploadId=2")),
+    equal_paths("/buckets/testbucket/objects/testobject/uploads/2?AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR"
+                "&Expires=1364406757&Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D&partNumber=1",
+                rewrite_with(headers([{"host", "testbucket." ++ ?ROOT_HOST}]),
+                             "/testobject?Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D"
+                             "&Expires=1364406757&AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR&partNumber=1&uploadId=2")),
     equal_paths("/buckets/testbucket/objects/testobject?AWSAccessKeyId=BF_BI8XYKFJSIW-NNAIR"
                 "&Expires=1364406757&Signature=x%2B0vteNN1YillZNw4yDGVQWrT2s%3D",
                 rewrite_with(headers([]),


### PR DESCRIPTION
When multi-part uploads and query string authentication are used together, Riak CS raises several different exceptions.

I want to upload some files with an AJAX client. To this end, I need to apply the multi-part upload and the query string authentication. However, I met some problems.

The first issue is the lack of CORS support. I fixed that by setting up nginx to reply to `OPTIONS` requests with the correct headers.

After that, when uploading with the `PUT` method, Riak CS replies with a 405 (Method not allowed) HTTP code with no additional message.
If I use the `POST` method, I get a 403 (Forbidden) HTTP code and "Access Denied" in the XML response.

I tried with both URL formats:
- /bucket/key?Signature=X&Expires=X&AWSAccessKeyId=X&uploadId=X&partNumber=X
- /bucket/key/uploads/uploadId?Signature=X&Expires=X&AWSAccessKeyId=X&partNumber=X

My script works well on Amazon S3 (with the first URL format) but fails on Riak CS 1.3.1 on Debian 64-bits.
