### PR TITLE
Address performance issues when exporting XML documents

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "95be39ee41c349309564f4c9298f1f74bfdaeef3"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
+        {xmerl, ".*", {git, "git://github.com/kellymclaughlin/xmerl", "f5ab514a1bca00f57b051476371f15686ccc210d"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
        ]}.

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -36,6 +36,7 @@
          to_xml/1]).
 
 -define(XML_SCHEMA_INSTANCE, "http://www.w3.org/2001/XMLSchema-instance").
+-define(ELEMENT, '#element#').
 
 -type attributes() :: [{atom(), string()}].
 -type external_node() :: {atom(), [string()]}.
@@ -157,15 +158,15 @@ common_prefix_to_xml(CommonPrefix) ->
 
 -spec make_internal_node(atom(), term()) -> internal_node().
 make_internal_node(Name, Content) ->
-    {Name, Content}.
+    {{?ELEMENT, Name}, Content}.
 
 -spec make_internal_node(atom(), attributes(), term()) -> internal_node().
 make_internal_node(Name, Attributes, Content) ->
-    {Name, Attributes, Content}.
+    { {?ELEMENT, Name}, Attributes, Content}.
 
 -spec make_external_node(atom(), term()) -> external_node().
 make_external_node(Name, Content) ->
-    {Name, [format_value(Content)]}.
+    { {?ELEMENT, Name}, [format_value(Content)]}.
 
 %% @doc Assemble the xml for the set of grantees for an acl.
 -spec make_grants([acl_grant()]) -> [internal_node()].


### PR DESCRIPTION
Address the repeated calls to `error_handler:undefined_function` that results in a call to the code_server and is a performance bottleneck. This commit adds a dependency on a [fork](https://github.com/kellymclaughlin/xmerl) of the `xmerl` library extracted from the OTP bundle. This fork has been modified so that a default callback function (_e.g._ `xmerl_xml:'#element#'`) can be specified for handling an element instead of the only option being to attempt to call a function matching the element name first and then calling the default element handler.

This commit also changes the `riak_cs_xml` module to pass in the tuples of `{'#element#', ElementName}` instead of just `ElementName` to directly use the default element callback function. This avoids having to implement a callback function for each and every element name and avoid the penalty of hitting the `code_server` numerous times when generating a response for a user request.

In my opinion `xmerl` is fundamentally flawed for not already having a way to directly specify a default element handler. I extracted the library and created a fork because even if we submit a patch to the OTP team to address this problem, it would still probably be 6 months or so before it made its way into a release and then more time before we would move to that new version of Erlang for Riak CS and even more time before we cut a release with it. I personally think having to add callbacks for each XML element name we might use is cumbersome and error prone. If we start using new element names and forget to add the appropriate callbacks then we silently take a performance hit. Using the fork I created we eliminate the overhead and the problem of silent performance degradation. 
