### PR TITLE
Make logging in bucket listing map function lager version agnostic

### DIFF
--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -516,8 +516,13 @@ map_keys_and_manifests(Object, _, _) ->
                 []
         end
     catch Type:Reason ->
-            _ = lager:warning("Riak CS object list map failed: ~p:~p",
-                              [Type, Reason]),
+            _ = lager:log(error,
+                          self(),
+                          "Riak CS object list map failed for ~p:~p with reason ~p:~p",
+                          [riak_object:bucket(Object),
+                           riak_object:key(Object),
+                           Type,
+                           Reason]),
             []
     end.
 


### PR DESCRIPTION
The parse transform for lager changed between lager 1.2.X and lager 2.0.0.
This causes problems listing the contents of buckets when using Riak CS 1.4 or
later with older versions of Riak because the map_keys_and_manifests function
is run on Riak nodes as part of a MapReduce job. That function contains a
lager call that is rewritten to use a lager module that did not exist in
versions prior to 2.0.0 and when run on Riak nodes that still uses an earlier
lager version it can result in errors. The errors happen when the bucket that
a list operation is run against contains a deleted object. This commit changes
the lager call in the map_keys_and_manifests function to use a call that is
not transformed and is safe for older Riak versions as well as the 1.4.X
releases.
