### PR TITLE
Bump erlcloud dependency to 0.4.3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,5 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "95be39ee41c349309564f4c9298f1f74bfdaeef3"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
        ]}.


### PR DESCRIPTION
The 0.4.3 tag of erlcloud increases some ibrowse timeouts and this
helps with spurious riak_test failures when running on slow hosts.
