### PR TITLE
Downloads of multi-part uploaded files fail with s3cmd and the Java client

### DIFF
--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -406,7 +406,7 @@ do_part_common2(complete, RiakcPid,
                           end,
                 NewManifest = Manifest?MANIFEST{state = active,
                                                 content_length = Bytes,
-                                                content_md5 = UUID,
+                                                content_md5 = {UUID, "-" ++ integer_to_list(ordsets:size(PartsToKeep))},
                                                 props = MProps2},
                 ok = riak_cs_manifest_fsm:add_new_manifest(ManiPid, NewManifest),
                 case PartsToDelete of

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -24,6 +24,7 @@
 
 %% Public API
 -export([etag_from_binary/1,
+         etag_from_binary/2,
          etag_from_binary_no_quotes/1,
          check_bucket_exists/2,
          chunked_md5/3,
@@ -100,6 +101,8 @@
 %% @doc Convert the passed binary into a string where the numbers are
 %% represented in hexadecimal (lowercase and 0 prefilled).
 -spec binary_to_hexlist(binary()) -> string().
+binary_to_hexlist({Bin, Suffix}) ->
+    binary_to_hexlist(Bin) ++ Suffix;
 binary_to_hexlist(Bin) ->
     XBin =
         [ begin
@@ -117,7 +120,15 @@ binary_to_hexlist(Bin) ->
 %% around it.
 -spec etag_from_binary(binary()) -> string().
 etag_from_binary(Binary) ->
-    "\"" ++ etag_from_binary_no_quotes(Binary) ++ "\"".
+    etag_from_binary(Binary, []).
+
+%% @doc Return a hexadecimal string of `Binary', with double quotes
+%% around it.
+-spec etag_from_binary(binary(), string()) -> string().
+etag_from_binary(Binary, []) ->
+    "\"" ++ etag_from_binary_no_quotes(Binary) ++ "\"";
+etag_from_binary(Binary, Suffix) ->
+    "\"" ++ etag_from_binary_no_quotes(Binary) ++ Suffix ++ "\"".
 
 %% @doc Return a hexadecimal string of `Binary', without double quotes
 %% around it.


### PR DESCRIPTION
s3cmd and the Amazon AWS Java client (and potentially others) require that the ETag returned  for multi-part uploaded files contain a "-" character.  This requirement is not captured in the API spec, and appears to be a quirk implemented in these clients.  The issue was discovered as part of CloudStack development and testing (see http://mail-archives.apache.org/mod_mbox/cloudstack-dev/201306.mbox/%3C77B337AF224FD84CBF8401947098DD87038FCD%40SJCPEX01CL01.citrite.net%3E).

Thanks to Edison Su (@edisonsu) and Min Chen for running down the issue.
