### PR TITLE
Set pb_backlog in Riak config for riak_test runs

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -153,6 +153,8 @@ riak_oss_config(Backend) ->
      lager_config(),
      {riak_core,
       [{default_bucket_props, [{allow_mult, true}]}]},
+     {riak_api,
+      [{pb_backlog, 256}]},
      {riak_kv,
       [{add_paths, AddPaths}] ++
           backend_config(Backend)


### PR DESCRIPTION
Backport of #665 to `release/1.4` branch.

Specify a pb_backlog of 256 in the Riak app.config for riak_test runs
to avoid spurious riak_test failures due to disconnected Riak pids.
