### PR TITLE
Add option to allow a delay for the initial GC collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,16 @@ xref: compile
 ## Packaging targets
 ##
 .PHONY: package
-export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE RIAK_CS_EE_DEPS
+export PKG_VERSION PKG_ID PKG_BUILD BASE_DIR ERLANG_BIN REBAR OVERLAY_VARS RELEASE
+
+## Do not export RIAK_CS_EE_DEPS unless it is set, since even an empty
+## variable will affect the build and 'export' by default makes it empty
+## if it is unset
+BUILD_EE = $(shell test -n "$${RIAK_CS_EE_DEPS+x}" && echo "true" || echo "false")
+ifeq ($(BUILD_EE),true)
+export RIAK_CS_EE_DEPS=true
+endif
+
 
 package.src: deps
 	mkdir -p package

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ package.src: deps
 	git archive --format=tar --prefix=$(PKG_ID)/ $(PKG_REVISION)| (cd package && tar -xf -)
 	cp rebar.config.script package/$(PKG_ID)
 	make -C package/$(PKG_ID) deps
+	mkdir -p package/$(PKG_ID)/priv
+	git --git-dir=.git describe --tags >package/$(PKG_ID)/priv/vsn.git
 	for dep in package/$(PKG_ID)/deps/*; do \
              echo "Processing dep: $${dep}"; \
              mkdir -p $${dep}/priv; \

--- a/include/riak_cs_gc_d.hrl
+++ b/include/riak_cs_gc_d.hrl
@@ -35,5 +35,6 @@
           pause_state :: undefined | atom(), % state of the fsm when a delete batch was paused
           interval_remaining :: undefined | non_neg_integer(), % used when moving from paused -> idle
           timer_ref :: reference(),
-          delete_fsm_pid :: pid()
+          delete_fsm_pid :: pid(),
+          initial_delay :: non_neg_integer()
          }).

--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
 ]}.
 
 {deps, [
-        {node_package, "1.3.4", {git, "git://github.com/basho/node_package", {tag, "1.3.4"}}},
+        {node_package, "1.3.8", {git, "git://github.com/basho/node_package", {tag, "1.3.8"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.0"}}},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,10 +1,10 @@
 
 UseEEDeps = case os:getenv("RIAK_CS_EE_DEPS") of
                 false ->
-                    false;
-                [] ->
+                    io:format("Building riak-cs~n"),
                     false;
                 _ ->
+                    io:format("Building riak-cs-ee~n"),
                     true
             end,
 case UseEEDeps of
@@ -61,7 +61,8 @@ case UseEEDeps of
 {vendor_contact_name, \"Basho Package Maintainer\"}.
 {vendor_contact_email, \"packaging@basho.com\"}.
 {license_full_text, \"This software is provided under license from Basho Technologies.\"}.
-{solaris_pkgname, \"BASHOriak-cs-ee\"}.",
+{solaris_pkgname, \"BASHOriak-cs-ee\"}.
+{debuild_extra_options, \"-e RIAK_CS_EE_DEPS=true\"}.",
                 file:write_file("pkg.vars.config", Bytes),
                 EE_DEPS =
                     [

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -31,6 +31,7 @@
 %% export Public API
 -export([decode_and_merge_siblings/2,
          gc_interval/0,
+         initial_gc_delay/0,
          gc_retry_interval/0,
          gc_active_manifests/3,
          gc_specific_manifests/5,
@@ -55,7 +56,7 @@
 %% Note that any error is irrespective of the current position of the GC states.
 %% Some manifests may have been GC'd and then an error occurs. In this case the
 %% client will only get the error response.
--spec gc_active_manifests(binary(), binary(), pid()) -> 
+-spec gc_active_manifests(binary(), binary(), pid()) ->
     {ok, [binary()]} | {error, term()}.
 gc_active_manifests(Bucket, Key, RiakcPid) ->
     gc_active_manifests(Bucket, Key, RiakcPid, []).
@@ -65,19 +66,19 @@ gc_active_manifests(Bucket, Key, RiakcPid) ->
     {ok, [binary()]} | {error, term()}.
 gc_active_manifests(Bucket, Key, RiakcPid, UUIDs) ->
    case get_active_manifests(Bucket, Key, RiakcPid) of
-        {ok, _RiakObject, []} -> 
+        {ok, _RiakObject, []} ->
             {ok, UUIDs};
         {ok, RiakObject, Manifests} ->
             UnchangedManifests = clean_manifests(Manifests, RiakcPid),
             case gc_manifests(UnchangedManifests, RiakObject, Bucket, Key, RiakcPid) of
-                {error, _}=Error -> 
+                {error, _}=Error ->
                     Error;
-                NewUUIDs -> 
+                NewUUIDs ->
                     gc_active_manifests(Bucket, Key, RiakcPid, UUIDs ++ NewUUIDs)
             end;
         {error, notfound} ->
             {ok, UUIDs};
-        {error, _}=Error -> 
+        {error, _}=Error ->
             Error
     end.
 
@@ -87,25 +88,25 @@ get_active_manifests(Bucket, Key, RiakcPid) ->
     active_manifests(riak_cs_utils:get_manifests(RiakcPid, Bucket, Key)).
 
 -spec active_manifests({ok, riakc_obj:riakc_obj(), [lfs_manifest()]}) ->
-                          {ok, riakc_obj:riakc_obj(), [lfs_manifest()]}; 
+                          {ok, riakc_obj:riakc_obj(), [lfs_manifest()]};
                       ({error, term()}) ->
                           {error, term()}.
-active_manifests({ok, RiakObject, Manifests}) -> 
+active_manifests({ok, RiakObject, Manifests}) ->
     {ok, RiakObject, riak_cs_manifest_utils:active_manifests(Manifests)};
-active_manifests({error, _}=Error) -> 
+active_manifests({error, _}=Error) ->
     Error.
 
 -spec clean_manifests([lfs_manifest()], pid()) -> [lfs_manifest()].
 clean_manifests(ActiveManifests, RiakcPid) ->
-    [M || M <- ActiveManifests, clean_multipart_manifest(M, RiakcPid)]. 
+    [M || M <- ActiveManifests, clean_multipart_manifest(M, RiakcPid)].
 
 -spec clean_multipart_manifest(lfs_manifest(), pid()) -> true | false.
 clean_multipart_manifest(M, RiakcPid) ->
     is_multipart_clean(riak_cs_mp_utils:clean_multipart_unused_parts(M, RiakcPid)).
 
-is_multipart_clean(same) -> 
+is_multipart_clean(same) ->
     true;
-is_multipart_clean(updated) -> 
+is_multipart_clean(updated) ->
     false.
 
 -spec gc_manifests(Manifests :: [lfs_manifest()],
@@ -117,9 +118,9 @@ is_multipart_clean(updated) ->
 gc_manifests(Manifests, RiakObject, Bucket, Key, RiakcPid) ->
     F = fun(_M, {error, _}=Error) ->
                Error;
-           (M, UUIDs) -> 
-               gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs) 
-        end, 
+           (M, UUIDs) ->
+               gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs)
+        end,
     lists:foldl(F, [], Manifests).
 
 -spec gc_manifest(M :: lfs_manifest(),
@@ -133,9 +134,9 @@ gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs) ->
     UUID = M?MANIFEST.uuid,
     check(gc_specific_manifests_to_delete([UUID], RiakObject, Bucket, Key, RiakcPid), [UUID | UUIDs]).
 
-check({ok, _}, Val) -> 
+check({ok, _}, Val) ->
     Val;
-check({error, _}=Error, _Val) -> 
+check({error, _}=Error, _Val) ->
     Error.
 
 -spec gc_specific_manifests_to_delete(UUIDsToMark :: [binary()],
@@ -209,6 +210,17 @@ gc_interval() ->
             ?DEFAULT_GC_INTERVAL;
         {ok, Interval} ->
             Interval
+    end.
+
+%% @doc Return the number of seconds to wait in addition to the
+%% specified GC interval before scheduling the initial GC collection.
+-spec initial_gc_delay() -> non_neg_integer().
+initial_gc_delay() ->
+    case application:get_env(riak_cs, initial_gc_delay) of
+        undefined ->
+            0;
+        {ok, Delay} ->
+            Delay
     end.
 
 %% @doc Return the number of seconds to wait before rescheduling a

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -142,7 +142,9 @@ stop() ->
 
 init(_Args) ->
     Interval = riak_cs_gc:gc_interval(),
-    SchedState = schedule_next(#state{interval=Interval}),
+    InitialDelay = riak_cs_gc:initial_gc_delay(),
+    SchedState = schedule_next(#state{interval=Interval,
+                                      initial_delay=InitialDelay}),
     {ok, idle, SchedState}.
 
 %% Asynchronous events
@@ -489,7 +491,8 @@ schedule_next(#state{interval=infinity}=State) ->
     %% nothing to schedule, all triggers manual
     State;
 schedule_next(#state{batch_start=Current,
-                     interval=Interval}=State) ->
+                     interval=Interval,
+                     initial_delay=undefined}=State) ->
     Next = calendar:gregorian_seconds_to_datetime(
              riak_cs_gc:timestamp() + Interval),
     _ = lager:debug("Scheduling next garbage collection for ~p",
@@ -498,7 +501,21 @@ schedule_next(#state{batch_start=Current,
     State#state{batch_start=undefined,
                 last=Current,
                 next=Next,
-                timer_ref=TimerRef}.
+                timer_ref=TimerRef};
+schedule_next(#state{batch_start=Current,
+                     interval=Interval,
+                     initial_delay=InitialDelay}=State) ->
+    Next = calendar:gregorian_seconds_to_datetime(
+             riak_cs_gc:timestamp() + Interval),
+    _ = lager:debug("Scheduling next garbage collection for ~p",
+                    [Next]),
+    TimerValue = Interval * 1000 + InitialDelay * 1000,
+    TimerRef = erlang:send_after(TimerValue, self(), start_batch),
+    State#state{batch_start=undefined,
+                last=Current,
+                next=Next,
+                timer_ref=TimerRef,
+                initial_delay=undefined}.
 
 %% @doc Actually kick off the batch.  After calling this function, you
 %% must advance the FSM state to `fetching_next_fileset'.

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -288,27 +288,33 @@ upgrade_manifest(#lfs_manifest_v2{block_size=BlockSize,
                                  props=Properties,
                                  cluster_id=ClusterID}) ->
 
-    ?MANIFEST{block_size=BlockSize,
-              bkey=Bkey,
-              metadata=Metadata,
-              created=Created,
-              uuid=UUID,
-              content_length=ContentLength,
-              content_type=ContentType,
-              content_md5=ContentMd5,
-              state=State,
-              write_start_time=WriteStartTime,
-              last_block_written_time=LastBlockWrittenTime,
-              write_blocks_remaining=WriteBlocksRemaining,
-              delete_marked_time=DeleteMarkedTime,
-              last_block_deleted_time=LastBlockDeletedTime,
-              delete_blocks_remaining=DeleteBlocksRemaining,
-              acl=Acl,
-              props=Properties,
-              cluster_id=ClusterID};
+    upgrade_manifest(?MANIFEST{block_size=BlockSize,
+                               bkey=Bkey,
+                               metadata=Metadata,
+                               created=Created,
+                               uuid=UUID,
+                               content_length=ContentLength,
+                               content_type=ContentType,
+                               content_md5=ContentMd5,
+                               state=State,
+                               write_start_time=WriteStartTime,
+                               last_block_written_time=LastBlockWrittenTime,
+                               write_blocks_remaining=WriteBlocksRemaining,
+                               delete_marked_time=DeleteMarkedTime,
+                               last_block_deleted_time=LastBlockDeletedTime,
+                               delete_blocks_remaining=DeleteBlocksRemaining,
+                               acl=Acl,
+                               props=Properties,
+                               cluster_id=ClusterID});
 
-upgrade_manifest(?MANIFEST{}=M) ->
-    M.
+upgrade_manifest(?MANIFEST{props=Props}=M) ->
+    M?MANIFEST{props=fixup_props(Props)}.
+
+-spec fixup_props(undefined | list()) -> list().
+fixup_props(undefined) ->
+    [];
+fixup_props(Props) when is_list(Props) ->
+    Props.
 
 %%%===================================================================
 %%% Internal functions

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -516,8 +516,13 @@ map_keys_and_manifests(Object, _, _) ->
                 []
         end
     catch Type:Reason ->
-            _ = lager:warning("Riak CS object list map failed: ~p:~p",
-                              [Type, Reason]),
+            _ = lager:log(error,
+                          self(),
+                          "Riak CS object list map failed for ~p:~p with reason ~p:~p",
+                          [riak_object:bucket(Object),
+                           riak_object:key(Object),
+                           Type,
+                           Reason]),
             []
     end.
 


### PR DESCRIPTION
Add an option that allows the initial run of the GC daemon to be delay by some
number of seconds. This provides a convenient way for the GC daemon to be run
on multiple nodes without overlapping the collection and cleanup effort among
nodes. The option is called initial_gc_delay and is specified in seconds. The
value only applies to the initial collection run when the riak_cs node is
started.
