### PR TITLE
Add Riak Disk Stats WM API (DO NOT MERGE)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,5 +36,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "8739ba8d1630682830be0b95b45cfcbe933b6ad0"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}},
+        {riakhttpc, ".*", {git, "git://github.com/basho/riak-erlang-http-client.git", {branch, "master"}}}
        ]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -14,6 +14,7 @@
          runtime_tools,
          mochiweb,
          webmachine,
+         riakhttpc,
          lager,
          lager_syslog,
          poolboy,

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -17,6 +17,7 @@
 {admin_port,        8000}.
 {riak_ip,           "127.0.0.1"}.
 {riak_pb_port,      8087}.
+{riak_http_port,    8098}.
 {auth_bypass,       false}.
 {admin_key,         "admin-key"}.
 {admin_secret,      "admin-secret"}.

--- a/src/riak_cs_riak_http_client.erl
+++ b/src/riak_cs_riak_http_client.erl
@@ -1,0 +1,49 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Entry point for a non-pooled HTTP connection to Riak
+
+-module(riak_cs_riak_http_client).
+
+-export([riak_http_host_port/0,
+         get_rhc/0
+]).
+
+-spec riak_http_host_port() -> {string(), pos_integer()}.
+riak_http_host_port() ->
+    case application:get_env(riak_cs, riak_ip) of
+        {ok, Host} ->
+            ok;
+        undefined ->
+            Host = "127.0.0.1"
+    end,
+    case application:get_env(riak_cs, riak_http_port) of
+        {ok, Port} ->
+            ok;
+        undefined ->
+            Port = 8098
+    end,
+    {Host, Port}.
+
+get_rhc() ->
+    {Host, Port} = riak_http_host_port(),
+    Prefix = "riak",   % Required for create(), but should not be used, since this is old-style
+    Opts = [],
+    rhc:create(Host, Port, Prefix, Opts).

--- a/src/riak_cs_riak_stats.erl
+++ b/src/riak_cs_riak_stats.erl
@@ -77,10 +77,12 @@ get_riak_cluster_disk_usage() ->
     ClusterDiskUsageKB = PartitionUsedKB * NodeCount,
     ClusterDiskFreeKB = ClusterCapacityKB - ClusterDiskUsageKB,
     ObjectCapacityRemainingKB = round(ClusterDiskFreeKB / NVal),
-    {{<<"cluster_capacity">>, ClusterCapacityKB},
+    {struct, 
+    [{<<"cluster_capacity">>, ClusterCapacityKB},
      {<<"cluster_disk_usage_kb">>, ClusterDiskUsageKB},
      {<<"cluster_disk_free_kb">>, ClusterDiskFreeKB},
      {<<"cluster_node_count">>, NodeCount},
      {<<"n_val">>, NVal},
      {<<"object_storage_capacity_remaining_kb">>, ObjectCapacityRemainingKB}
+     ]
     }.

--- a/src/riak_cs_riak_stats.erl
+++ b/src/riak_cs_riak_stats.erl
@@ -1,0 +1,86 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Helpers for Riak node stats (via Riak HTTP API)
+
+-module(riak_cs_riak_stats).
+
+-export([
+         riak_stats/0,
+         get_riak_stat/1,
+         get_riak_stat/2,
+         get_riak_disk_stat/0,
+         get_riak_disk_stat/1,
+         get_riak_root_disk_usage/0,
+         get_riak_node_count/0,
+         get_riak_cluster_disk_usage/0
+]).
+
+riak_stats() ->
+    Rhc = riak_cs_riak_http_client:get_rhc(),
+    Rhc:get_server_stats().
+
+get_riak_stat(Key) ->
+    case riak_stats() of
+        {ok, Stats} ->
+            get_riak_stat(Stats, Key);            
+        {error, Error} ->
+            {error, Error}
+    end.
+
+get_riak_stat(Stats, Key) ->
+    proplists:get_value(Key, Stats).
+
+get_riak_disk_stat() ->
+    get_riak_stat(<<"disk">>).
+
+get_riak_disk_stat(PartitionKey) ->
+    DiskStats = get_riak_disk_stat(),
+    DiskStatProplist = [ {PartitionId, [{<<"id">>, PartitionId} | PartitionStats]} 
+                            || {struct, [{<<"id">>, PartitionId} | PartitionStats]} <- DiskStats ],
+    [_PartitionId, {<<"size">>, PartitionTotalKB}, {<<"used">>, PercentageUsed}] = 
+        proplists:get_value(PartitionKey, DiskStatProplist),
+    {PartitionKey, PartitionTotalKB, PercentageUsed}.
+
+get_riak_root_disk_usage() ->
+    RootPartition = <<"/">>,  % TODO: assume/hardcode for now, load from config or discover later
+    get_riak_disk_stat(RootPartition).
+
+get_riak_node_count() ->
+    NodeList = get_riak_stat(<<"ring_members">>),
+    length(NodeList).
+
+get_riak_cluster_disk_usage() ->
+    {_PartitionKey, PartitionTotalKB, PercentageUsed} = get_riak_root_disk_usage(),
+    PartitionUsedKB = round(PartitionTotalKB * PercentageUsed / 100),
+    % PartitionFreeKB = PartitionTotalKB - PartitionUsedKB,
+    NVal = 3,  % TODO: hardcode for now, discover via api later
+    NodeCount = get_riak_node_count(),
+    ClusterCapacityKB = PartitionTotalKB * NodeCount,
+    ClusterDiskUsageKB = PartitionUsedKB * NodeCount,
+    ClusterDiskFreeKB = ClusterCapacityKB - ClusterDiskUsageKB,
+    ObjectCapacityRemainingKB = round(ClusterDiskFreeKB / NVal),
+    {{<<"cluster_capacity">>, ClusterCapacityKB},
+     {<<"cluster_disk_usage_kb">>, ClusterDiskUsageKB},
+     {<<"cluster_disk_free_kb">>, ClusterDiskFreeKB},
+     {<<"cluster_node_count">>, NodeCount},
+     {<<"n_val">>, NVal},
+     {<<"object_storage_capacity_remaining_kb">>, ObjectCapacityRemainingKB}
+    }.

--- a/src/riak_cs_riak_stats.erl
+++ b/src/riak_cs_riak_stats.erl
@@ -30,7 +30,8 @@
          get_riak_disk_stat/1,
          get_riak_root_disk_usage/0,
          get_riak_node_count/0,
-         get_riak_cluster_disk_usage/0
+         get_riak_cluster_disk_usage/0,
+         get_riak_bitcask_nval/0
 ]).
 
 riak_stats() ->
@@ -67,11 +68,15 @@ get_riak_node_count() ->
     NodeList = get_riak_stat(<<"ring_members">>),
     length(NodeList).
 
+get_riak_bitcask_nval() ->
+    NVal = 3,  % TODO: hardcode for now, discover via api later
+    NVal.
+
 get_riak_cluster_disk_usage() ->
     {_PartitionKey, PartitionTotalKB, PercentageUsed} = get_riak_root_disk_usage(),
     PartitionUsedKB = round(PartitionTotalKB * PercentageUsed / 100),
     % PartitionFreeKB = PartitionTotalKB - PartitionUsedKB,
-    NVal = 3,  % TODO: hardcode for now, discover via api later
+    NVal = get_riak_bitcask_nval(),
     NodeCount = get_riak_node_count(),
     ClusterCapacityKB = PartitionTotalKB * NodeCount,
     ClusterDiskUsageKB = PartitionUsedKB * NodeCount,

--- a/src/riak_cs_users.erl
+++ b/src/riak_cs_users.erl
@@ -1,0 +1,86 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Helpers for listing Riak CS users
+
+-module(riak_cs_users).
+
+-export([
+         stream_users/4
+]).
+-include("riak_cs.hrl").
+
+stream_users(Format, RiakPid, Boundary, Status) ->
+    case riakc_pb_socket:stream_list_keys(RiakPid, ?USER_BUCKET) of
+        {ok, ReqId} ->
+            case riak_cs_utils:riak_connection() of
+                {ok, RiakPid2} ->
+                    Res = wait_for_users(Format, RiakPid2, ReqId, Boundary, Status),
+                    riak_cs_utils:close_riak_connection(RiakPid2),
+                    Res;
+                {error, _Reason} ->
+                    wait_for_users(Format, RiakPid, ReqId, Boundary, Status)
+            end;
+        {error, _Reason} ->
+            {<<>>, done}
+    end.
+
+wait_for_users(Format, RiakPid, ReqId, Boundary, Status) ->
+    receive
+        {ReqId, {keys, UserIds}} ->
+            FoldFun = user_fold_fun(RiakPid, Status),
+            Doc = users_doc(lists:foldl(FoldFun, [], UserIds),
+                            Format,
+                            Boundary),
+            {Doc, fun() -> wait_for_users(Format, RiakPid, ReqId, Boundary, Status) end};
+        {ReqId, done} ->
+            {list_to_binary(["\r\n--", Boundary, "--"]), done};
+        _ ->
+            wait_for_users(Format, RiakPid, ReqId, Boundary, Status)
+    end.
+
+%% @doc Compile a multipart entity for a set of user documents.
+users_doc(UserDocs, xml, Boundary) ->
+    ["\r\n--",
+     Boundary,
+     "\r\nContent-Type: ", ?XML_TYPE, "\r\n\r\n",
+     riak_cs_xml:to_xml({users, UserDocs})];
+users_doc(UserDocs, json, Boundary) ->
+    ["\r\n--",
+     Boundary,
+     "\r\nContent-Type: ", ?JSON_TYPE, "\r\n\r\n",
+     riak_cs_json:to_json({users, UserDocs})].
+
+%% @doc Return a fold function to retrieve and filter user accounts
+user_fold_fun(RiakPid, Status) ->
+    fun(UserId, Users) ->
+            case riak_cs_utils:get_user(binary_to_list(UserId), RiakPid) of
+                {ok, {User, _}} when User?RCS_USER.status =:= Status;
+                                     Status =:= undefined ->
+                    [User | Users];
+                {ok, _} ->
+                    %% Status is defined and does not match the account status
+                    Users;
+                {error, Reason} ->
+                    _ = lager:warning("Failed to fetch user record. KeyId: ~p"
+                                      " Reason: ~p", [UserId, Reason]),
+                    Users
+            end
+    end.

--- a/src/riak_cs_users.erl
+++ b/src/riak_cs_users.erl
@@ -23,9 +23,74 @@
 -module(riak_cs_users).
 
 -export([
-         stream_users/4
+         stream_users/4,
+         wait_for_all_user_storage/0,
+         total_user_storage/0
 ]).
 -include("riak_cs.hrl").
+
+user_bucket_sum([Bucket|OtherBuckets]) ->
+    {_BucketName, {struct, [_ObjectCount, {<<"Bytes">>, BucketBytes}]}} = Bucket,
+    BucketBytes + user_bucket_sum(OtherBuckets);
+
+user_bucket_sum([]) -> 0.
+
+total_user_storage() ->
+    StorageByUser = wait_for_all_user_storage(),
+    FilteredList = [User || User <- StorageByUser, length(User) > 0],
+    FlatList = [UserContents || [UserContents|[]] <- FilteredList],
+    TotalsByUser = [ {struct, [{<<"user_key">>, UserId}, 
+                               {<<"user_object_bytes">>, user_bucket_sum(UserBuckets)}]}
+                    || {{_, UserId}, UserBuckets} <- FlatList],
+    TotalBytes = lists:sum([UserBytes || {struct, [_, {_, UserBytes}]} <- TotalsByUser]),
+    NVal = riak_cs_riak_stats:get_riak_bitcask_nval(),
+    {struct,
+        [{<<"n_val">>, NVal},
+         {<<"total_user_object_bytes">>, TotalBytes},
+         {<<"users">>, TotalsByUser}]}.
+         
+
+wait_for_user_list({_Data, done}, Acc) -> Acc;
+wait_for_user_list({Data, F}, Acc) -> wait_for_user_list(F(), [Data|Acc]).
+
+wait_for_all_user_storage() ->
+    wait_for_user_list(list_user_storage(), []).
+
+list_user_storage() ->
+    case riak_cs_utils:riak_connection() of
+        {ok, RiakcPid} ->
+            list_user_storage(RiakcPid);
+            % list_users(Format, RiakcPid, Boundary, Status);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+list_user_storage(RiakPid) ->
+    case riakc_pb_socket:stream_list_keys(RiakPid, ?USER_BUCKET) of
+        {ok, ReqId} ->
+            case riak_cs_utils:riak_connection() of
+                {ok, RiakPid2} ->
+                    Res = wait_for_user_storage(RiakPid2, ReqId),
+                    riak_cs_utils:close_riak_connection(RiakPid2),
+                    Res;
+                {error, _Reason} ->
+                    wait_for_user_storage(RiakPid, ReqId)
+            end;
+        {error, _Reason} ->
+            {<<>>, done}
+    end. 
+
+wait_for_user_storage(RiakPid, ReqId) ->
+    receive
+        {ReqId, {keys, UserIds}} ->
+            FoldFun = user_storage_fold_fun(RiakPid),
+            Acc = lists:flatten(lists:foldl(FoldFun, [], UserIds)),
+            {Acc, fun() -> wait_for_user_storage(RiakPid, ReqId) end};
+        {ReqId, done} ->
+            {<<>>, done};
+        _ ->
+            wait_for_user_storage(RiakPid, ReqId)
+    end.
 
 stream_users(Format, RiakPid, Boundary, Status) ->
     case riakc_pb_socket:stream_list_keys(RiakPid, ?USER_BUCKET) of
@@ -78,6 +143,18 @@ user_fold_fun(RiakPid, Status) ->
                 {ok, _} ->
                     %% Status is defined and does not match the account status
                     Users;
+                {error, Reason} ->
+                    _ = lager:warning("Failed to fetch user record. KeyId: ~p"
+                                      " Reason: ~p", [UserId, Reason]),
+                    Users
+            end
+    end.
+
+user_storage_fold_fun(RiakPid) ->
+    fun(UserId, Users) ->
+            case riak_cs_storage:sum_user(RiakPid, binary_to_list(UserId)) of
+                {ok, UserBucketList} ->
+                    [{{<<"user_key">>, UserId}, UserBucketList} | Users];
                 {error, Reason} ->
                     _ = lager:warning("Failed to fetch user record. KeyId: ~p"
                                       " Reason: ~p", [UserId, Reason]),

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -57,6 +57,7 @@ admin_resources(Props) ->
     [
      {["riak-cs", "stats"], riak_cs_wm_stats, Props},
      {["riak-cs", "disk_usage"], riak_cs_wm_disk_usage, []},
+     {["riak-cs", "users_disk_usage"], riak_cs_wm_users_disk_usage, []},
      {["riak-cs", "ping"], riak_cs_wm_ping, []},
      {["riak-cs", "users"], riak_cs_wm_users, Props},
      {["riak-cs", "user", '*'], riak_cs_wm_user, Props},

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -56,6 +56,7 @@ stats_props() ->
 admin_resources(Props) ->
     [
      {["riak-cs", "stats"], riak_cs_wm_stats, Props},
+     {["riak-cs", "disk_usage"], riak_cs_wm_disk_usage, []},
      {["riak-cs", "ping"], riak_cs_wm_ping, []},
      {["riak-cs", "users"], riak_cs_wm_users, Props},
      {["riak-cs", "user", '*'], riak_cs_wm_user, Props},

--- a/src/riak_cs_wm_disk_usage.erl
+++ b/src/riak_cs_wm_disk_usage.erl
@@ -1,0 +1,101 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_wm_disk_usage).
+
+-export([init/1,
+         service_available/2,
+         allowed_methods/2,
+         to_html/2,
+         finish_request/2]).
+
+-include("riak_cs.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-record(test_context, {pool_pid=true :: boolean(),
+                       riakc_pid :: 'undefined' | pid()}).
+
+%% -------------------------------------------------------------------
+%% Webmachine callbacks
+%% -------------------------------------------------------------------
+
+init(_Config) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"init">>),
+    {ok, #test_context{}}.
+
+service_available(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"service_available">>),
+    Available = true,
+    UpdCtx = Ctx,
+    % case poolboy:checkout(request_pool, true, test_timeout()) of
+    %     full ->
+    %         case riak_cs_riakc_pool_worker:start_link([]) of
+    %             {ok, Pid} ->
+    %                 UpdCtx = Ctx#test_context{riakc_pid=Pid,
+    %                                           pool_pid=false};
+    %             {error, _} ->
+    %                 Pid = undefined,
+    %                 UpdCtx = Ctx
+    %         end;
+    %     Pid ->
+    %         UpdCtx = Ctx#test_context{riakc_pid=Pid}
+    % end,
+    % case (catch riakc_pb_socket:test(Pid, test_timeout())) of
+    %     pong ->
+    %         Available = true;
+    %     _ ->
+    %         Available = false
+    % end,
+    {Available, RD, UpdCtx}.
+
+allowed_methods(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"allowed_methods">>),
+    {['GET', 'HEAD'], RD, Ctx}.
+
+to_html(ReqData, Ctx) ->
+    {Json, RD2, C2} = produce_body(ReqData, Ctx),
+    {Json, RD2, C2}.
+    % {"TEST OK", ReqData, Ctx}.
+
+produce_body(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"produce_body">>),
+    Body = mochijson2:encode(get_disk_stats()),
+    ETag = riak_cs_utils:etag_from_binary(riak_cs_utils:md5(Body)),
+    RD2 = wrq:set_resp_header("ETag", ETag, RD),
+    riak_cs_dtrace:dt_wm_return(?MODULE, <<"produce_body">>),
+    {Body, RD2, Ctx}.
+
+finish_request(RD, Ctx=#test_context{riakc_pid=undefined}) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"finish_request">>, [0], []),
+    {true, RD, Ctx};
+finish_request(RD, Ctx=#test_context{}) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"finish_request">>, [1], []),
+    riak_cs_dtrace:dt_wm_return(?MODULE, <<"finish_request">>, [1], []),
+    {true, RD, Ctx#test_context{riakc_pid=undefined}}.
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+get_disk_stats() ->
+    DiskData = disksup:get_disk_data(),
+    [Root|_] = DiskData,
+    {Id, KByte, Capacity} = Root,
+    {struct, [{id, Id}, {kb, KByte}, {percent_full, Capacity}]}.

--- a/src/riak_cs_wm_disk_usage.erl
+++ b/src/riak_cs_wm_disk_usage.erl
@@ -72,7 +72,6 @@ allowed_methods(RD, Ctx) ->
 to_html(ReqData, Ctx) ->
     {Json, RD2, C2} = produce_body(ReqData, Ctx),
     {Json, RD2, C2}.
-    % {"TEST OK", ReqData, Ctx}.
 
 produce_body(RD, Ctx) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"produce_body">>),
@@ -95,7 +94,4 @@ finish_request(RD, Ctx=#test_context{}) ->
 %% -------------------------------------------------------------------
 
 get_disk_stats() ->
-    DiskData = disksup:get_disk_data(),
-    [Root|_] = DiskData,
-    {Id, KByte, Capacity} = Root,
-    {struct, [{id, Id}, {kb, KByte}, {percent_full, Capacity}]}.
+    riak_cs_riak_stats:get_riak_cluster_disk_usage().

--- a/src/riak_cs_wm_users_disk_usage.erl
+++ b/src/riak_cs_wm_users_disk_usage.erl
@@ -1,0 +1,78 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_wm_users_disk_usage).
+
+-export([init/1,
+         service_available/2,
+         allowed_methods/2,
+         to_html/2,
+         finish_request/2]).
+
+-include("riak_cs.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-record(test_context, {pool_pid=true :: boolean(),
+                       riakc_pid :: 'undefined' | pid()}).
+
+%% -------------------------------------------------------------------
+%% Webmachine callbacks
+%% -------------------------------------------------------------------
+
+init(_Config) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"init">>),
+    {ok, #test_context{}}.
+
+service_available(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"service_available">>),
+    Available = true,
+    UpdCtx = Ctx,
+    {Available, RD, UpdCtx}.
+
+allowed_methods(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"allowed_methods">>),
+    {['GET', 'HEAD'], RD, Ctx}.
+
+to_html(ReqData, Ctx) ->
+    {Json, RD2, C2} = produce_body(ReqData, Ctx),
+    {Json, RD2, C2}.
+
+produce_body(RD, Ctx) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"produce_body">>),
+    Body = mochijson2:encode(get_user_disk_stats()),
+    ETag = riak_cs_utils:etag_from_binary(riak_cs_utils:md5(Body)),
+    RD2 = wrq:set_resp_header("ETag", ETag, RD),
+    riak_cs_dtrace:dt_wm_return(?MODULE, <<"produce_body">>),
+    {Body, RD2, Ctx}.
+
+finish_request(RD, Ctx=#test_context{riakc_pid=undefined}) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"finish_request">>, [0], []),
+    {true, RD, Ctx};
+finish_request(RD, Ctx=#test_context{}) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"finish_request">>, [1], []),
+    riak_cs_dtrace:dt_wm_return(?MODULE, <<"finish_request">>, [1], []),
+    {true, RD, Ctx#test_context{riakc_pid=undefined}}.
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+get_user_disk_stats() ->
+    riak_cs_users:total_user_storage().


### PR DESCRIPTION
Opening a PR for peer review before a customer demo. 
This adds a Riak erlang HTTP client to CS, and adds a Riak disk stats webmachine API call (for use with Riak CS Control).
Implements issue https://github.com/basho/riak_cs/issues/612 , for use with https://github.com/basho/riak_cs_control/issues/39
