### PR TITLE
Fix regression in generate_etag function in riak_cs_wm_object

### DIFF
--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -132,7 +132,9 @@ etag_from_binary(Binary, Suffix) ->
 
 %% @doc Return a hexadecimal string of `Binary', without double quotes
 %% around it.
--spec etag_from_binary_no_quotes(binary()) -> string().
+-spec etag_from_binary_no_quotes(binary() | {binary(), string()}) -> string().
+etag_from_binary_no_quotes({Binary, Suffix}) ->
+    binary_to_hexlist(Binary) ++ Suffix;
 etag_from_binary_no_quotes(Binary) ->
     binary_to_hexlist(Binary).
 

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -129,7 +129,7 @@ content_types_provided(RD, Ctx=#context{local_context=LocalCtx,
 -spec generate_etag(#wm_reqdata{}, #context{}) -> {string(), #wm_reqdata{}, #context{}}.
 generate_etag(RD, Ctx=#context{local_context=LocalCtx}) ->
     Mfst = LocalCtx#key_context.manifest,
-    ETag = format_etag(Mfst?MANIFEST.content_md5),
+    ETag = riak_cs_utils:etag_from_binary_no_quotes(Mfst?MANIFEST.content_md5),
     {ETag, RD, Ctx}.
 
 -spec last_modified(#wm_reqdata{}, #context{}) -> {calendar:datetime(), #wm_reqdata{}, #context{}}.


### PR DESCRIPTION
This regression snuck in as part of e827ff1ce415b51d4aa374c16c3c00fa381833a1. 
The etag returned from generate_etag should not be quoted. This caused the 
object_get_conditional_test riak_test module to fail.
