### PR TITLE
Add config option to avoid local bucket check at creation time

### DIFF
--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -29,6 +29,7 @@
          auth_module/0,
          cluster_id/1,
          cs_version/0,
+         disable_local_bucket_check/0,
          enforce_multipart_part_size/0,
          get_env/3,
          key_list_multiplier/0,
@@ -123,6 +124,10 @@ admin_auth_enabled() ->
 -spec auth_module() -> atom().
 auth_module() ->
     get_env(riak_cs, auth_module, ?DEFAULT_AUTH_MODULE).
+
+-spec disable_local_bucket_check() -> boolean().
+disable_local_bucket_check() ->
+    get_env(riak_cs, disable_local_bucket_check, false).
 
 -spec enforce_multipart_part_size() -> boolean().
 enforce_multipart_part_size() ->
@@ -228,7 +233,7 @@ proxy_get_active() ->
 trust_x_forwarded_for() ->
     case application:get_env(riak_cs, trust_x_forwarded_for) of
         {ok, true} -> true;
-        {ok, false} -> false;    
+        {ok, false} -> false;
         {ok, _} ->
             _ = lager:warning("trust_x_forwarded_for value in app.config is invalid"),
             false;

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -184,7 +184,8 @@ create_bucket(User, UserObj, Bucket, ACL, RiakPid) ->
     CurrentBuckets = get_buckets(User),
 
     %% Do not attempt to create bucket if the user already owns it
-    AttemptCreate = not bucket_exists(CurrentBuckets, binary_to_list(Bucket)),
+    AttemptCreate = riak_cs_config:disable_local_bucket_check() orelse
+        not bucket_exists(CurrentBuckets, binary_to_list(Bucket)),
     case AttemptCreate of
         true ->
             case valid_bucket_name(Bucket) of


### PR DESCRIPTION
Add a disable_local_bucket check option to disable local checking for a
bucket's existence when determining if a bucket creation request should be
sent to stanchion. The default is false and represents an optimization for
work flows that unnecessarily create the same bucket many times. Setting it to
true can help in situations where the user's view of bucket ownership differs
from the canonical ownership record.
