### PR TITLE
Create vsn.git at priv/ under top level directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ package.src: deps
 	git archive --format=tar --prefix=$(PKG_ID)/ $(PKG_REVISION)| (cd package && tar -xf -)
 	cp rebar.config.script package/$(PKG_ID)
 	make -C package/$(PKG_ID) deps
+	mkdir -p package/$(PKG_ID)/priv
+	git --git-dir=.git describe --tags >package/$(PKG_ID)/priv/vsn.git
 	for dep in package/$(PKG_ID)/deps/*; do \
              echo "Processing dep: $${dep}"; \
              mkdir -p $${dep}/priv; \


### PR DESCRIPTION
This PR addresses #672 .

Riak does not have top level `src/*.app.src` but Riak CS and Stanchion have.
By creating `priv/vsn.git`, rebar finds it and compiles `*.app.src` .
