### PR TITLE
Update `clj-aws-s3` to 0.4.2

### DIFF
--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,6 +1,6 @@
 (defproject java-s3-tests/java-s3-tests "0.0.1"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.reiddraper/clj-aws-s3 "0.4.1"]
+                 [com.reiddraper/clj-aws-s3 "0.4.2"]
                  [clj-http "0.7.1"]
                  [cheshire "5.1.0"]]
   :profiles {:dev {:dependencies [[midje "1.5.1"]]}}


### PR DESCRIPTION
This uses the Java AWS SJD 1.4.7 which eliminates some of the connection
reset errors we were seeing.
