### PR TITLE
Don't export variables from case statements

### DIFF
--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -185,18 +185,8 @@ riak_connection() ->
 %% that has been merged.
 -spec riak_host_port() -> {string(), pos_integer()}.
 riak_host_port() ->
-    case application:get_env(riak_cs, riak_ip) of
-        {ok, Host} ->
-            ok;
-        undefined ->
-            Host = "127.0.0.1"
-    end,
-    case application:get_env(riak_cs, riak_pb_port) of
-        {ok, Port} ->
-            ok;
-        undefined ->
-            Port = 8087
-    end,
+    Host = application:get_env(riak_cs, riak_ip, "127.0.0.1"),
+    Port = application:get_env(riak_cs, riak_pb_port, 8087),
     {Host, Port}.
 
 cleanup(Table, Pid, Mon) ->

--- a/src/riak_cs_access_log_handler.erl
+++ b/src/riak_cs_access_log_handler.erl
@@ -155,13 +155,13 @@ init(_) ->
                                max_size=FlushSize,
                                size=0},
             case schedule_archival(InitState) of
-                {ok, SchedState} -> ok;
+                {ok, _SchedState}=OK ->
+                    OK;
                 {error, _Behind} ->
                     %% startup was right on a boundary, just try again,
                     %% and fail if this one also fails
-                    {ok, SchedState} = schedule_archival(InitState)
-            end,
-            {ok, SchedState};
+                    schedule_archival(InitState)
+            end;
         {{error, Reason}, _} ->
             _ = lager:error("Error starting access logger: ~s", [Reason]),
             %% can't simply {error, Reason} out here, because

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -128,16 +128,6 @@ riak_connection() ->
 %% that has been merged.
 -spec riak_host_port() -> {string(), pos_integer()}.
 riak_host_port() ->
-    case application:get_env(riak_cs, riak_ip) of
-        {ok, Host} ->
-            ok;
-        undefined ->
-            Host = "127.0.0.1"
-    end,
-    case application:get_env(riak_cs, riak_pb_port) of
-        {ok, Port} ->
-            ok;
-        undefined ->
-            Port = 8087
-    end,
+    Host = application:get_env(riak_cs, riak_ip, "127.0.0.1"),
+    Port = application:get_env(riak_cs, riak_pb_port, 8087),
     {Host, Port}.

--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -238,15 +238,16 @@ blocks_to_delete_from_manifest(Manifest=?MANIFEST{state=State,
   when State =:= pending_delete;State =:= writing; State =:= scheduled_delete ->
     case riak_cs_lfs_utils:block_sequences_for_manifest(Manifest) of
         []=Blocks ->
-            UpdManifest = Manifest?MANIFEST{delete_blocks_remaining=[],
-                                            state=deleted};
+            {Manifest?MANIFEST{delete_blocks_remaining=[],
+                               state=deleted},
+             Blocks};
         Blocks ->
-            UpdManifest = Manifest?MANIFEST{delete_blocks_remaining=Blocks}
-    end,
-    {UpdManifest, Blocks};
+            {Manifest?MANIFEST{delete_blocks_remaining=Blocks},
+             Blocks}
+    end;
 blocks_to_delete_from_manifest(Manifest) ->
     {Manifest,
-        Manifest?MANIFEST.delete_blocks_remaining}.
+     Manifest?MANIFEST.delete_blocks_remaining}.
 
 %% ===================================================================
 %% Test API

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -176,17 +176,18 @@ fetching_next_fileset(continue, State=#state{batch=[FileSetKey | RestKeys],
                                              riak=RiakPid
                                             }) ->
     %% Fetch the next set of manifests for deletion
+    {NewStateData, NextState} =
     case fetch_next_fileset(FileSetKey, RiakPid) of
         {ok, FileSet, RiakObj} ->
-            NewStateData = State#state{current_files=twop_set:to_list(FileSet),
+            {State#state{current_files=twop_set:to_list(FileSet),
                                        current_fileset=FileSet,
                                        current_riak_object=RiakObj,
                                        manif_count=ManifCount+twop_set:size(FileSet)},
-            NextState = initiating_file_delete;
+            initiating_file_delete};
         {error, _} ->
-            NewStateData = State#state{batch=RestKeys,
-                                       batch_skips=BatchSkips+1},
-            NextState = fetching_next_fileset
+            {State#state{batch=RestKeys,
+                         batch_skips=BatchSkips+1},
+             fetching_next_fileset}
     end,
     ok = continue(),
     {next_state, NextState, NewStateData};

--- a/src/riak_cs_get_fsm.erl
+++ b/src/riak_cs_get_fsm.erl
@@ -221,14 +221,14 @@ waiting_continue_or_stop({continue, Range}, #state{manifest=Manifest,
             TotalBlocks = length(BlocksOrder),
 
             %% Start the block servers
-            case Readers of
+            FreeReaders = case Readers of
                 undefined ->
-                    FreeReaders =
-                    riak_cs_block_server:start_block_servers(RiakPid,
+                    R = riak_cs_block_server:start_block_servers(RiakPid,
                         FetchConcurrency),
-                    _ = lager:debug("Block Servers: ~p", [FreeReaders]);
+                    _ = lager:debug("Block Servers: ~p", [R]),
+                    R;
                 _ ->
-                    FreeReaders = Readers
+                    Readers
             end,
             %% start retrieving the first set of blocks
             UpdState = State#state{blocks_order=BlocksOrder,

--- a/src/riak_cs_keystone_auth.erl
+++ b/src/riak_cs_keystone_auth.erl
@@ -155,28 +155,28 @@ calculate_sts(RD) ->
         {Path,QS} -> [Path, canonicalize_qs(lists:sort(QS))]
     end,
     Expires = wrq:get_qs_value("Expires", RD),
-    case Expires of
+    Date = case Expires of
         undefined ->
             case proplists:is_defined("x-amz-date", Headers) of
                 true ->
-                    Date = "\n";
+                    "\n";
                 false ->
-                    Date = [wrq:get_req_header("date", RD), "\n"]
+                    [wrq:get_req_header("date", RD), "\n"]
             end;
         _ ->
-            Date = Expires ++ "\n"
+            Expires ++ "\n"
     end,
-    case wrq:get_req_header("content-md5", RD) of
+    CMD5 = case wrq:get_req_header("content-md5", RD) of
         undefined ->
-            CMD5 = [];
-        CMD5 ->
-            ok
+            [];
+        M ->
+            M
     end,
-    case wrq:get_req_header("content-type", RD) of
+    ContentType = case wrq:get_req_header("content-type", RD) of
         undefined ->
-            ContentType = [];
-        ContentType ->
-            ok
+            [];
+        CType  ->
+            CType
     end,
     list_to_binary([atom_to_list(wrq:method(RD)), "\n",
                     CMD5,

--- a/src/riak_cs_riakc_pool_worker.erl
+++ b/src/riak_cs_riakc_pool_worker.erl
@@ -28,18 +28,8 @@
 
 -spec riak_host_port() -> {string(), pos_integer()}.
 riak_host_port() ->
-    case application:get_env(riak_cs, riak_ip) of
-        {ok, Host} ->
-            ok;
-        undefined ->
-            Host = "127.0.0.1"
-    end,
-    case application:get_env(riak_cs, riak_pb_port) of
-        {ok, Port} ->
-            ok;
-        undefined ->
-            Port = 8087
-    end,
+    Host = application:get_env(riak_cs, riak_ip, "127.0.0.1"),
+    Port = application:get_env(riak_cs, riak_pb_port, 8087),
     {Host, Port}.
 
 -spec start_link(term()) -> {ok, pid()} | {error, term()}.

--- a/src/riak_cs_s3_auth.erl
+++ b/src/riak_cs_s3_auth.erl
@@ -95,28 +95,28 @@ calculate_signature(KeyData, RD) ->
         {Path,QS} -> [Path, canonicalize_qs(QS)]
     end,
     Expires = wrq:get_qs_value("Expires", RD),
-    case Expires of
+    Date = case Expires of
         undefined ->
             case proplists:is_defined("x-amz-date", Headers) of
                 true ->
-                    Date = "\n";
+                    "\n";
                 false ->
-                    Date = [wrq:get_req_header("date", RD), "\n"]
+                    [wrq:get_req_header("date", RD), "\n"]
             end;
         _ ->
-            Date = Expires ++ "\n"
+            Expires ++ "\n"
     end,
-    case wrq:get_req_header("content-md5", RD) of
+    CMD5 = case wrq:get_req_header("content-md5", RD) of
         undefined ->
-            CMD5 = [];
-        CMD5 ->
-            ok
+            [];
+        M ->
+            M
     end,
-    case wrq:get_req_header("content-type", RD) of
+    ContentType = case wrq:get_req_header("content-type", RD) of
         undefined ->
-            ContentType = [];
-        ContentType ->
-            ok
+            [];
+        CType ->
+            CType
     end,
     STS = [atom_to_list(wrq:method(RD)), "\n",
            CMD5,

--- a/src/riak_cs_wm_users.erl
+++ b/src/riak_cs_wm_users.erl
@@ -69,13 +69,13 @@ produce_json(RD, Ctx=#context{riakc_pid=RiakPid}) ->
                                 "multipart/mixed; boundary="++Boundary,
                                 RD),
     StatusQsVal = wrq:get_qs_value("status", RD),
-    case StatusQsVal of
+    Status = case StatusQsVal of
         "enabled" ->
-            Status = enabled;
+            enabled;
         "disabled" ->
-            Status = disabled;
+            disabled;
         _ ->
-            Status = undefined
+            undefined
     end,
     {{stream, {<<>>, fun() -> stream_users(json, RiakPid, Boundary, Status) end}}, UpdRD, Ctx}.
 
@@ -85,13 +85,13 @@ produce_xml(RD, Ctx=#context{riakc_pid=RiakPid}) ->
                                 "multipart/mixed; boundary="++Boundary,
                                 RD),
     StatusQsVal = wrq:get_qs_value("status", RD),
-    case StatusQsVal of
+    Status = case StatusQsVal of
         "enabled" ->
-            Status = enabled;
+            enabled;
         "disabled" ->
-            Status = disabled;
+            disabled;
         _ ->
-            Status = undefined
+            undefined
     end,
     {{stream, {<<>>, fun() -> stream_users(xml, RiakPid, Boundary, Status) end}}, UpdRD, Ctx}.
 

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -181,16 +181,15 @@ handle_validation_response({error, Reason}, RD, Ctx, _, Conv2KeyCtx, _) ->
                                   {error, bad_auth | notfound | no_user_key | term()}.
 validate_auth_header(RD, AuthBypass, RiakPid, Ctx) ->
     AuthHeader = wrq:get_req_header("authorization", RD),
+    {AuthMod, KeyId, Signature} =
     case AuthHeader of
         undefined ->
             %% Check for auth info presented as query params
             KeyId0 = wrq:get_qs_value(?QS_KEYID, RD),
             EncodedSig = wrq:get_qs_value(?QS_SIGNATURE, RD),
-            {AuthMod, KeyId, Signature} = parse_auth_params(KeyId0,
-                                                            EncodedSig,
-                                                            AuthBypass);
+            parse_auth_params(KeyId0, EncodedSig, AuthBypass);
         _ ->
-            {AuthMod, KeyId, Signature} = parse_auth_header(AuthHeader, AuthBypass)
+            parse_auth_header(AuthHeader, AuthBypass)
     end,
     case riak_cs_utils:get_user(KeyId, RiakPid) of
         {ok, {User, UserObj}} when User?RCS_USER.status =:= enabled ->


### PR DESCRIPTION
I temporarily used the `warn_export_vars` compile option to spot these. I've also spotted a few areas where we repeat ourselves, but I think it'd be best to tackle that in a separate issue. Or a separate commit on this same branch.
