### PR TITLE
Align ERL_MAX_PORTS with Riak default: 64000

### DIFF
--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -17,7 +17,7 @@
 +W w
 
 ## Increase number of concurrent ports/sockets
--env ERL_MAX_PORTS 4096
+-env ERL_MAX_PORTS 64000
 
 ## Tweak GC to run more often 
 -env ERL_FULLSWEEP_AFTER 0


### PR DESCRIPTION
At some point Riak was bumped from 4096 by default to 64000. R16 is actually higher by default, at 65536.

We'll eventually have to address the fact that R17 moves this to +Q
