### PR TITLE
Append random number to epoch binary

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -458,6 +458,7 @@
 -define(DEFAULT_LEEWAY_SECONDS, 86400). %% 24-hours
 -define(DEFAULT_GC_INTERVAL, 900). %% 15 minutes
 -define(DEFAULT_GC_RETRY_INTERVAL, 21600). %% 6 hours
+-define(DEFAULT_GC_KEY_SUFFIX_MAX, 256).
 -define(EPOCH_START, <<"0">>).
 -define(DEFAULT_CLUSTER_ID_TIMEOUT,5000).
 -define(DEFAULT_AUTH_MODULE, riak_cs_s3_auth).

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -42,7 +42,9 @@
          riak_cs_stat/0,
          set_md5_chunk_size/1,
          use_t2b_compression/0,
-         trust_x_forwarded_for/0
+         trust_x_forwarded_for/0,
+         gc_key_suffix_max/0,
+         set_gc_key_suffix_max/1
         ]).
 
 %% OpenStack config
@@ -239,6 +241,18 @@ trust_x_forwarded_for() ->
             false;
         undefined -> false %% secure by default!
     end.
+
+%% @doc Return the max value for GC bucket key suffix.
+%% A suffix value is a random integer between 1 and the returned value.
+-spec gc_key_suffix_max() -> pos_integer().
+gc_key_suffix_max() ->
+    get_env(riak_cs, gc_key_suffix_max, ?DEFAULT_GC_KEY_SUFFIX_MAX).
+
+-spec set_gc_key_suffix_max(integer()) -> ok | {error, invalid_value}.
+set_gc_key_suffix_max(MaxValue) when is_integer(MaxValue) andalso MaxValue > 0 ->
+    application:set_env(riak_cs, gc_key_suffix_max, MaxValue);
+set_gc_key_suffix_max(_MaxValue) ->
+    {error, invalid_value}.
 
 %% ===================================================================
 %% S3 config options

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -250,6 +250,7 @@ leeway_seconds() ->
 timestamp() ->
     timestamp(os:timestamp()).
 
+-spec timestamp(erlang:timestamp()) -> non_neg_integer().
 timestamp(ErlangTime) ->
     riak_cs_utils:second_resolution_timestamp(ErlangTime).
 
@@ -344,17 +345,17 @@ build_manifest_set(Manifests) ->
 -spec generate_key(boolean()) -> binary().
 generate_key(AddLeewayP) ->
     Now = os:timestamp(),
-    list_to_binary([integer_to_list(key_timestamp(Now, AddLeewayP)),
-                    $_,
-                    key_suffix(Now)]).
+    list_to_binary([key_timestamp(Now, AddLeewayP), $_, key_suffix(Now)]).
 
+-spec key_timestamp(erlang:timestamp(), boolean()) -> string().
 key_timestamp(Time, true) ->
-    timestamp(Time) + leeway_seconds();
+    integer_to_list(timestamp(Time) + leeway_seconds());
 key_timestamp(Time, false) ->
-    timestamp(Time).
+    integer_to_list(timestamp(Time)).
 
+-spec key_suffix(erlang:timestamp()) -> string().
 key_suffix(Time) ->
-    random:seed(Time),
+    _ = random:seed(Time),
     integer_to_list(random:uniform(riak_cs_config:gc_key_suffix_max())).
 
 %% @doc Given a list of riakc_obj-flavored object (with potentially

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -346,14 +346,18 @@ build_manifest_set(Manifests) ->
 -spec generate_key(boolean()) -> binary().
 generate_key(AddLeewayP) ->
     Now = os:timestamp(),
-    random:seed(Now),
-    list_to_binary(
-      [integer_to_list(
-         timestamp(Now) + if not AddLeewayP -> 0;
-                             true           -> leeway_seconds()
-                          end),
-       $_,
-       integer_to_list(random:uniform(?GC_KEY_SUFFIX_MAX))]).
+    list_to_binary([integer_to_list(key_timestamp(Now, AddLeewayP)),
+                    $_,
+                    key_suffix(Now)]).
+
+key_timestamp(Time, true) ->
+    timestamp(Time) + leeway_seconds();
+key_timestamp(Time, false) ->
+    timestamp(Time).
+
+key_suffix(Time) ->
+    random:seed(Time),
+    integer_to_list(random:uniform(?GC_KEY_SUFFIX_MAX)).
 
 %% @doc Given a list of riakc_obj-flavored object (with potentially
 %%      many siblings and perhaps a tombstone), decode and merge them.

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -42,8 +42,6 @@
 %% export for repl debugging and testing
 -export([get_active_manifests/3]).
 
--define(GC_KEY_SUFFIX_MAX, 1000).
-
 %%%===================================================================
 %%% Public API
 %%%===================================================================
@@ -357,7 +355,7 @@ key_timestamp(Time, false) ->
 
 key_suffix(Time) ->
     random:seed(Time),
-    integer_to_list(random:uniform(?GC_KEY_SUFFIX_MAX)).
+    integer_to_list(random:uniform(riak_cs_config:gc_key_suffix_max())).
 
 %% @doc Given a list of riakc_obj-flavored object (with potentially
 %%      many siblings and perhaps a tombstone), decode and merge them.


### PR DESCRIPTION
This PR addresses #681 .

Every CS DELETE execute GET/PUT to a single BKey = {riak-cs-gc, Epoch}.
Appending random number to Epoch (hopefully) solve this hot key problem.

GC daemon can collect garbage with suffixed key because it accesses
keys by binary range 2i.
