### PR TITLE
bucket policy: use X-Forwarded-For instead of peer

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -145,6 +145,12 @@
               %% 21600 is 6-hours.
               {gc_retry_interval, 21600},
 
+              %% If your load balancer adds 'X-Forwarded-For' header
+              %% and it is reliable (able to gaurantee it is not added
+              %% by malicious user), turn this true. Otherwise, by
+              %% default, Riak CS takes source IP address as an input.
+              {trust_x_forwarded_for, false},
+
               %% == DTrace ==
 
               %% If your Erlang virtual machine supports DTrace (or

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -40,7 +40,8 @@
          response_module/1,
          riak_cs_stat/0,
          set_md5_chunk_size/1,
-         use_t2b_compression/0
+         use_t2b_compression/0,
+         trust_x_forwarded_for/0
         ]).
 
 %% OpenStack config
@@ -221,6 +222,17 @@ proxy_get_active() ->
             _ = lager:warning("proxy_get value in app.config is invalid"),
             false;
         undefined -> false
+    end.
+
+-spec trust_x_forwarded_for() -> true | false.
+trust_x_forwarded_for() ->
+    case application:get_env(riak_cs, trust_x_forwarded_for) of
+        {ok, true} -> true;
+        {ok, false} -> false;    
+        {ok, _} ->
+            _ = lager:warning("trust_x_forwarded_for value in app.config is invalid"),
+            false;
+        undefined -> false %% secure by default!
     end.
 
 %% ===================================================================

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -28,6 +28,7 @@
 -include("riak_cs.hrl").
 -include("s3_api.hrl").
 -include_lib("webmachine/include/wm_reqdata.hrl").
+-include_lib("webmachine/include/wm_reqstate.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 
 %% Public API
@@ -492,7 +493,14 @@ eval_bool(#wm_reqdata{scheme=Scheme} = _Req, Conds) ->
 
 -spec eval_ip_address(#wm_reqdata{}, [{'aws:SourceIp', binary()}]) -> boolean().
 eval_ip_address(Req, Conds) ->
-    case parse_ip(Req#wm_reqdata.peer) of
+    IPAddress = case riak_cs_config:trust_x_forwarded_for() of
+                    true -> wrq:peer(Req);
+                    false ->
+                        ReqState = Req#wm_reqdata.wm_state,
+                        {ok, {Addr,_}} = inet:peername(ReqState#wm_reqstate.socket),
+                        inet_parse:ntoa(Addr)
+                end,
+    case parse_ip(IPAddress) of
         {error, _} ->
             false;
         {Peer, _} ->

--- a/test/riak_cs_s3_policy_eqc.erl
+++ b/test/riak_cs_s3_policy_eqc.erl
@@ -60,6 +60,7 @@ prop_ip_filter() ->
     ?FORALL({Policy0, Access0, IP, PrefixDigit},
             {policy_v1(), access_v1(), inet_ip_address_v4(), choose(0,32)},
             begin
+                application:set_env(riak_cs, trust_x_forwarded_for, true),
                 %% replace IP in the policy with prefix mask
                 Statement0 = hd(Policy0?POLICY.statement),
                 IPStr0 = lists:flatten(io_lib:format("~s/~p",
@@ -126,6 +127,7 @@ prop_secure_transport() ->
 prop_eval() ->
     ?FORALL({Policy, Access}, {policy_v1(), access_v1()},
             begin
+                application:set_env(riak_cs, trust_x_forwarded_for, true),
                 JsonPolicy = riak_cs_s3_policy:policy_to_json_term(Policy),
                 case riak_cs_s3_policy:eval(Access, JsonPolicy) of
                     true -> true;
@@ -138,19 +140,20 @@ prop_eval() ->
 prop_policy_v1()->
     ?FORALL(Policy, policy_v1(),
             begin
-                 JsonPolicy =
+                application:set_env(riak_cs, trust_x_forwarded_for, true),
+                JsonPolicy =
                     riak_cs_s3_policy:policy_to_json_term(Policy),
-                 {ok, PolicyFromJson} =
+                {ok, PolicyFromJson} =
                     riak_cs_s3_policy:policy_from_json(JsonPolicy),
                 (Policy?POLICY.id =:= PolicyFromJson?POLICY.id)
                     andalso
                       (Policy?POLICY.version =:= PolicyFromJson?POLICY.version)
-                andalso
-                lists:all(fun({LHS, RHS}) ->
-                                  riak_cs_s3_policy:statement_eq(LHS, RHS)
-                          end,
-                          lists:zip(Policy?POLICY.statement,
-                                    PolicyFromJson?POLICY.statement))
+                    andalso
+                    lists:all(fun({LHS, RHS}) ->
+                                      riak_cs_s3_policy:statement_eq(LHS, RHS)
+                              end,
+                              lists:zip(Policy?POLICY.statement,
+                                        PolicyFromJson?POLICY.statement))
             end).
 
 

--- a/test/riak_cs_s3_policy_test.erl
+++ b/test/riak_cs_s3_policy_test.erl
@@ -131,6 +131,19 @@ eval_ip_address_test()->
                                               [garbage,{chiba, boo},"saitama",
                                                {'aws:SourceIp', {{23,23,0,0},{255,255,0,0}}}, hage])).
 
+eval_ip_address_test_trust_x_forwarded_for_false_test() ->
+    application:set_env(riak_cs, trust_x_forwarded_for, false),
+    Conds = [garbage,{chiba, boo},"saitama",
+             {'aws:SourceIp', {{23,23,0,0},{255,255,0,0}}}, hage],
+    %% This test fails because it tries to use the socket from wm_reqstate to
+    %% get the peer address, but it's not a real wm request. 
+    %% If trust_x_forwarded_for = true, it would just use the peer address and the call would
+    %% succeed
+    ?assertError({badrecord, wm_reqstate},
+        riak_cs_s3_policy:eval_ip_address(#wm_reqdata{peer="23.23.23.23"}, Conds)),
+    %% Reset env for next test
+    application:set_env(riak_cs, trust_x_forwarded_for, true).
+
 eval_ip_addresses_test()->
     ?assert(riak_cs_s3_policy:eval_ip_address(#wm_reqdata{peer = "23.23.23.23"},
                                               [{'aws:SourceIp', {{1,1,1,1}, {255,255,255,0}}},

--- a/test/riak_cs_s3_policy_test.erl
+++ b/test/riak_cs_s3_policy_test.erl
@@ -96,6 +96,7 @@ sample_plain_allow_policy()->
       "}" >>.
 
 sample_policy_check_test()->
+    application:set_env(riak_cs, trust_x_forwarded_for, true),
     JsonPolicy0 = sample_plain_allow_policy(),
     {ok, Policy} = riak_cs_s3_policy:policy_from_json(JsonPolicy0),
     Access = #access_v1{method='GET', target=object, id="spam/ham/egg",
@@ -201,6 +202,7 @@ sample_securetransport_statement()->
 
 
 secure_transport_test()->
+    application:set_env(riak_cs, trust_x_forwarded_for, true),
     JsonPolicy0 = sample_securetransport_statement(),
     {ok, Policy} = riak_cs_s3_policy:policy_from_json(JsonPolicy0),
     Req = #wm_reqdata{peer="192.168.0.1", scheme=https},


### PR DESCRIPTION
> If riak-cs is behind a load balancer or reverse proxy, we should be looking for the IP address from a header, like [X-Forwarded-For](http://en.wikipedia.org/wiki/X-Forwarded-For). How about two app.config settings

from Reid's comment: https://github.com/basho/riak_cs/pull/364#discussion_r2543118
