### PR TITLE
Add option to allow a delay for the initial GC collection

### DIFF
--- a/include/riak_cs_gc_d.hrl
+++ b/include/riak_cs_gc_d.hrl
@@ -35,5 +35,6 @@
           pause_state :: undefined | atom(), % state of the fsm when a delete batch was paused
           interval_remaining :: undefined | non_neg_integer(), % used when moving from paused -> idle
           timer_ref :: reference(),
-          delete_fsm_pid :: pid()
+          delete_fsm_pid :: pid(),
+          initial_delay :: non_neg_integer()
          }).

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -31,6 +31,7 @@
 %% export Public API
 -export([decode_and_merge_siblings/2,
          gc_interval/0,
+         initial_gc_delay/0,
          gc_retry_interval/0,
          gc_active_manifests/3,
          gc_specific_manifests/5,
@@ -55,7 +56,7 @@
 %% Note that any error is irrespective of the current position of the GC states.
 %% Some manifests may have been GC'd and then an error occurs. In this case the
 %% client will only get the error response.
--spec gc_active_manifests(binary(), binary(), pid()) -> 
+-spec gc_active_manifests(binary(), binary(), pid()) ->
     {ok, [binary()]} | {error, term()}.
 gc_active_manifests(Bucket, Key, RiakcPid) ->
     gc_active_manifests(Bucket, Key, RiakcPid, []).
@@ -65,19 +66,19 @@ gc_active_manifests(Bucket, Key, RiakcPid) ->
     {ok, [binary()]} | {error, term()}.
 gc_active_manifests(Bucket, Key, RiakcPid, UUIDs) ->
    case get_active_manifests(Bucket, Key, RiakcPid) of
-        {ok, _RiakObject, []} -> 
+        {ok, _RiakObject, []} ->
             {ok, UUIDs};
         {ok, RiakObject, Manifests} ->
             UnchangedManifests = clean_manifests(Manifests, RiakcPid),
             case gc_manifests(UnchangedManifests, RiakObject, Bucket, Key, RiakcPid) of
-                {error, _}=Error -> 
+                {error, _}=Error ->
                     Error;
-                NewUUIDs -> 
+                NewUUIDs ->
                     gc_active_manifests(Bucket, Key, RiakcPid, UUIDs ++ NewUUIDs)
             end;
         {error, notfound} ->
             {ok, UUIDs};
-        {error, _}=Error -> 
+        {error, _}=Error ->
             Error
     end.
 
@@ -87,25 +88,25 @@ get_active_manifests(Bucket, Key, RiakcPid) ->
     active_manifests(riak_cs_utils:get_manifests(RiakcPid, Bucket, Key)).
 
 -spec active_manifests({ok, riakc_obj:riakc_obj(), [lfs_manifest()]}) ->
-                          {ok, riakc_obj:riakc_obj(), [lfs_manifest()]}; 
+                          {ok, riakc_obj:riakc_obj(), [lfs_manifest()]};
                       ({error, term()}) ->
                           {error, term()}.
-active_manifests({ok, RiakObject, Manifests}) -> 
+active_manifests({ok, RiakObject, Manifests}) ->
     {ok, RiakObject, riak_cs_manifest_utils:active_manifests(Manifests)};
-active_manifests({error, _}=Error) -> 
+active_manifests({error, _}=Error) ->
     Error.
 
 -spec clean_manifests([lfs_manifest()], pid()) -> [lfs_manifest()].
 clean_manifests(ActiveManifests, RiakcPid) ->
-    [M || M <- ActiveManifests, clean_multipart_manifest(M, RiakcPid)]. 
+    [M || M <- ActiveManifests, clean_multipart_manifest(M, RiakcPid)].
 
 -spec clean_multipart_manifest(lfs_manifest(), pid()) -> true | false.
 clean_multipart_manifest(M, RiakcPid) ->
     is_multipart_clean(riak_cs_mp_utils:clean_multipart_unused_parts(M, RiakcPid)).
 
-is_multipart_clean(same) -> 
+is_multipart_clean(same) ->
     true;
-is_multipart_clean(updated) -> 
+is_multipart_clean(updated) ->
     false.
 
 -spec gc_manifests(Manifests :: [lfs_manifest()],
@@ -117,9 +118,9 @@ is_multipart_clean(updated) ->
 gc_manifests(Manifests, RiakObject, Bucket, Key, RiakcPid) ->
     F = fun(_M, {error, _}=Error) ->
                Error;
-           (M, UUIDs) -> 
-               gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs) 
-        end, 
+           (M, UUIDs) ->
+               gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs)
+        end,
     lists:foldl(F, [], Manifests).
 
 -spec gc_manifest(M :: lfs_manifest(),
@@ -133,9 +134,9 @@ gc_manifest(M, RiakObject, Bucket, Key, RiakcPid, UUIDs) ->
     UUID = M?MANIFEST.uuid,
     check(gc_specific_manifests_to_delete([UUID], RiakObject, Bucket, Key, RiakcPid), [UUID | UUIDs]).
 
-check({ok, _}, Val) -> 
+check({ok, _}, Val) ->
     Val;
-check({error, _}=Error, _Val) -> 
+check({error, _}=Error, _Val) ->
     Error.
 
 -spec gc_specific_manifests_to_delete(UUIDsToMark :: [binary()],
@@ -209,6 +210,17 @@ gc_interval() ->
             ?DEFAULT_GC_INTERVAL;
         {ok, Interval} ->
             Interval
+    end.
+
+%% @doc Return the number of seconds to wait in addition to the
+%% specified GC interval before scheduling the initial GC collection.
+-spec initial_gc_delay() -> non_neg_integer().
+initial_gc_delay() ->
+    case application:get_env(riak_cs, initial_gc_delay) of
+        undefined ->
+            0;
+        {ok, Delay} ->
+            Delay
     end.
 
 %% @doc Return the number of seconds to wait before rescheduling a

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -142,7 +142,9 @@ stop() ->
 
 init(_Args) ->
     Interval = riak_cs_gc:gc_interval(),
-    SchedState = schedule_next(#state{interval=Interval}),
+    InitialDelay = riak_cs_gc:initial_gc_delay(),
+    SchedState = schedule_next(#state{interval=Interval,
+                                      initial_delay=InitialDelay}),
     {ok, idle, SchedState}.
 
 %% Asynchronous events
@@ -489,7 +491,8 @@ schedule_next(#state{interval=infinity}=State) ->
     %% nothing to schedule, all triggers manual
     State;
 schedule_next(#state{batch_start=Current,
-                     interval=Interval}=State) ->
+                     interval=Interval,
+                     initial_delay=undefined}=State) ->
     Next = calendar:gregorian_seconds_to_datetime(
              riak_cs_gc:timestamp() + Interval),
     _ = lager:debug("Scheduling next garbage collection for ~p",
@@ -498,7 +501,21 @@ schedule_next(#state{batch_start=Current,
     State#state{batch_start=undefined,
                 last=Current,
                 next=Next,
-                timer_ref=TimerRef}.
+                timer_ref=TimerRef};
+schedule_next(#state{batch_start=Current,
+                     interval=Interval,
+                     initial_delay=InitialDelay}=State) ->
+    Next = calendar:gregorian_seconds_to_datetime(
+             riak_cs_gc:timestamp() + Interval),
+    _ = lager:debug("Scheduling next garbage collection for ~p",
+                    [Next]),
+    TimerValue = Interval * 1000 + InitialDelay * 1000,
+    TimerRef = erlang:send_after(TimerValue, self(), start_batch),
+    State#state{batch_start=undefined,
+                last=Current,
+                next=Next,
+                timer_ref=TimerRef,
+                initial_delay=undefined}.
 
 %% @doc Actually kick off the batch.  After calling this function, you
 %% must advance the FSM state to `fetching_next_fileset'.


### PR DESCRIPTION
Add an option that allows the initial run of the GC daemon to be delay
by some number of seconds. This provides a convenient way for the GC
daemon to be run on multiple nodes without overlapping the collection
and cleanup effort among nodes. The option is called initial_gc_delay
and is specified in seconds. The value only applies to the initial
collection run when the riak_cs node is started.
