### PR TITLE
Fix riak-cs-ee build on debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,16 @@ xref: compile
 ## Packaging targets
 ##
 .PHONY: package
-export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE RIAK_CS_EE_DEPS
+export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE
+
+## Do not export RIAK_CS_EE_DEPS unless it is set, since even an empty
+## variable will affect the build and 'export' by default makes it empty
+## if it is unset
+BUILD_EE = $(shell test -n "$${RIAK_CS_EE_DEPS+x}" && echo "true" || echo "false")
+ifeq ($(BUILD_EE),true)
+export RIAK_CS_EE_DEPS=true
+endif
+
 
 package.src: deps
 	mkdir -p package

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
 ]}.
 
 {deps, [
-        {node_package, "1.3.4", {git, "git://github.com/basho/node_package", {tag, "1.3.4"}}},
+        {node_package, "1.3.8", {git, "git://github.com/basho/node_package", {tag, "1.3.8"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,10 +1,10 @@
 
 UseEEDeps = case os:getenv("RIAK_CS_EE_DEPS") of
                 false ->
-                    false;
-                [] ->
+                    io:format("Building riak-cs~n"),
                     false;
                 _ ->
+                    io:format("Building riak-cs-ee~n"),
                     true
             end,
 case UseEEDeps of
@@ -61,7 +61,8 @@ case UseEEDeps of
 {vendor_contact_name, \"Basho Package Maintainer\"}.
 {vendor_contact_email, \"packaging@basho.com\"}.
 {license_full_text, \"This software is provided under license from Basho Technologies.\"}.
-{solaris_pkgname, \"BASHOriak-cs-ee\"}.",
+{solaris_pkgname, \"BASHOriak-cs-ee\"}.
+{debuild_extra_options, \"-e RIAK_CS_EE_DEPS=true\"}.",
                 file:write_file("pkg.vars.config", Bytes),
                 EE_DEPS =
                     [


### PR DESCRIPTION
## Description

During build of debian packages, the environment is cleaned by debuild
by setting all environmental variables to "".  This fact made the
passing of RIAK_CS_EE_DEPS variable work on accident until the `[]->false`
pattern was added to the rebar.config.script.  Though adding that
pattern fixed the OSS build, it did break debian package builds.

This commit fixes this by removing that check, but also not
automatically exporting the RIAK_CS_EE_DEPS makefile since an export
will export an empty variable and the rebar.config.script can now
trigger on an empty setting again.

Calling `unset RIAK_CS_EE_DEPS` is the only way to build an OSS
build after previously exporting the variable for riak-cs-ee.

In addtion a flag is passed into the debian's debuild so when
it RIAK_CS_EE_DEPS is available even when the environment is cleaned.
## Testing

Testing this is really annoying, so I did it myself and recorded my steps if anyone wants to sanity check.
### Case of unset variable

```
$ unset RIAK_CS_EE_DEPS
$ env | grep RIAK_CS_EE_DEPS

# Confirm rebar works w/o make
$ ./rebar get-deps
Building riak-cs
==> rel (get-deps)
==> riak_cs (get-deps)
<snip>

# Confirm same with make
$ make deps
Building riak-cs
==> rel (get-deps)
==> riak_cs (get-deps)

# Confirm package does not build EE version
$ make dist
Building riak-cs
<snip>
tar -C package -czf package/riak-cs-1.4.1.7.g9299226.tar.gz riak-cs-1.4.1.7.g9299226
cp package/riak-cs-1.4.1.7.g9299226.tar.gz .
# confirm make didn't add a variable and cause submake to build EE
$ diff pkg.vars.config package/riak-cs-1.4.1.7.g9299226/pkg.vars.config
$ grep package_name pkg.vars.config
{package_name, "riak-cs"}.
$ tar -tzf package/riak-cs-1.4.1.7.g9299226.tar.gz | grep riak_repl
```
### Case of set variable

```
$ export RIAK_CS_EE_DEPS=true
$ env | grep RIAK_CS_EE_DEPS
RIAK_CS_EE_DEPS=true
$ ./rebar get-deps
Building riak-cs-ee
==> rel (get-deps)
==> riak_cs (get-deps)
<snip>
$ make dist
Building riak-cs-ee
==> rel (get-deps)
==> riak_cs (get-deps)
<snip>
tar -C package -czf package/riak-cs-1.4.1.7.g9299226.tar.gz riak-cs-1.4.1.7.g9299226
cp package/riak-cs-1.4.1.7.g9299226.tar.gz .
$ diff pkg.vars.config package/riak-cs-1.4.1.7.g9299226/pkg.vars.config
$ grep package_name pkg.vars.config
{package_name, "riak-cs-ee"}.
$ tar -tzf package/riak-cs-1.4.1.7.g9299226.tar.gz| grep riak_repl
<snip>
riak-cs-1.4.1.7.g9299226/deps/riak_repl_pb_api/src/riak_repl_pb_api.app.src
riak-cs-1.4.1.7.g9299226/deps/riak_repl_pb_api/src/riak_repl_pb_api.erl
riak-cs-1.4.1.7.g9299226/deps/riak_repl_pb_api/priv/vsn.git

```
#### Testing package on Ubuntu

```
$ git checkout bugfix/jem-debian-missing-repl-cs-ee
Branch bugfix/jem-debian-missing-repl-cs-ee set up to track remote branch bugfix/jem-debian-missing-repl-cs-ee from origin.
Switched to a new branch 'bugfix/jem-debian-missing-repl-cs-ee'
$ uname -a
Linux build-ubuntu-1204-64 3.2.0-40-generic #64-Ubuntu SMP Mon Mar 25 21:22:10 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
$ env | grep RIAK_CS_EE_DEPS
$ export RIAK_CS_EE_DEPS=true
$ env | grep RIAK_CS_EE_DEPS
RIAK_CS_EE_DEPS=true
$ make package
Building riak-cs-ee
==> rel (get-deps)
==> riak_cs (get-deps)
<snip>
$ dpkg-deb -c package/packages/riak-cs-ee_1.4.1.10.g028bb83-1_amd64.deb | grep riak_repl
<snip>
-rw-r--r-- root/root      7532 2013-10-03 16:51 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.3/ebin/riak_repl_pb_api.beam
-rw-r--r-- root/root       255 2013-10-03 16:51 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.3/ebin/riak_repl_pb_api.app
-rw-r--r-- root/root     12520 2013-10-03 16:51 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.3/ebin/riak_repl_pb.beam
drwxr-xr-x root/root         0 2013-10-03 16:51 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.3/include/
-rw-r--r-- root/root       690 2013-10-03 16:51 ./usr/lib/riak-cs/lib/riak_repl_pb_api-0.2.3/include/riak_repl_pb.hrl
```
### Case of empty variable, but set (should act same as set variable)

```
$ export RIAK_CS_EE_DEPS=
$ env | grep RIAK_CS_EE_DEPS
RIAK_CS_EE_DEPS=
$ ./rebar get-deps
Building riak-cs-ee
==> rel (get-deps)
==> riak_cs (get-deps)
<snip>
$ make deps
Building riak-cs-ee
==> rel (get-deps)
<snip>
```
