### PR TITLE
add offset to date of 'riak-cs-gc status'

### DIFF
--- a/include/riak_cs_gc_d.hrl
+++ b/include/riak_cs_gc_d.hrl
@@ -20,8 +20,8 @@
 
 -record(state, {
           interval :: 'infinity' | non_neg_integer(),
-          last :: undefined | calendar:datetime(), % the last time a deletion was scheduled
-          next :: undefined | calendar:datetime(), % the next scheduled gc time
+          last :: undefined | non_neg_integer(), % the last time a deletion was scheduled
+          next :: undefined | non_neg_integer(), % the next scheduled gc time
           riak :: undefined | pid(), % Riak connection pid
           current_files :: [lfs_manifest()],
           current_fileset :: twop_set:twop_set(),

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -43,6 +43,9 @@
 
 -define(SCRIPT_NAME, "riak-cs-gc").
 
+-define(SECONDS_PER_DAY, 86400).
+-define(DAYS_FROM_0_TO_1970, 719528).
+
 %%%===================================================================
 %%% Public API
 %%%===================================================================
@@ -183,7 +186,8 @@ human_detail(Name, Value) ->
 
 human_time(undefined) -> "unknown/never";
 human_time(Seconds) ->
-    rts:iso8601(calendar:gregorian_seconds_to_datetime(Seconds)).
+    Seconds0 = Seconds + ?DAYS_FROM_0_TO_1970*?SECONDS_PER_DAY,
+    rts:iso8601(calendar:gregorian_seconds_to_datetime(Seconds0)).
 
 parse_interval_opts([]) ->
     undefined;

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -182,9 +182,8 @@ human_detail(Name, Value) ->
     {io_lib:format("~p", [Name]), io_lib:format("~p", [Value])}.
 
 human_time(undefined) -> "unknown/never";
-human_time(Seconds) when is_integer(Seconds) ->
-    human_time(calendar:gregorian_seconds_to_datetime(Seconds));
-human_time(Datetime)  -> rts:iso8601(Datetime).
+human_time(Seconds) ->
+    rts:iso8601(calendar:gregorian_seconds_to_datetime(Seconds)).
 
 parse_interval_opts([]) ->
     undefined;

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -490,10 +490,7 @@ schedule_next(#state{interval=infinity}=State) ->
     State;
 schedule_next(#state{batch_start=Current,
                      interval=Interval}=State) ->
-    Next = calendar:gregorian_seconds_to_datetime(
-             riak_cs_gc:timestamp() + Interval),
-    _ = lager:debug("Scheduling next garbage collection for ~p",
-                    [Next]),
+    Next = riak_cs_gc:timestamp() + Interval,
     TimerRef = erlang:send_after(Interval*1000, self(), start_batch),
     State#state{batch_start=undefined,
                 last=Current,


### PR DESCRIPTION
`riak-cs-gc status`'s output looks like to need to convert epoch time to UTC.
#### before fix

```
% ./riak-cs-gc batch & ./riak-cs-gc status
[1] 6732
Garbage collection batch started.
A garbage collection batch is in progress
  The current garbage collection interval is: 900
  Last run started at: 00430917T132740Z                <------------
  Current run started at: 00430917T132742Z             <------------
  Next run scheduled for: 00430917T134240Z             <------------
  Elapsed time of current run: 0
  Files deleted in current run: 0
  Files skipped in current run: 0
  Files left in current run: 0
[1]  + 6732 done       ./riak-cs-gc batch
```
#### after fix

```
% ./riak-cs-gc batch & ./riak-cs-gc status
[1] 96703
Garbage collection batch started.
A garbage collection batch is in progress
  The current garbage collection interval is: 900
  Last run started at: 20130917T132621Z                <------------
  Current run started at: 20130917T132623Z             <------------
  Next run scheduled for: 20130917T134121Z             <------------
  Elapsed time of current run: 0
  Files deleted in current run: 0
  Files skipped in current run: 0
  Files left in current run: 0
[1]  + 96703 done       ./riak-cs-gc batch
```
