### PR TITLE
Quick fix for manifest props=undefined, needed for upgrades from very old versions of Riak CS

### DIFF
--- a/src/riak_cs_diags.erl
+++ b/src/riak_cs_diags.erl
@@ -98,7 +98,7 @@ print_multipart_manifest(Props, Indent) ->
     end.
 
 deleted(Props) ->
-    lists:keymember(deleted, 1, Props).
+    lists:keymember(deleted, 1, riak_cs_manifest_utils:fix_props(Props)).
 
 %% ====================================================================
 %% gen_server callbacks

--- a/src/riak_cs_manifest_resolution.erl
+++ b/src/riak_cs_manifest_resolution.erl
@@ -128,8 +128,8 @@ resolve_deleted_blocks(A, B) ->
     safe_intersection(ADeleted, BDeleted).
 
 resolve_props(A, B) ->
-    Ps_A = A?MANIFEST.props,
-    Ps_B = B?MANIFEST.props,
+    Ps_A = riak_cs_manifest_utils:fix_props(A?MANIFEST.props),
+    Ps_B = riak_cs_manifest_utils:fix_props(B?MANIFEST.props),
     {_, _, New} = lists:foldl(fun resolve_a_prop/2,
                               {Ps_A, Ps_B, []},
                               [fun resolve_prop_multipart/2,

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -42,7 +42,8 @@
          prune/1,
          prune/2,
          upgrade_wrapped_manifests/1,
-         upgrade_manifest/1]).
+         upgrade_manifest/1,
+         fix_props/1]).
 
 %%%===================================================================
 %%% API

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -163,7 +163,7 @@ mark_deleted(Dict, UUIDsToMark) ->
                 true ->
                     V?MANIFEST{state=pending_delete,
                                delete_marked_time=os:timestamp(),
-                               props=[{deleted, true} | V?MANIFEST.props]};
+                               props=[{deleted, true} | fix_props(V?MANIFEST.props)]};
                 false ->
                     V
             end
@@ -304,7 +304,7 @@ upgrade_manifest(#lfs_manifest_v2{block_size=BlockSize,
               last_block_deleted_time=LastBlockDeletedTime,
               delete_blocks_remaining=DeleteBlocksRemaining,
               acl=Acl,
-              props=Properties,
+              props=fix_props(Properties),
               cluster_id=ClusterID};
 
 upgrade_manifest(?MANIFEST{}=M) ->
@@ -339,7 +339,7 @@ manifest_is_active(_Manifest) -> false.
 
 -spec delete_time(lfs_manifest()) -> erlang:timestamp() | undefined.
 delete_time(Manifest) ->
-    case proplists:is_defined(deleted, Manifest?MANIFEST.props) of
+    case proplists:is_defined(deleted, fix_props(Manifest?MANIFEST.props)) of
         true ->
             Manifest?MANIFEST.delete_marked_time;
         false ->
@@ -434,6 +434,11 @@ seconds_diff(T2, T1) ->
     TimeDiffMicrosends = timer:now_diff(T2, T1),
     SecondsTime = TimeDiffMicrosends / (1000 * 1000),
     erlang:trunc(SecondsTime).
+
+fix_props(L) when is_list(L) ->
+    L;
+fix_props(_) ->
+    [].
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -633,7 +633,7 @@ handle_get_manifests_result(_) ->
 
 -spec is_multipart_manifest(?MANIFEST{}) -> boolean().
 is_multipart_manifest(?MANIFEST{props=Props}) ->
-    case proplists:get_value(multipart, Props) of
+    case proplists:get_value(multipart, riak_cs_manifest_utils:fix_props(Props)) of
         undefined ->
             false;
         _ ->
@@ -642,7 +642,7 @@ is_multipart_manifest(?MANIFEST{props=Props}) ->
 
 -spec multipart_description(?MANIFEST{}) -> ?MULTIPART_DESCR{}.
 multipart_description(Manifest) ->
-    MpM =  proplists:get_value(multipart, Manifest?MANIFEST.props),
+    MpM =  proplists:get_value(multipart, riak_cs_manifest_utils:fix_props(Manifest?MANIFEST.props)),
     ?MULTIPART_DESCR{
        key = element(2, Manifest?MANIFEST.bkey),
        upload_id = Manifest?MANIFEST.uuid,
@@ -783,12 +783,12 @@ get_mp_manifest(?MANIFEST{props = Props}) when is_list(Props) ->
     %%       to version v2 and beyond, this might be a good place to add
     %%       a record conversion function to handle older versions of
     %%       the multipart record?
-    proplists:get_value(multipart, Props, undefined);
+    proplists:get_value(multipart, riak_cs_manifest_utils:fix_props(Props), undefined);
 get_mp_manifest(_) ->
     undefined.
 
 replace_mp_manifest(MpM, Props) ->
-    [{multipart, MpM}|proplists:delete(multipart, Props)].
+    [{multipart, MpM}|proplists:delete(multipart, riak_cs_manifest_utils:fix_props(Props))].
 
 %% ===================================================================
 %% EUnit tests

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -126,7 +126,7 @@ count_multipart_parts(Resolved) ->
     lists:foldl(fun count_multipart_parts/2, {0, 0}, Resolved).
 
 count_multipart_parts({_UUID, M}, {MPparts, MPbytes} = Acc) ->
-    case {M?MANIFEST.state, proplists:get_value(multipart, M?MANIFEST.props)} of
+    case {M?MANIFEST.state, proplists:get_value(multipart, riak_cs_manifest_utils:fix_props(M?MANIFEST.props))} of
         {writing, MP} ->
             Ps = MP?MULTIPART_MANIFEST.parts,
             {MPparts + length(Ps),


### PR DESCRIPTION
Witnessed after upgrading from an ancient version of Riak CS to 1.4.1.

```
2013-09-11 09:05:05.871 UTC [error] <0.25995.4> CRASH REPORT Process <0.25995.4> with 0 neighbours exited with reason: no function clause matching proplists:is_defined(deleted, undefined) line 184 in gen_fsm:terminate/7 line 611
2013-09-11 09:05:05.872 UTC [error] <0.25994.4> gen_fsm <0.25994.4> in state prepare terminated with reason: {{function_clause,[{proplists,is_defined,[deleted,undefined],[{file,"proplists.erl"},{line,184}]},{riak_cs_manifest_utils,delete_time,1,[{file,"src/riak_cs_manifest_utils.erl"},{line,342}]},{riak_cs_manifest_utils,'-latest_delete_time/1-fun-0-',2,[{file,"src/riak_cs_manifest_utils.erl"},{line,368}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{riak_cs_manifest_utils,deleted_while_writing,1,[{file,"src/riak_cs_manifest_utils.erl"},{line,355}]},{riak_cs_utils,gc_deleted_while_writing_manifests,...},...]},...}
2013-09-11 09:05:05.873 UTC [error] <0.25994.4> CRASH REPORT Process <0.25994.4> with 0 neighbours exited with reason: {{function_clause,[{proplists,is_defined,[deleted,undefined],[{file,"proplists.erl"},{line,184}]},{riak_cs_manifest_utils,delete_time,1,[{file,"src/riak_cs_manifest_utils.erl"},{line,342}]},{riak_cs_manifest_utils,'-latest_delete_time/1-fun-0-',2,[{file,"src/riak_cs_manifest_utils.erl"},{line,368}]},{lists,foldl,3,[{file,"lists.erl"},{line,1197}]},{riak_cs_manifest_utils,deleted_while_writing,1,[{file,"src/riak_cs_manifest_utils.erl"},{line,355}]},{riak_cs_utils,gc_deleted_while_writing_manifests,...},...]},...} in gen_fsm:terminate/7 line 611
```

This patch is a quick, end-of-work-day-want-to-get-out-of-the-office fix.  It is extremely lightly tested by the compiler only.
