### PR TITLE
Create user endpoint doesn't work with riak_cs_oos_rewrite module

### DIFF
--- a/src/riak_cs_oos_rewrite.erl
+++ b/src/riak_cs_oos_rewrite.erl
@@ -56,6 +56,8 @@ original_resource(RD) ->
 %% the account identifier, and the remainder of the path information
 %% pertaining to the requested object storage operation.
 -spec parse_path(string()) -> {string(), string(), string()}.
+parse_path(Path="/riak-cs" ++ _) ->
+    {"v1", undefined, Path};
 parse_path(Path) ->
     [ApiVsn, Account | RestPath] = string:tokens(Path, "/"),
     {ApiVsn, Account, "/" ++ string:join(RestPath, "/")}.
@@ -69,7 +71,7 @@ rewrite_headers(Headers, RawPath, ApiVsn, Account) ->
 
 %% @doc Internal function to handle rewriting the URL. Only `v1' of
 %% the API is supported since right now it is the only version that
-%% exists, but crash if another version is specfified.
+%% exists, but crash if another version is specified.
 -spec rewrite_path(string(), atom(), string(), string()) -> string().
 rewrite_path("v1", Method, Path, QS) ->
     rewrite_v1_path(Method, Path, QS).


### PR DESCRIPTION
If the `rewrite_module` setting is set to `riak_cs_oos_rewrite`, `POSTs` to `/riak-cs/users` do not result in a newly created user:

```
$ curl -i -XPOST http://10.0.2.15:8080/riak-cs/user \
    -H 'Content-Type: application/json'  \
    --data '{"email":"admin@admin.com", "name":"admin"}'
curl: (52) Empty reply from server
```

State of `app.config` when the user creation attempt was made (thank Chef for shifting everything around):

``` erlang
[
    {lager, [
        {crash_log, "/var/log/riak-cs/crash.log"},
        {crash_log_count, 5},
        {crash_log_date, "$D0"},
        {crash_log_msg_size, 65536},
        {crash_log_size, 10485760},
        {error_logger_redirect, true},
        {handlers, [
            {lager_file_backend, [
                {"/var/log/riak-cs/error.log", error, 10485760, "$D0", 5},
                {"/var/log/riak-cs/console.log", info, 10485760, "$D0", 5}
            ]}
        ]}
    ]},
    {riak_cs, [
        {access_archive_period, 3600},
        {access_archiver_max_backlog, 2},
        {access_log_flush_factor, 1},
        {access_log_flush_size, 1000000},
        {admin_key, "admin-key"},
        {admin_secret, "admin-secret"},
        {anonymous_user_creation, true},
        {auth_module, riak_cs_s3_auth},
        {connection_pools, [
            {bucket_list_pool, {5, 0}},
            {request_pool, {128, 0}}
        ]},
        {cs_ip, "10.0.2.15"},
        {cs_port, 8080},
        {cs_root_host, "s3.amazonaws.com"},
        {cs_version, 10400},
        {dtrace_support, false},
        {fold_objects_for_list_keys, false},
        {gc_interval, 900},
        {gc_retry_interval, 21600},
        {leeway_seconds, 86400},
        {n_val_1_get_requests, true},
        {rewrite_module, riak_cs_oos_rewrite},
        {riak_ip, "10.0.2.15"},
        {riak_pb_port, 8087},
        {stanchion_ip, "10.0.2.15"},
        {stanchion_port, 8085},
        {stanchion_ssl, false},
        {storage_archive_period, 86400},
        {storage_schedule, [
        ]},
        {trust_x_forwarded_for, false},
        {usage_request_limit, 744}
    ]},
    {sasl, [
        {sasl_error_logger, false},
        {utc_log, true}
    ]},
    {webmachine, [
        {log_handlers, [
            {riak_cs_access_log_handler, [
            ]},
            {webmachine_log_handler, [
                "/var/log/riak-cs"
            ]}
        ]},
        {server_name, "Riak CS"}
    ]}
].
```
