### PR TITLE
Reset xref and dialyzer ignore files

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,87 +1,31 @@
-############## Warnings from dependencies that we might/should fix?
-^glc_code.erl:
+############## Warnings from dependencies that we might/should fix
+^riak_kv_pb.erl:
+^riak_pb.erl:
+^riak_pb_codec.erl:
+^riak_search_pb.erl:
+^riak_pb_search_codec.erl:
+^riakc_pb_socket.erl:1352:
+^riakc_pb_socket.erl:1689:
 ^lager.erl:
 ^lager_app.erl:
 ^lager_util.erl:
-^lager_default_tracer.erl:
+^  lager_default_tracer:
 ^mochiglobal.erl:
 ^mochiweb.erl:
 ^mochiweb_http.erl:
 ^mochiweb_request.erl:
 ^mochiweb_socket_server.erl:
-^protobuffs.erl:
 ^protobuffs_compile.erl:
-^riak_kv_pb.erl:
-^riak_pb.erl:
-^riak_repl_pb.erl:
-^riak_repl_pb_api.erl:
-^riak_search_pb.erl:
-^riakc_pb_socket.erl:
 ^webmachine.erl:
 ^webmachine_decision_core.erl:
-^webmachine_logger.erl:
 ^webmachine_log.erl:
 ^webmachine_log_handler.erl:
 ^webmachine_perf_log_handler.erl:
 ^webmachine_mochiweb.erl:
-^webmachine_perf_logger.erl:
 ^webmachine_request.erl:
 ^webmachine_resource.erl:
 ^webmachine_sup.erl:
 ^webmachine_dispatcher.erl:
-^webmachine_router.erl:
-^lager.erl:
-^lager_app.erl:
-^lager_util.erl:
-^  lager_default_tracer:
-^glc_code.erl:
-############## Warnings from dependencies that are outside our scope
-^bread.erl:
-^dtop.erl:
-^dtopConsumer.erl:
-^eper.erl:
-^erlcloud.erl:
-^erlcloud_elb.erl:
-^erlcloud_s3.erl:
-^folsom_ets.erl:
-^folsom_metrics_spiral.erl:
-^folsom_sample_exdec.erl:
-^folsom_sup.erl:
-^giddyup.erl:
-^gperfGtk.erl:
-^ibrowse_http_client.erl
-^leexinc.hrl:
-^logReader.erl:
-^mapred_verify.erl:
-^meck.erl:
-^meck_cover.erl:
-^ntopConsumer.erl:
-^pokemon_pb.erl:
-^prfDog.erl:
-^prfHost.erl:
-^prfSys.erl:
-^prfTarg.erl:
-^prfTrc.erl:
-^prf_crypto.erl:
-^redbug.erl:
-^reloader.erl:
-^rhc.erl:
-^rhc_listkeys.erl:
-^rhc_obj.erl:
-^riak_test.erl:
-^riak_test_group_leader.erl:
-^riak_test_runner.erl:
-^rt.erl:
-^rtdev.erl:
-^sherk.erl:
-^sherk_aquire.erl:
-^sherk_ets.erl:
-^sherk_scan.erl:
-^sherk_tab.erl:
-^sherk_target.erl:
-^syslog.erl:
-^watchdog.erl:
-############## datatypes due to riak_kv and other deps
   riak_kv_backend:fold_buckets_fun/0
   riak_kv_backend:fold_keys_fun/0
   riak_kv_backend:fold_objects_fun/0
@@ -93,95 +37,80 @@
   riak_object:key/1
   riak_object:new/3
   riak_object:update_metadata/2
-  riak_repl_pb_api:get/5
-  riak_repl_pb_api:get_clusterid/2
-  calendar:day/0
-  calendar:hour/0
-  calendar:month/0
-  calendar:year/0
+############## Warnings from dependencies that are outside our scope
+^bread.erl:
+^dtop.erl:
+^dtopConsumer.erl:
+^eper.erl:
+^erlcloud.erl:
+^erlcloud_ec2.erl:
+^erlcloud_elb.erl:
+^erlcloud_mturk.erl:
+^erlcloud_s3.erl:
+^folsom_ets.erl:
+^folsom_sample_exdec.erl:
+^folsom_sup.erl:
+^gperfGtk.erl:
+^ibrowse_http_client.erl
+^leexinc.hrl:
+^logReader.erl:
+^meck_code_gen.erl:
+^meck_cover.erl:
+^meck_proc.erl:
+^ntopConsumer.erl:
+^pokemon_pb.erl:
+^prfDog.erl:
+^prfHost.erl:
+^prfSys.erl:
+^prfTarg.erl:
+^prfTrc.erl:
+^prf_crypto.erl:
+^redbug.erl:
+^reloader.erl:
+^sherk.erl:
+^sherk_aquire.erl:
+^sherk_ets.erl:
+^sherk_scan.erl:
+^sherk_tab.erl:
+^sherk_target.erl:
+^syslog.erl:
+^watchdog.erl:
+^glc_code.erl:
   lager_default:info/1
   gre:event/0
-############## stuff defined in test (we should dialyze these someday)
-  riakc_pb_socket_fake:start_link/0
+  hamcrest:assert_that/2
+  hamcrest:is_matcher/1
+############## our code, but don't know how to fix
+^riak_cs_gc.erl:185:
+^riak_cs_stats.erl:200:
 ############## functions due to riak_kv stuff in this repo
   app_helper:get_prop_or_env/3
   app_helper:get_prop_or_env/4
 ############## harmless/intentional missing functions
+  calendar:day/0
+  calendar:hour/0
+  calendar:month/0
+  calendar:year/0
   dtrace:init/0
-  edoc:application/3
-  edoc:get_doc/3
-  edoc:layout/2
-  edoc_data:overview/4
-  edoc_data:package/4
-  edoc_extract:file/4
-  edoc_lib:copy_file/2
-  edoc_lib:join_uri/2
-  edoc_lib:run_layout/2
-  edoc_lib:segment/2
-  edoc_lib:strip_space/1
-  edoc_lib:transpose/1
-  edoc_lib:write_file/3
-  edoc_lib:write_file/4
-  edoc_lib:write_info_file/4
-  edoc_refs:relative_package_path/2
-  edoc_report:report/2
-  edoc_report:warning/2
   erlsom:sax/3
-  eunit:test/1
-  eunit_lib:command/1
   fdsrv:bind_socket/2
   fdsrv:start/0
   fdsrv:stop/0
   gtknode:cmd/2
   gtknode:start/1
-  rebar_config:get_global/3
-  rebar_config:set/3
-  rebar_erlc_compiler:compile/2
-  rebar_file_utils:rm_rf/1
-  rebar_utils:ebin_dir/0
-  riak:client_connect/1
+  gre:event/0
+  hamcrest:matchspec/0
+  meck_history:history_record/0
+  ordsets:ordset/0
+############## stuff defined in riak (we should dialyze these someday)
+  riak_repl_pb_api:get/5
+  riak_repl_pb_api:get_clusterid/2
   riak:stop/1
   riak_core_bucket:get_bucket/1
-  riak_core_ring:all_members/1
-  riak_core_ring:all_owners/1
-  riak_core_ring:claimant/1
-  riak_core_ring:member_status/2
-  riak_core_ring:pending_changes/1
-  riak_core_ring:ready_members/1
-  riak_core_ring:ring_ready/1
-  riak_cs_dummy_reader:get_manifest/1
-  riak_cs_dummy_reader:start_link/1
-  riak_kv_mapred_filters:build_exprs/1
-  xmerl:export_simple/2
-  xmerl:export_simple/3
-  xmerl:export_simple_content/2
-  xmerl_html:'#element#'/5
-  xmerl_lib:end_tag/1
-  xmerl_lib:expand_element/1
-  xmerl_lib:find_attribute/2
-  xmerl_lib:mapxml/2
-  xmerl_lib:start_tag/2
-  xmerl_scan:string/1
-  xmerl_scan:string/2
-  xmerl_ucs:from_utf16be/1
-  xmerl_ucs:from_utf8/1
-  xmerl_ucs:to_utf8/1
-  xmerl_xpath:string/2
-############# stuff dialyzer has stumped us on - mostly unused code where
-############# we've gone in and added a throw / log to be sure
-riak_cs_mp_utils.erl:522: The pattern <Bucket, OwnerStr> can never match since previous clauses completely covered the type <_,'undefined' | {_,_,_}>
-^riak_cs_lfs_utils.erl:119:
-riak_cs_gc.erl:.*: The pattern ..UUID, _... _. can never match the type ..$
-############# Due to inadequate specs with our riak-erlang-client tag
-riak_cs_gc_d.erl:[0-9]+: Function fetch_eligible_manifest_keys/2 will never be called
-riak_cs_gc_d.erl:[0-9]+: Function eligible_manifest_keys/1 will never be called
-riak_cs_gc_d.erl:[0-9]+: Function gc_index_query/2 will never be called
-^riak_cs_riakc_pool_worker.erl:54:
-riak_cs_storage_d.erl:[0-9]+: Function fetch_user_list/1 will never be called
-riak_cs_wm_ping.erl:46: The pattern 'undefined' can never match the type pid()
-############## All the others..........
-riak_cs_blockall_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_s3_passthru_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_s3_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_keystone_auth.erl:23: Callback info about the riak_cs_auth behaviour is not available
-riak_cs_s3_policy.erl:26: Callback info about the riak_cs_policy behaviour is not available
+  riak_object:get_values/1
+  riak_object:key/1
+  riak_kv_backend:fold_buckets_fun/0
+  riak_kv_backend:fold_keys_fun/0
+  riak_kv_backend:fold_objects_fun/0
+  riak_object:bucket/0
+  riak_object:key/0

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R14B0[34]|R15"}.
+{require_otp_vsn, "R14B0[34]|R15|R16"}.
 
 {cover_enabled, true}.
 
@@ -31,9 +31,9 @@
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
-        {eper, ".*", {git, "git://github.com/basho/eper.git", "3280b736057a6cf5c01590c79fd192f7e8645270"}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "95be39ee41c349309564f4c9298f1f74bfdaeef3"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "2d605e2c7bdd158075842c8a8dc826bfb9c2c33b"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "2d605e2c7bdd158075842c8a8dc826bfb9c2c33b"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "6936e6ebe7861a1e45cb578c87067fc98fe16414"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "6936e6ebe7861a1e45cb578c87067fc98fe16414"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "7ae5c67f83648ce5669d3c7ff4fcd33de38064d3"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,5 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "95be39ee41c349309564f4c9298f1f74bfdaeef3"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
        ]}.

--- a/rel/files/vm.args
+++ b/rel/files/vm.args
@@ -17,7 +17,7 @@
 +W w
 
 ## Increase number of concurrent ports/sockets
--env ERL_MAX_PORTS 4096
+-env ERL_MAX_PORTS 64000
 
 ## Tweak GC to run more often 
 -env ERL_FULLSWEEP_AFTER 0

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -153,6 +153,8 @@ riak_oss_config(Backend) ->
      lager_config(),
      {riak_core,
       [{default_bucket_props, [{allow_mult, true}]}]},
+     {riak_api,
+      [{pb_backlog, 256}]},
      {riak_kv,
       [{add_paths, AddPaths}] ++
           backend_config(Backend)

--- a/riak_test/tests/object_get_test.erl
+++ b/riak_test/tests/object_get_test.erl
@@ -102,7 +102,7 @@ mp_get_cases(UserConfig) ->
     SmallContent = multipart_upload(?TEST_BUCKET, ?KEY_MP_SMALL,
                                     [mb(3)], UserConfig),
     LargeContent = multipart_upload(?TEST_BUCKET, ?KEY_MP_LARGE,
-                                    [mb(10), mb(5), mb(9) + 123, mb(6), mb(400)], % 30MB + 523 B
+                                    [mb(10), mb(5), mb(9) + 123, mb(6), 400], % 30MB + 523 B
                                     UserConfig),
 
     %% Range GET for single part / single block

--- a/src/riak_cs_auth.erl
+++ b/src/riak_cs_auth.erl
@@ -20,12 +20,27 @@
 
 -module(riak_cs_auth).
 
--export([behaviour_info/1]).
+%% -export([behaviour_info/1]).
 
--compile(export_all).
+-include("riak_cs.hrl").
+%% -compile(export_all).
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [{identify, 2}, {authenticate, 4}];
-behaviour_info(_Other) ->
-    undefined.
+-type wm_reqdata() :: tuple().
+-type wm_context() :: tuple().
+
+%% TODO: arguments of identify/2, and 3rd&4th arguments of
+%%       authenticate/4 are actually #wm_reqdata{} and #context{}
+%%       from webmachine, but can't compile after webmachine.hrl import.
+-callback identify(RD :: wm_reqdata(), Ctx :: wm_context()) ->
+    failed | {string() | undefined, string() | tuple()} |
+    {string(), undefined}.
+
+-callback authenticate(rcs_user(), string() | {string(), term()} | undefined,
+                       wm_reqdata(), wm_context()) ->
+    ok | {error, atom()}.     
+
+%% -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
+%% behaviour_info(callbacks) ->
+%%     [{identify, 2}, {authenticate, 4}];
+%% behaviour_info(_Other) ->
+%%     undefined.

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -177,7 +177,7 @@ handle_mark_as_pending_delete({ok, RiakObject}, Bucket, Key, UUIDsToMark, RiakcP
     Manifests = riak_cs_utils:manifests_from_riak_object(RiakObject),
     PDManifests = riak_cs_manifest_utils:manifests_to_gc(UUIDsToMark, Manifests),
     MoveResult = move_manifests_to_gc_bucket(PDManifests, RiakcPid),
-    %% riak_cs_gc.erl:89: The pattern [{UUID, _} | _] can never match
+    %% riak_cs_gc.erl:185: The pattern [{UUID, _} | _] can never match
     %% the type [] Oi, this is a stumper.  Just overwrite a file once,
     %% and it's obvious that PDManifests is a non-empty list and
     %% indeed has 2-tuples.  And the spec for

--- a/src/riak_cs_json.erl
+++ b/src/riak_cs_json.erl
@@ -141,7 +141,7 @@ target_tuple_values(Keys, JsonItems) ->
       [proplists:get_value(element(Index, Keys), JsonItems)
        || Index <- lists:seq(1, tuple_size(Keys))]).
 
--spec user_object(rcs_user()) -> {struct, proplist:proplist()}.
+-spec user_object(rcs_user()) -> {struct, proplists:proplist()}.
 user_object(?RCS_USER{email=Email,
                       display_name=DisplayName,
                       name=Name,

--- a/src/riak_cs_keystone_auth.erl
+++ b/src/riak_cs_keystone_auth.erl
@@ -48,7 +48,9 @@ identify(RD, #context{api=s3}) ->
 identify(RD, #context{api=oos}) ->
     validate_token(oos, wrq:get_req_header("x-auth-token", RD)).
 
--spec authenticate(rcs_user(), {string(), term()}, #wm_reqdata{}, #context{}) ->
+-spec authenticate(rcs_user(),
+                   {string(), term()}|tuple(),
+                   #wm_reqdata{}, #context{}) ->
                           ok | {error, invalid_authentication}.
 authenticate(_User, {_, TokenItems}, _RD, _Ctx) ->
     %% @TODO Expand authentication check for non-operators who may

--- a/src/riak_cs_list_objects_fsm_v2.erl
+++ b/src/riak_cs_list_objects_fsm_v2.erl
@@ -504,8 +504,9 @@ extract_timings(Requests) ->
     [extract_timing(R) || R <- Requests].
 
 %% TODO: time to make legit types out of these
--spec extract_timing({term(), non_neg_integer(), {term(), term()}}) ->
-    {term(), term()}.
+-spec extract_timing({term(), non_neg_integer(),
+                      {erlang:timestamp(), erlang:timestamp()}}) ->
+    {non_neg_integer(), non_neg_integer()}.
 extract_timing({_Range, NumKeysReturned, {StartTime, EndTime}}) ->
     MillisecondDiff = riak_cs_utils:timestamp_to_milliseconds(EndTime) -
                       riak_cs_utils:timestamp_to_milliseconds(StartTime),

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -84,7 +84,7 @@ active_manifests(Dict) ->
 
 %% @doc Return a list of all manifests in the
 %% `active' or `writing' state
--spec active_and_writing_manifests(orddict:orddict()) -> [lfs_manifest()].
+-spec active_and_writing_manifests(orddict:orddict()) -> [{binary(), lfs_manifest()}].
 active_and_writing_manifests(Dict) ->
     orddict:to_list(filter_manifests_by_state(Dict, [active, writing])).
 

--- a/src/riak_cs_policy.erl
+++ b/src/riak_cs_policy.erl
@@ -20,13 +20,21 @@
 
 -module(riak_cs_policy).
 
--export([behaviour_info/1]).
+-include("riak_cs.hrl").
 
--compile(export_all).
+-callback eval(access(), policy() | undefined | binary() ) -> boolean() | undefined.
+-callback check_policy(access(), policy()) -> ok | {error, atom()}.
+-callback reqdata_to_access(RD :: term(), Target::atom(), ID::binary()|undefined) -> access().
+-callback policy_from_json(JSON::binary()) -> {ok, policy()} | {error, term()}.
+-callback policy_to_json_term(policy()) -> JSON::binary().
 
--spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
-behaviour_info(callbacks) ->
-    [{eval, 2}, {check_policy, 2}, {reqdata_to_access, 3},
-     {policy_from_json, 1}, {policy_to_json_term, 1}];
-behaviour_info(_Other) ->
-    undefined.
+%% -export([behaviour_info/1]).
+
+%% -compile(export_all).
+
+%% -spec behaviour_info(atom()) -> 'undefined' | [{atom(), arity()}].
+%% behaviour_info(callbacks) ->
+%%     [{eval, 2}, {check_policy, 2}, {reqdata_to_access, 3},
+%%      {policy_from_json, 1}, {policy_to_json_term, 1}];
+%% behaviour_info(_Other) ->
+%%     undefined.

--- a/src/riak_cs_s3_auth.erl
+++ b/src/riak_cs_s3_auth.erl
@@ -86,6 +86,9 @@ parse_auth_header("AWS " ++ Key) ->
 parse_auth_header(_) ->
     {undefined, undefined}.
 
+%% TODO:
+%% can this be replaced with stanchion_auth:request_sinature/2?
+%% - which is included in velvet.
 calculate_signature(KeyData, RD) ->
     Headers = riak_cs_wm_utils:normalize_headers(RD),
     AmazonHeaders = riak_cs_wm_utils:extract_amazon_headers(Headers),
@@ -127,8 +130,14 @@ calculate_signature(KeyData, RD) ->
            AmazonHeaders,
            Resource],
     _ = lager:debug("STS: ~p", [STS]),
-    base64:encode_to_string(
-      crypto:sha_mac(KeyData, STS)).
+
+    %% This is for compatibility for R16B and R15B
+    %% R15B does not have crypto:hmac/3, which looks
+    %% newly added in R16B. in future crypto:hmac_final/1
+    %% will probably replaced with crypto:hmac/3
+    %% like crypto:hmac(sha, KeyData, STS)
+    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
+    base64:encode_to_string(crypto:hmac_final(Ctx)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->
     PresentedSignature == CalculatedSignature.

--- a/src/riak_cs_s3_auth.erl
+++ b/src/riak_cs_s3_auth.erl
@@ -86,9 +86,6 @@ parse_auth_header("AWS " ++ Key) ->
 parse_auth_header(_) ->
     {undefined, undefined}.
 
-%% TODO:
-%% can this be replaced with stanchion_auth:request_sinature/2?
-%% - which is included in velvet.
 calculate_signature(KeyData, RD) ->
     Headers = riak_cs_wm_utils:normalize_headers(RD),
     AmazonHeaders = riak_cs_wm_utils:extract_amazon_headers(Headers),
@@ -131,13 +128,7 @@ calculate_signature(KeyData, RD) ->
            Resource],
     _ = lager:debug("STS: ~p", [STS]),
 
-    %% This is for compatibility for R16B and R15B
-    %% R15B does not have crypto:hmac/3, which looks
-    %% newly added in R16B. in future crypto:hmac_final/1
-    %% will probably replaced with crypto:hmac/3
-    %% like crypto:hmac(sha, KeyData, STS)
-    Ctx = crypto:hmac_update(crypto:hmac_init(sha, KeyData), STS),
-    base64:encode_to_string(crypto:hmac_final(Ctx)).
+    base64:encode_to_string(riak_cs_utils:sha_mac(KeyData, STS)).
 
 check_auth(PresentedSignature, CalculatedSignature) ->
     PresentedSignature == CalculatedSignature.

--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -181,14 +181,14 @@ format_subresources([{Key, []} | _]) ->
     ["/", Key].
 
 %% @doc Format a proplist of query parameters into a string
--spec format_query_params(query_params()) -> string().
+-spec format_query_params(query_params()) -> iolist().
 format_query_params([]) ->
     [];
 format_query_params(QueryParams) ->
     format_query_params(QueryParams, []).
 
 %% @doc Format a proplist of query parameters into a string
--spec format_query_params(query_params(), list()) -> list().
+-spec format_query_params(query_params(), iolist()) -> iolist().
 format_query_params([], QS) ->
     ["?", QS];
 format_query_params([{Key, []} | RestParams], []) ->

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -193,5 +193,9 @@ raw_report_pool(Pool) ->
     case poolboy:status(Pool) of
         {_PoolState, PoolWorkers, PoolOverflow, PoolSize} ->
             { Pool, [ PoolWorkers, PoolOverflow, PoolSize ] };
+
+        %% riak_cs_stats.erl:200: The variable _ can never match since previous clauses completely covered the type {atom(),integer(),integer(),integer()}
+        %% dialyer says above match always succeeds. We still don't
+        %% trust against future code change.
         _ -> { Pool, [ -1, -1, -1 ] }
     end.

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -43,6 +43,7 @@
          is_admin/1,
          map_keys_and_manifests/3,
          sha_mac/2,
+         sha/1,
          md5/1,
          md5_init/0,
          md5_update/2,
@@ -529,13 +530,15 @@ reduce_keys_and_manifests(Acc, _) ->
     Acc.
 
 -spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
-%% -spec sha(binary()) -> binary().
+-spec sha(binary()) -> binary().
 
 -ifdef(new_hash).
 sha_mac(Key,STS) -> crypto:hmac(sha, Key,STS).
+sha(Bin) -> crypto:hash(sha, Bin).
 
 -else.
 sha_mac(Key,STS) -> crypto:sha_mac(Key,STS).
+sha(Bin) -> crypto:sha(Bin).
 
 -endif.
 

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -538,19 +538,19 @@ md5(List) when is_list(List) ->
 
 -spec md5_init() -> context().
 md5_init() ->
-    crypto:md5_init().
+    crypto:hash_init(md5).
 
 -define(MAX_UPDATE_SIZE, (32*1024)).
 
 -spec md5_update(context(), binary()) -> context().
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
-    crypto:md5_update(Ctx, Bin);
+    crypto:hash_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
-    md5_update(crypto:md5_update(Ctx, Part), Rest).
+    md5_update(crypto:hash_update(Ctx, Part), Rest).
 
 -spec md5_final(context()) -> digest().
 md5_final(Ctx) ->
-    crypto:md5_final(Ctx).
+    crypto:hash_final(Ctx).
 
 %% @doc Get an object from Riak
 -spec get_object(binary(), binary(), pid()) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -42,6 +42,7 @@
          has_tombstone/1,
          is_admin/1,
          map_keys_and_manifests/3,
+         sha_mac/2,
          md5/1,
          md5_init/0,
          md5_update/2,
@@ -527,6 +528,17 @@ map_keys_and_manifests(Object, _, _) ->
 reduce_keys_and_manifests(Acc, _) ->
     Acc.
 
+-spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
+%% -spec sha(binary()) -> binary().
+
+-ifdef(new_hash).
+sha_mac(Key,STS) -> crypto:hmac(sha, Key,STS).
+
+-else.
+sha_mac(Key,STS) -> crypto:sha_mac(Key,STS).
+
+-endif.
+
 -type context() :: binary().
 -type digest() :: binary().
 
@@ -536,22 +548,30 @@ md5(Bin) when is_binary(Bin) ->
 md5(List) when is_list(List) ->
     md5(list_to_binary(List)).
 
--spec md5_init() -> context().
-md5_init() ->
-    crypto:hash_init(md5).
-
 -define(MAX_UPDATE_SIZE, (32*1024)).
-
+-spec md5_init() -> context().
 -spec md5_update(context(), binary()) -> context().
+-spec md5_final(context()) -> digest().
+
+-ifdef(new_hash).
+md5_init() -> crypto:hash_init(md5).
+
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
     crypto:hash_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
     md5_update(crypto:hash_update(Ctx, Part), Rest).
 
--spec md5_final(context()) -> digest().
-md5_final(Ctx) ->
-    crypto:hash_final(Ctx).
+md5_final(Ctx) -> crypto:hash_final(Ctx).
+-else.
+md5_init() -> crypto:md5_init().
 
+md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
+    crypto:md5_update(Ctx, Bin);
+md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
+    md5_update(crypto:md5_update(Ctx, Part), Rest).
+
+md5_final(Ctx) -> crypto:md5_final(Ctx).
+-endif.
 %% @doc Get an object from Riak
 -spec get_object(binary(), binary(), pid()) ->
                         {ok, riakc_obj:riakc_obj()} | {error, term()}.

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -542,7 +542,9 @@ sha(Bin) -> crypto:sha(Bin).
 
 -endif.
 
--type context() :: binary().
+-type crypto_context() :: {'md4' | 'md5' | 'ripemd160' | 'sha' |
+                           'sha224' | 'sha256' | 'sha384' | 'sha512',
+                           binary()}.
 -type digest() :: binary().
 
 -spec md5(string() | binary()) -> digest().
@@ -552,9 +554,9 @@ md5(List) when is_list(List) ->
     md5(list_to_binary(List)).
 
 -define(MAX_UPDATE_SIZE, (32*1024)).
--spec md5_init() -> context().
--spec md5_update(context(), binary()) -> context().
--spec md5_final(context()) -> digest().
+-spec md5_init() -> crypto_context().
+-spec md5_update(crypto_context(), binary()) -> crypto_context().
+-spec md5_final(crypto_context()) -> digest().
 
 -ifdef(new_hash).
 md5_init() -> crypto:hash_init(md5).
@@ -984,11 +986,16 @@ format_acl_policy_response({ok, Acl}, {ok, Policy}) ->
 second_resolution_timestamp({MegaSecs, Secs, _MicroSecs}) ->
     (MegaSecs * 1000000) + Secs.
 
--spec timestamp_to_seconds(erlang:timestamp()) -> float().
+%% same as timestamp_to_milliseconds below
+-spec timestamp_to_seconds(erlang:timestamp()) -> number().
 timestamp_to_seconds({MegaSecs, Secs, MicroSecs}) ->
     (MegaSecs * 1000000) + Secs + (MicroSecs / 1000000).
 
--spec timestamp_to_milliseconds(erlang:timestamp()) -> float().
+%% riak_cs_utils.erl:991: Invalid type specification for function riak_cs_utils:timestamp_to_milliseconds/1. The success typing is ({number(),number(),number()}) -> float()
+%% this is also a derp that dialyzer shows above message when defined
+%% like this, as manpage says it's three-integer tuple :
+%% -spec timestamp_to_milliseconds(erlang:timestamp()) -> integer().
+-spec timestamp_to_milliseconds(erlang:timestamp()) -> number().
 timestamp_to_milliseconds(Timestamp) ->
     timestamp_to_seconds(Timestamp) * 1000.
 
@@ -1337,7 +1344,7 @@ generate_canonical_id(KeyID, Secret) ->
                           Id2:Bytes/binary >>)).
 
 %% @doc Generate an access key for a user
--spec generate_key(binary()) -> [iodata()].
+-spec generate_key(binary()) -> [byte()].
 generate_key(UserName) ->
     Ctx = crypto:hmac_init(sha, UserName),
     Ctx1 = crypto:hmac_update(Ctx, druuid:v4()),

--- a/src/riak_cs_wm_users.erl
+++ b/src/riak_cs_wm_users.erl
@@ -180,6 +180,6 @@ user_fold_fun(RiakPid, Status) ->
     end.
 
 unique_id() ->
-    Rand = crypto:sha(term_to_binary({make_ref(), now()})),
+    Rand = crypto:hash(sha, term_to_binary({make_ref(), now()})),
     <<I:160/integer>> = Rand,
     integer_to_list(I, 36).

--- a/src/riak_cs_wm_users.erl
+++ b/src/riak_cs_wm_users.erl
@@ -180,6 +180,6 @@ user_fold_fun(RiakPid, Status) ->
     end.
 
 unique_id() ->
-    Rand = crypto:hash(sha, term_to_binary({make_ref(), now()})),
+    Rand = riak_cs_utils:sha(term_to_binary({make_ref(), now()})),
     <<I:160/integer>> = Rand,
     integer_to_list(I, 36).

--- a/test/riak_cs_utils_eqc.erl
+++ b/test/riak_cs_utils_eqc.erl
@@ -35,11 +35,17 @@ eqc_test_() ->
 %% EQC Properties
 %% ====================================================================
 
+-ifdef(new_hash).
 prop_md5() ->
     _ = crypto:start(),
     ?FORALL(Bin, gen_bin(),
-            %% TODO: stanchion_utils is from velvet, needs update
-            stanchion_utils:md5(Bin) == riak_cs_utils:md5(Bin)).
+            crypto:hash(md5, Bin) == riak_cs_utils:md5(Bin)).
+-else.
+prop_md5() ->
+    _ = crypto:start(),
+    ?FORALL(Bin, gen_bin(),
+            crypto:md5(Bin) == riak_cs_utils:md5(Bin)).
+-endif.
 
 gen_bin() ->
     oneof([binary(),

--- a/test/riak_cs_utils_eqc.erl
+++ b/test/riak_cs_utils_eqc.erl
@@ -38,7 +38,8 @@ eqc_test_() ->
 prop_md5() ->
     _ = crypto:start(),
     ?FORALL(Bin, gen_bin(),
-            crypto:md5(Bin) == riak_cs_utils:md5(Bin)).
+            %% TODO: stanchion_utils is from velvet, needs update
+            stanchion_utils:md5(Bin) == riak_cs_utils:md5(Bin)).
 
 gen_bin() ->
     oneof([binary(),

--- a/test/riak_cs_utils_test.erl
+++ b/test/riak_cs_utils_test.erl
@@ -303,4 +303,8 @@ bucket_resolution_test() ->
     ?assertEqual([hd(lists:reverse(BucketList4))], ResBuckets4),
     ?assertEqual([hd(BucketList5)], ResBuckets5).
 
+hash_test() ->
+    %% to prevent undef or else
+    true = is_binary(riak_cs_utils:sha(<<"deadbeef">>)).
+
 -endif.


### PR DESCRIPTION
Particularly if we move to a different version of Erlang, I think it's good practice to start fresh with our xref and dialyzer 'grep -v' files.
