### PR TITLE
add riak-cs-stanchion command to switch stanchion manually

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -20,7 +20,7 @@ case UseEEDeps of
 {package_install_user, \"riakcs\"}.
 {package_install_group, \"riak\"}.
 {package_install_user_desc, \"Riak CS user\"}.
-{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}]]}}.
+{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}], [{name, \"riak-cs-stanchion\"}]]}}.
 {package_shortdesc, \"Riak CS\"}.
 {package_patch_dir, \"basho-patches\"}.
 {package_desc, \"Riak CS\"}.

--- a/rel/files/riak-cs-stanchion
+++ b/rel/files/riak-cs-stanchion
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Pull environment for this install
+. "{{runner_base_dir}}/lib/env.sh"
+
+# Make sure the user running this script is the owner and/or su to that user
+check_user $@
+
+# Make sure CWD is set to runner run dir
+cd $RUNNER_BASE_DIR
+
+# Check the first argument for instructions
+case "$1" in
+    switch|show)
+        # Make sure the local node IS running
+        node_up_check
+
+        $NODETOOL rpc riak_cs_stanchion_console $@
+        ;;
+    *)
+        echo "Usage: $SCRIPT { switch HOST PORT | show }"
+        exit 1
+        ;;
+esac

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -69,5 +69,6 @@
            %% Copy additional bin scripts
            {template, "files/riak-cs-access", "bin/riak-cs-access"},
            {template, "files/riak-cs-storage", "bin/riak-cs-storage"},
-           {template, "files/riak-cs-gc", "bin/riak-cs-gc"}
+           {template, "files/riak-cs-gc", "bin/riak-cs-gc"},
+           {template, "files/riak-cs-stanchion", "bin/riak-cs-stanchion"}
           ]}.

--- a/src/riak_cs_stanchion_console.erl
+++ b/src/riak_cs_stanchion_console.erl
@@ -1,0 +1,75 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc These functions are used by the riak-cs-gc command line script.
+
+-module(riak_cs_stanchion_console).
+
+-export([
+         switch/1,
+         show/1
+        ]).
+
+-define(SAFELY(Code, Description),
+        try
+            Code
+        catch
+            Type:Reason ->
+                io:format("~s failed:~n  ~p:~p~n",
+                          [Description, Type, Reason]),
+                error
+        end).
+
+-define(SCRIPT_NAME, "riak-cs-stanchion").
+-include("riak_cs.hrl").
+
+%%%===================================================================
+%%% Public API
+%%%===================================================================
+
+%% @doc Kick off a gc round, unless one is already
+%% in progress.
+switch([Host, Port]) ->
+    Msg = io_lib:format("Switching stanchion to ~s:~s", [Host, Port]),
+    ?SAFELY(begin
+                NewPort = list_to_integer(Port),
+                true = (0 < NewPort andalso NewPort < 65536),
+                %% {_, _, SSL} = riak_cs_utils:stanchion_data(),
+                %% currently this does not work due to bad path generation of velvet:ping/3
+                %% ok = velvet:ping(Host, NewPort, SSL),
+
+                %% Or, set this configuration to dummy host/port
+                %% to block bucket/user creation/deletion
+                %% in case of multiple stanchion working.
+                ok = application:set_env(riak_cs, stanchion_ip, Host),
+                ok = application:set_env(riak_cs, stanchion_port, NewPort)
+            end, Msg).
+
+
+show([]) ->
+    ?SAFELY(begin
+                {Host, Port, SSL} = riak_cs_utils:stanchion_data(),
+                Scheme = case SSL of
+                             true -> "https://";
+                             false -> "http://"
+                         end,
+                io:format("Current Stanchion Adderss: ~s~s:~s~n",
+                          [Scheme, Host, integer_to_list(Port)])
+            end, "Retrieving Stanchion info failed").

--- a/src/riak_cs_stanchion_console.erl
+++ b/src/riak_cs_stanchion_console.erl
@@ -58,7 +58,11 @@ switch([Host, Port]) ->
                 %% to block bucket/user creation/deletion
                 %% in case of multiple stanchion working.
                 ok = application:set_env(riak_cs, stanchion_ip, Host),
-                ok = application:set_env(riak_cs, stanchion_port, NewPort)
+                ok = application:set_env(riak_cs, stanchion_port, NewPort),
+                Msg2 = io_lib:format("Succesfully witched stanchion to ~s:~s: This change is only effective until restart.~n",
+                                    [Host, Port]),
+                _ = lager:info(Msg2),
+                io:format("~sTo make permanent change, be sure to edit app.config file.~n", [Msg2])
             end, Msg).
 
 

--- a/src/riak_cs_stanchion_console.erl
+++ b/src/riak_cs_stanchion_console.erl
@@ -18,7 +18,7 @@
 %%
 %% ---------------------------------------------------------------------
 
-%% @doc These functions are used by the riak-cs-gc command line script.
+%% @doc These functions are used by the riak-cs-stanchion command line script.
 
 -module(riak_cs_stanchion_console).
 
@@ -44,8 +44,7 @@
 %%% Public API
 %%%===================================================================
 
-%% @doc Kick off a gc round, unless one is already
-%% in progress.
+%% @doc Switch Stanchion to a new one. Can be used for disabling.
 switch([Host, Port]) ->
     Msg = io_lib:format("Switching stanchion to ~s:~s", [Host, Port]),
     ?SAFELY(begin

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -86,7 +86,9 @@
          update_key_secret/1,
          update_obj_value/2,
          pid_to_binary/1,
-         update_user/3]).
+         update_user/3,
+         stanchion_data/0
+        ]).
 
 -include("riak_cs.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").


### PR DESCRIPTION
Add a command to switch stanchion location setting. This command
assumes a use case where:
1. stanchion fails (or kill the old one, ensure killed)
2. decide a new stanchion with a brand new location (host,port)
3. put a new stanchion location via `riak-cs-stanchion switch`

Also, users can confirm stanchion setting by `show` subcommand.
I believe this will make operation in case of stanchion failure much easier
than before.

I'd like to discuss about the risk that this command may lead operational
mistake to diverse stanchion settings.
