### PR TITLE
Add `riak-cs-stanchion` script to riak-cs-ee packages

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -61,7 +61,7 @@ case UseEEDeps of
 {package_install_user, \"riakcs\"}.
 {package_install_group, \"riak\"}.
 {package_install_user_desc, \"Riak CS user\"}.
-{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}]]}}.
+{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}], [{name, \"riak-cs-stanchion\"}]]}}.
 {package_shortdesc, \"Riak CS\"}.
 {package_patch_dir, \"basho-patches\"}.
 {package_desc, \"Riak CS\"}.


### PR DESCRIPTION
Addresses: #684

The `riak-cs-stanchion` script was added to the riak-cs packages, but not riak-cs-ee.
