### PR TITLE
Improve handling of Riak disconnection errors on object downloads

### DIFF
--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -281,6 +281,9 @@ try_local_get(RiakcPid, FullBucket, FullKey, GetOptions1, GetOptions2,
             handle_local_notfound(RiakcPid, FullBucket, FullKey, GetOptions2,
                                   ProceedFun, RetryFun, NumRetries, UseProxyGet,
                                   ProxyActive, ClusterID);
+        {error, disconnected} ->
+            _ = lager:error("do_get_block: socket disconnected"),
+            RetryFun(NumRetries + 1);
         {error, Other} ->
             _ = lager:error("do_get_block: other error 1: ~p\n", [Other]),
             RetryFun(failure)
@@ -312,6 +315,9 @@ handle_local_notfound(RiakcPid, FullBucket, FullKey, GetOptions2,
                 false ->
                     RetryFun(failure)
             end;
+        {error, disconnected} ->
+            _ = lager:error("do_get_block: socket disconnected"),
+            RetryFun(NumRetries + 1);
         {error, Other} ->
             _ = lager:error("do_get_block: other error 2: ~p\n", [Other]),
             RetryFun(failure)


### PR DESCRIPTION
Change the behavior when a Riak connection is closed during an object 
downloading. There is existing retry logic to handle the case when n_val=1
block requests fail with a notfound or timeout error. It is desirable to also
retry requests in the case of a transient connection failure, especially in
the case of the download of a sizable object. Allowing the disconnect error to
trigger the retry logic provides time for the automatic reconnection process
to work and provides a mechanism for in-progress downloads to continue and 
complete successfully.
