### PR TITLE
Bugfix/s3conf test redirect

### DIFF
--- a/client_tests/python/ceph_tests/Makefile
+++ b/client_tests/python/ceph_tests/Makefile
@@ -17,7 +17,7 @@ $(DEPS) $(BIN): s3-tests env
 
 test: $(DEPS) $(BIN)
 	@echo $(CS_HTTP_PORT)
-	@./s3_conf.sh &> s3-tests/s3test.conf
+	@./s3_conf.sh > s3-tests/s3test.conf
 	@cd s3-tests && S3TEST_CONF=s3test.conf env/bin/nosetests s3tests.functional.test_s3
 
 clean:


### PR DESCRIPTION
After executing "make" at client_test/python/ceph_tests,
s3-tests/s3test.conf is empty and all tests fail on GNU/Linux(Ubuntu 12.10).

This PR intends to redirect command output to config file without make it background.

Memo:

Behaiviour of "&>" seems to be dependent on shells.
On Ubuntu Linux 12.10 ...

bash: output is redirected

```
    $ bash -c 'echo hoge &> out.txt'
    $ cat out.txt
    hoge
```

zsh: output is redirected

```
    $ rm out.txt
    $ zsh -c 'echo hoge &> out.txt'
    $ cat out.txt
    hoge
```

sh: output is shown in stdout and out.txt remains empty

```
    $ rm out.txt
    $ sh -c 'echo hoge &> out.txt'
    hoge
    $ cat out.txt
```
