### PR TITLE
Fix rebar.config.script check for OTP version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,7 +33,7 @@
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.0"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
-        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "75dfa8ecd388f593b2c99b9bdd388e3fc4a79f0b"}},
+        {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "c643ab9042fc22bd623df86980663a3e6b55d0dd"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,5 +1,5 @@
 UpdConfig =
-    case erlang:system_info(otp_release) =< "R15B01" of
+    case erlang:system_info(otp_release) < "R16" of
         true ->
             CONFIG;
         false ->


### PR DESCRIPTION
Some new functions were added to the crypto API after R15B01, but the hmac/3
and hmac/4 functions did not arrive until R16. Only set new_hash if the OTP
version is R16 or above.
