### PR TITLE
Bugfix/reduce wastefully large object size

### DIFF
--- a/riak_test/tests/object_get_test.erl
+++ b/riak_test/tests/object_get_test.erl
@@ -102,7 +102,7 @@ mp_get_cases(UserConfig) ->
     SmallContent = multipart_upload(?TEST_BUCKET, ?KEY_MP_SMALL,
                                     [mb(3)], UserConfig),
     LargeContent = multipart_upload(?TEST_BUCKET, ?KEY_MP_LARGE,
-                                    [mb(10), mb(5), mb(9) + 123, mb(6), mb(400)], % 30MB + 523 B
+                                    [mb(10), mb(5), mb(9) + 123, mb(6), 400], % 30MB + 523 B
                                     UserConfig),
 
     %% Range GET for single part / single block


### PR DESCRIPTION
I embedded typo in object size and riak_test uses large memory and takes time. Oops, sorry...
This fix reduce 400MB object to 400 bytes.

P.S. This fix changes only a test case of riak_test. So does not affect 1.4.1 release.
