### PR TITLE
fix R16 support on velvet and new_hash macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,12 @@ OVERLAY_VARS    ?=
 CS_HTTP_PORT    ?= 8080
 PULSE_TESTS = riak_cs_get_fsm_pulse
 
-VSN := $(shell erl -eval 'io:format("~s~n", [erlang:system_info(otp_release)]), init:stop().' | grep 'R' | sed -e 's,R\(..\)B.*,\1,')
-NEW_HASH := $(shell expr $(VSN) \>= 16)
-
 .PHONY: rel stagedevrel deps test
 
 all: deps compile
 
 compile:
-ifeq ($(NEW_HASH),1)
-	@(./rebar compile -Dnew_hash)
-else
 	@(./rebar compile)
-endif
 
 compile-client-test: all
 	@./rebar client_test_compile
@@ -59,19 +52,11 @@ distclean: clean
 	@rm -rf $(PKG_ID).tar.gz
 
 test: all
-ifeq ($(NEW_HASH),1)
-	@(./rebar skip_deps=true -Dnew_hash eunit)
-else
 	@./rebar skip_deps=true eunit
-endif
 
 pulse: all
 	@rm -rf $(BASE_DIR)/.eunit
-ifeq ($(NEW_HASH),1)
-	@./rebar -D PULSE -D new_hash eunit skip_deps=true suites=$(PULSE_TESTS)
-else
 	@./rebar -D PULSE eunit skip_deps=true suites=$(PULSE_TESTS)
-endif
 
 test-client: test-clojure test-python test-erlang test-ruby test-php
 

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "6936e6ebe7861a1e45cb578c87067fc98fe16414"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "337c6b4ceec2c848ab3a835707130935f5fe8212"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "337c6b4ceec2c848ab3a835707130935f5fe8212"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "75dfa8ecd388f593b2c99b9bdd388e3fc4a79f0b"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,16 @@
-
+UpdConfig =
+    case erlang:system_info(otp_release) =< "R15B01" of
+        true ->
+            CONFIG;
+        false ->
+            HashDefine = [{d,new_hash}],
+            case lists:keysearch(erl_opts, 1, CONFIG) of
+                {value, {erl_opts, Opts}} ->
+                    lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
+                false ->
+                    [{erl_opts, HashDefine}]
+           end
+    end,
 UseEEDeps = case os:getenv("RIAK_CS_EE_DEPS") of
                 false ->
                     false;
@@ -34,9 +46,9 @@ case UseEEDeps of
 {license_full_text, \"This software is provided under license from Basho Technologies.\"}.
 {solaris_pkgname, \"BASHOriak-cs\"}.",
         file:write_file("pkg.vars.config", Bytes),
-        CONFIG;
+        UpdConfig;
     true ->
-        case lists:keysearch(deps, 1, CONFIG) of
+        case lists:keysearch(deps, 1, UpdConfig) of
             {value, {deps, Deps}} ->
                 Bytes = "%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
@@ -67,8 +79,8 @@ case UseEEDeps of
                     [
                      {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.4"}}}
                     ],
-                lists:keyreplace(deps, 1, CONFIG, {deps, Deps ++ EE_DEPS});
+                lists:keyreplace(deps, 1, UpdConfig, {deps, Deps ++ EE_DEPS});
             _ ->
-                CONFIG
+                UpdConfig
         end
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -8,7 +8,7 @@ UpdConfig =
                 {value, {erl_opts, Opts}} ->
                     lists:keyreplace(erl_opts,1,CONFIG,{erl_opts,Opts++HashDefine});
                 false ->
-                    [{erl_opts, HashDefine}]
+                    CONFIG ++ [{erl_opts, HashDefine}]
            end
     end,
 UseEEDeps = case os:getenv("RIAK_CS_EE_DEPS") of

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -31,14 +31,14 @@
 -define(CSDEVS(N), lists:concat(["rcs-dev", N, "@127.0.0.1"])).
 -define(CSDEV(N), list_to_atom(?CSDEVS(N))).
 
--define(RIAK_ROOT, build_paths.root).
--define(RIAK_CURRENT, build_paths.current).
--define(EE_ROOT, build_paths.ee_root).
--define(EE_CURRENT, build_paths.ee_current).
--define(CS_ROOT, build_paths.cs_root).
--define(CS_CURRENT, build_paths.cs_current).
--define(STANCHION_ROOT, build_paths.stanchion_root).
--define(STANCHION_CURRENT, build_paths.stanchion_current).
+-define(RIAK_ROOT, <<"build_paths.root">>).
+-define(RIAK_CURRENT, <<"build_paths.current">>).
+-define(EE_ROOT, <<"build_paths.ee_root">>).
+-define(EE_CURRENT, <<"build_paths.ee_current">>).
+-define(CS_ROOT, <<"build_paths.cs_root">>).
+-define(CS_CURRENT, <<"build_paths.cs_current">>).
+-define(STANCHION_ROOT, <<"build_paths.stanchion_root">>).
+-define(STANCHION_CURRENT, <<"build_paths.stanchion_current">>).
 
 -define(PROXY_HOST, "localhost").
 -define(S3_HOST, "s3.amazonaws.com").
@@ -147,7 +147,7 @@ riak_config(ee, Backend) ->
     riak_ee_config(Backend).
 
 riak_oss_config(Backend) ->
-    CSCurrent = rt_config:get(build_paths.cs_current),
+    CSCurrent = rt_config:get(<<"build_paths.cs_current">>),
     AddPaths = filelib:wildcard(CSCurrent ++ "/dev/dev1/lib/riak_cs*/ebin"),
     [
      lager_config(),
@@ -615,5 +615,16 @@ wait_until(Fun, Condition, Retries, Delay) ->
 
 make_authorization(Method, Resource, ContentType, Config, Date) ->
     StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n, Resource],
-    Signature = base64:encode_to_string(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    Signature =
+        base64:encode_to_string(sha_mac(Config#aws_config.secret_access_key, StringToSign)),
     lists:flatten(["AWS ", Config#aws_config.access_key_id, $:, Signature]).
+
+-ifdef(new_hash).
+sha_mac(Key,STS) -> crypto:hmac(sha, Key,STS).
+sha(Bin) -> crypto:hash(sha, Bin).
+
+-else.
+sha_mac(Key,STS) -> crypto:sha_mac(Key,STS).
+sha(Bin) -> crypto:sha(Bin).
+
+-endif.


### PR DESCRIPTION
From [Kelly's patch](https://gist.github.com/kellymclaughlin/b27755fc6eda6b55c373) , with  Stanchion ( https://github.com/basho/stanchion/pull/64 ) and velvet ( https://github.com/basho/velvet/pull/12 ).

CC: https://github.com/basho/velvet/pull/11
