### PR TITLE
Refer forked xmerl to avoid many undef exceptions thrown

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "8739ba8d1630682830be0b95b45cfcbe933b6ad0"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
+        {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
        ]}.


### PR DESCRIPTION
Original issue: #669 

Add forked xmerl to deps which refers https://github.com/shino/xmerl/pull/2 .
Xmerl source is based on Kelly's fork, updated to R16B02's and fetched the following change.
- Pull request to erlang/otp by Richard Carlsson: https://github.com/erlang/otp/pull/87

The PR was already merged to both maint and master.
Once new Erlang/OTP will be released (probably R16B03), we don't need forked one any more.
