### PR TITLE
Fix riak_test failures as a result of httpc

### DIFF
--- a/client_tests/erlang/erlcloud_eqc.erl
+++ b/client_tests/erlang/erlcloud_eqc.erl
@@ -208,7 +208,8 @@ initial_state_data(Host, Port, ProxyHost, ProxyPort) ->
     #api_state{aws_config=#aws_config{s3_host=Host,
                                       s3_port=Port,
                                       s3_prot="http",
-                                      http_options=[{proxy, {{ProxyHost, ProxyPort}, []}}, {keep_alive_timeout, 100}]}}.
+                                      http_options=[{proxy_host, ProxyHost},
+                                                    {proxy_port, ProxyPort}]}}.
 
 next_state_data(start, user_created, S, AwsConfig, _C) ->
     S#api_state{aws_config=AwsConfig};
@@ -339,16 +340,12 @@ item_to_record_field(_, User) ->
     User.
 
 compose_url(#aws_config{http_options=HTTPOptions}) ->
-    {Host, Port} = grab_host_port(HTTPOptions),
+    {_, Host} = lists:keyfind(proxy_host, 1, HTTPOptions),
+    {_, Port} = lists:keyfind(proxy_port, 1, HTTPOptions),
     compose_url(Host, Port).
 
 compose_url(Host, Port) ->
     lists:flatten(["http://", Host, ":", integer_to_list(Port), "/riak-cs/user"]).
-
-grab_host_port([{proxy, {{Host, Port}, _}} | _T]) ->
-    {Host, Port};
-grab_host_port([_H | T]) ->
-    grab_host_port(T).
 
 compose_request(Name, Email) ->
     binary_to_list(

--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,5 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", {tag, "1.3.0-lager2.0"}}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.1p1"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}
        ]}.

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -112,7 +112,7 @@ config(Key, Secret, Port) ->
                     ?DEFAULT_PROTO,
                     ?PROXY_HOST,
                     Port,
-                    [{keep_alive_timeout, 100}]).
+                    []).
 
 create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),

--- a/riak_test/tests/cs512_regression_test.erl
+++ b/riak_test/tests/cs512_regression_test.erl
@@ -44,7 +44,7 @@ delete(UserConfig) ->
 
 assert_notfound(UserConfig) ->
     ?assertException(_,
-        {aws_error, {http_error, 404, "Object Not Found", _}},
+        {aws_error, {http_error, 404, _, _}},
         erlcloud_s3:get_object(?BUCKET, ?KEY, UserConfig)).
 
 setup() ->

--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -137,7 +137,7 @@ upload_and_assert_parts(Bucket, Key, UploadId, PartCount, Size, Config) ->
 
 upload_and_assert_part(Bucket, Key, UploadId, PartNum, PartData, Config) ->
     {RespHeaders, _UploadRes} = erlcloud_s3_multipart:upload_part(Bucket, Key, UploadId, PartNum, PartData, Config),
-    PartEtag = proplists:get_value("etag", RespHeaders),
+    PartEtag = proplists:get_value("ETag", RespHeaders),
     PartsTerm = erlcloud_s3_multipart:parts_to_term(
                   erlcloud_s3_multipart:list_parts(Bucket, Key, UploadId, [], Config)),
     Parts = proplists:get_value(parts, PartsTerm),

--- a/riak_test/tests/object_get_conditional_test.erl
+++ b/riak_test/tests/object_get_conditional_test.erl
@@ -64,7 +64,7 @@ setup_object(Bucket, Key, UserConfig) ->
 
 before_and_after_of_last_modified(Obj) ->
     Headers = proplists:get_value(headers, Obj),
-    LastModified = proplists:get_value("last-modified", Headers),
+    LastModified = proplists:get_value("Last-Modified", Headers),
     LastModifiedErlDate = httpd_util:convert_request_date(LastModified),
     LastModifiedSec = calendar:datetime_to_gregorian_seconds(LastModifiedErlDate),
     Before = rfc1123_date(LastModifiedSec - 1),
@@ -113,9 +113,9 @@ normal_get_case(Bucket, Key, ExpectedContent, Options, UserConfig) ->
     ?assertEqual(ExpectedContent, proplists:get_value(content, Obj)).
 
 not_modified_case(Bucket, Key, Options, UserConfig) ->
-    ?assertError({aws_error, {http_error, 304, "Not Modified", _Body}},
+    ?assertError({aws_error, {http_error, 304, _, _Body}},
                 erlcloud_s3:get_object(Bucket, Key, Options, UserConfig)).
 
 precondition_failed_case(Bucket, Key, Options, UserConfig) ->
-    ?assertError({aws_error, {http_error, 412, "Precondition Failed", _Body}},
+    ?assertError({aws_error, {http_error, 412, _, _Body}},
                  erlcloud_s3:get_object(Bucket, Key, Options, UserConfig)).

--- a/riak_test/tests/object_get_test.erl
+++ b/riak_test/tests/object_get_test.erl
@@ -183,7 +183,7 @@ assert_content_range(Skip, Length, Size, Obj) ->
     Expected = lists:flatten(
                  io_lib:format("bytes ~B-~B/~B", [Skip, Skip + Length - 1, Size])),
     Headers = proplists:get_value(headers, Obj),
-    ContentRange = proplists:get_value("content-range", Headers),
+    ContentRange = proplists:get_value("Content-Range", Headers),
     ?assertEqual(Expected, ContentRange).
 
 %% TODO: riak_test includes its own mochiweb by escriptizing.
@@ -218,7 +218,7 @@ upload_parts(Bucket, Key, UploadId, Config, PartCount, [Size | Sizes], Contents,
     Content = crypto:rand_bytes(Size),
     {RespHeaders, _UploadRes} = erlcloud_s3_multipart:upload_part(
                                   Bucket, Key, UploadId, PartCount, Content, Config),
-    PartEtag = proplists:get_value("etag", RespHeaders),
+    PartEtag = proplists:get_value("ETag", RespHeaders),
     lager:debug("UploadId: ~p~n", [UploadId]),
     lager:debug("PartEtag: ~p~n", [PartEtag]),
     upload_parts(Bucket, Key, UploadId, Config, PartCount + 1,

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -127,27 +127,12 @@ confirm() ->
                 erlcloud_s3:list_objects(?TEST_BUCKET, U1C2Config))]),
 
     lager:info("check that the 2 other objects can't be read"),
-    %% XXX I expect errors here, but I get successful objects containing <<>>
-    %?assertError({aws_error, _}, erlcloud_s3:get_object(?TEST_BUCKET,
-            %"object_two")),
-    %?assertError({aws_error, _}, erlcloud_s3:get_object(?TEST_BUCKET,
-            %"object_three")),
-
-    Obj4 = erlcloud_s3:get_object(?TEST_BUCKET, "object_two", U1C2Config),
-
-    %% Check content of Obj4
-    ?assertEqual(<<>>, proplists:get_value(content, Obj4)),
-    %% Check content_length of Obj4
-    ?assertEqual(integer_to_list(byte_size(Object2)),
-        proplists:get_value(content_length, Obj4)),
-
-    Obj5 = erlcloud_s3:get_object(?TEST_BUCKET, "object_three", U1C2Config),
-
-    %% Check content of Obj5
-    ?assertEqual(<<>>, proplists:get_value(content, Obj5)),
-    %% Check content_length of Obj5
-    ?assertEqual(integer_to_list(byte_size(Object3)),
-        proplists:get_value(content_length, Obj5)),
+    %% We expect errors here since proxy_get will fail due to the
+    %% clusters being disconnected.
+    ?assertError({aws_error, _}, erlcloud_s3:get_object(?TEST_BUCKET,
+            "object_two", U1C2Config)),
+    ?assertError({aws_error, _}, erlcloud_s3:get_object(?TEST_BUCKET,
+            "object_three", U1C2Config)),
 
     lager:info("reconnect clusters"),
     repl_helpers:add_site(hd(BNodes), {Ip, Port, "site1"}),
@@ -160,8 +145,8 @@ confirm() ->
     repl_helpers:del_site(LeaderB, "site1"),
 
     lager:info("check we still can't read object_three"),
-    Obj7 = erlcloud_s3:get_object(?TEST_BUCKET, "object_three", U1C2Config),
-    ?assertEqual(<<>>, proplists:get_value(content, Obj7)),
+    ?assertError({aws_error, _}, erlcloud_s3:get_object(?TEST_BUCKET,
+            "object_three", U1C2Config)),
 
     lager:info("check that proxy getting object_two wrote it locally, so we"
         " can read it"),


### PR DESCRIPTION
This commit fixes riak_tests that fail due to erlcloud_s3 using httpc.
erlcloud was patched to use ibrowse instead of httpc and the following
changes support api changes required by erlcloud.

fix cs512_regression riak_test

fix object_get_test when using erlcloud_s3 with ibrowse

fix 3 more riak_test tests
