### PR TITLE
Setting ACLs via headers at PUT Object creation

### DIFF
--- a/client_tests/clojure/clj-s3/.gitignore
+++ b/client_tests/clojure/clj-s3/.gitignore
@@ -8,3 +8,4 @@
 /.lein-deps-sum
 /target
 .lein-repl-history
+.nrepl-port

--- a/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
+++ b/client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj
@@ -33,8 +33,7 @@
     (make-url-with-resource location "/riak-cs/user")))
 
 (defn ^:internal parse-response-body [string]
-  (let [data (cheshire/parse-string string true)]
-    (select-keys data [:key_id :key_secret])))
+  (cheshire/parse-string string true))
 
 (defn ^:internal parse-response [response]
   (parse-response-body (:body response)))

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -80,6 +80,7 @@
                   user :: undefined | moss_user(),
                   user_object :: riakc_obj:riakc_obj(),
                   bucket :: binary(),
+                  acl :: 'undefined' | acl(),
                   requested_perm :: acl_perm(),
                   riakc_pid :: pid(),
                   riakc_pool :: atom(),
@@ -92,8 +93,7 @@
                   api :: atom()
                  }).
 
--record(key_context, {context :: #context{},
-                      manifest :: 'notfound' | lfs_manifest(),
+-record(key_context, {manifest :: 'notfound' | lfs_manifest(),
                       upload_id :: 'undefined' | binary(),
                       part_number :: 'undefined' | integer(),
                       part_uuid :: 'undefined' | binary(),
@@ -109,7 +109,9 @@
 -type acl_perm() :: 'READ' | 'WRITE' | 'READ_ACP' | 'WRITE_ACP' | 'FULL_CONTROL'.
 -type acl_perms() :: [acl_perm()].
 -type group_grant() :: 'AllUsers' | 'AuthUsers'.
--type acl_grantee() :: {string(), string()} | group_grant().
+-type acl_grantee() :: {DisplayName :: string(),
+                        CanonicalID :: string()} |
+                       group_grant().
 -type acl_grant() :: {acl_grantee(), acl_perms()}.
 %% acl_v1 owner fields: {DisplayName, CanonicalId}
 -type acl_owner2() :: {string(), string()}.

--- a/riak_test/tests/cs_631_regression_test.erl
+++ b/riak_test/tests/cs_631_regression_test.erl
@@ -37,6 +37,7 @@ confirm() ->
               {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4, Config),
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),
+    test_unknown_canonical_id_grant_returns_400(UserConfig),
     test_canned_acl_and_grants_returns_400(UserConfig).
 
 test_canned_acl_and_grants_returns_400(UserConfig) ->

--- a/riak_test/tests/cs_631_regression_test.erl
+++ b/riak_test/tests/cs_631_regression_test.erl
@@ -1,0 +1,54 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(cs_631_regression_test).
+%% @doc Integration test for [https://github.com/basho/riak_cs/issues/631]
+
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BUCKET, "cs-631-test-bucket").
+-define(KEY_1, "key-1").
+-define(KEY_2, "key-2").
+-define(VALUE, <<"632-test-value">>).
+
+
+-export([confirm/0]).
+
+confirm() ->
+    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
+              {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4, Config),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),
+    test_canned_acl_and_grants_returns_400(UserConfig).
+
+test_canned_acl_and_grants_returns_400(UserConfig) ->
+    Acl = [{acl, public_read}],
+    Headers = [{"x-amz-grant-write", "email=\"doesnmatter@example.com\""}],
+    ?assertError({aws_error, {http_error, 400, _, _}},
+                erlcloud_s3:put_object(?BUCKET, ?KEY_1, ?VALUE,
+                                      Acl, Headers, UserConfig)).
+
+test_unknown_canonical_id_grant_returns_400(UserConfig) ->
+    Acl = [],
+    Headers = [{"x-amz-grant-write", "id=\"badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad9badbad\""}],
+    ?assertError({aws_error, {http_error, 400, _, _}},
+                erlcloud_s3:put_object(?BUCKET, ?KEY_2, ?VALUE,
+                                      Acl, Headers, UserConfig)).

--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -28,6 +28,7 @@
 
 -ifdef(TEST).
 
+-compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
 -endif.

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -185,7 +185,7 @@ parse_grant_header_value(HeaderValue) ->
 %% into:
 %% `["emailAddress=\"xyz@amazon.com\"",
 %%  "emailAddress=\"abc@amazon.com\""]'
--spec split_header_values_and_strip(string()) -> string().
+-spec split_header_values_and_strip(string()) -> [string()].
 split_header_values_and_strip(Value) ->
     [string:strip(V) || V <- string:tokens(Value, ",")].
 

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -242,10 +242,12 @@ remove_quotes(String) ->
     end.
 
 %% @doc Return true if `String' is enclosed in quotation
-%% marks.
+%% marks. The enclosed string must also be non-empty.
 -spec starts_and_ends_with_quotes(string()) -> boolean().
 starts_and_ends_with_quotes(String) ->
-    hd(String) =:= 34 andalso lists:last(String) =:= 34.
+    length(String) > 2 andalso
+    hd(String) =:= 34 andalso
+    lists:last(String) =:= 34.
 
 %% @doc Attempt to turn a list of grants that use email addresses
 %% into a list of grants that only use canonical ids. Returns an error

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -22,6 +22,8 @@
 
 -module(riak_cs_acl_utils).
 
+-compile(export_all).
+
 -include("riak_cs.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
@@ -35,6 +37,7 @@
 -export([acl/4,
          default_acl/3,
          canned_acl/3,
+         specific_acl_grant/3,
          acl_from_xml/3,
          empty_acl_xml/0,
          requested_access/2,
@@ -80,11 +83,223 @@ canned_acl(HeaderVal, Owner, BucketOwner) ->
                                                     Owner,
                                                     BucketOwner)).
 
+%% @doc Turn a list of header-name, value pairs into an ACL. If the header
+%% values don't parse correctly, return `{error, invalid_argument}'. If
+%% the header references an email address that cannot be mapped to a
+%% canonical id, return `{error, unresolved_grant_email}'. Otherwise
+%% return an acl record.
+-spec specific_acl_grant(Owner :: acl_owner(),
+                         [{HeaderName :: acl_perm(),
+                           HeaderValue :: string()}],
+                         pid()) ->
+    {ok, #acl_v2{}} |
+    {error, 'invalid_argument'} |
+    {error, 'unresolved_grant_email'}.
+specific_acl_grant(Owner, Headers, RiakcPid) ->
+    %% TODO: this function is getting a bit long and confusing
+    Grants = [{HeaderName, parse_grant_header_value(GrantString)} ||
+            {HeaderName, GrantString} <- Headers],
+    case promote_failure([Grant || {_HeaderName, Grant} <- Grants]) of
+        {error, invalid_argument}=E ->
+            E;
+        {ok, _GoodGrants} ->
+            EmailsTranslated =  [{HeaderName, emails_to_ids(Grant, RiakcPid)} ||
+                    {HeaderName, {ok, Grant}} <- Grants],
+            case promote_failure([EmailOk || {_HeaderName, EmailOk} <- EmailsTranslated]) of
+                {error, unresolved_grant_email}=E ->
+                    E;
+                {ok, _GoodEmails} ->
+                    case valid_headers_to_grants([{HeaderName, Val} || {HeaderName, {ok, Val}} <- EmailsTranslated],
+                                                 RiakcPid) of
+                        {ok, AclGrants} ->
+                            {DisplayName, CanonicalId, KeyId} = Owner,
+                            {ok, acl(DisplayName, CanonicalId, KeyId, AclGrants)};
+                        {error, invalid_argument}=E ->
+                            E
+                    end
+            end
+    end.
+
+%% @doc Attempt to parse a list of ACL headers into a list
+%% of `acl_grant()'s.
+-spec valid_headers_to_grants(list(), pid()) ->
+    {ok, list(acl_grant())} | {error, invalid_argument}.
+valid_headers_to_grants(Pairs, RiakcPid) ->
+    MaybeGrants = [header_to_acl_grants(HeaderName, Grants, RiakcPid) ||
+            {HeaderName, Grants} <- Pairs],
+    case promote_failure(MaybeGrants) of
+        {ok, Grants} ->
+            {ok, lists:foldl(fun add_grant/2, [], lists:flatten(Grants))};
+        {error, invalid_argument}=E ->
+            E
+    end.
+
+%% @doc Attempt to turn a `acl_perm()' and list of grants
+%% into a list of `acl_grant()'s. At this point, email
+%% addresses have already been resolved, and headers parsed.
+-spec header_to_acl_grants(acl_perm(), list(), pid()) ->
+    {ok, list(acl_grant())} | {error, invalid_argument}.
+header_to_acl_grants(HeaderName, Grants, RiakcPid) ->
+    MaybeGrantList = lists:map(fun (Identifier) ->
+                    header_to_grant(HeaderName, Identifier, RiakcPid) end, Grants),
+    case promote_failure(MaybeGrantList) of
+        {ok, GrantList} ->
+            {ok, lists:foldl(fun add_grant/2, [], GrantList)};
+        {error, invalid_argument}=E ->
+            E
+    end.
+
+%% Attempt to turn an `acl_perm()' and `grant_user_identifier()'
+%% into an `acl_grant()'. If the `grant_user_identifier()' uses an
+%% id, and the name can't be found, returns `{error, invalid_argument}'.
+-spec header_to_grant(acl_perm(), {grant_user_identifier(), string()}, pid()) ->
+    {ok, acl_grant()} | {error, invalid_argument}.
+header_to_grant(Permission, {id, ID}, RiakcPid) ->
+    case name_for_canonical(ID, RiakcPid) of
+        {ok, DisplayName} ->
+            {ok, {{DisplayName, ID}, [Permission]}};
+        {error, invalid_argument}=E ->
+            E
+    end;
+header_to_grant(Permission, {uri, URI}, _RiakcPid) ->
+    case URI of
+        ?ALL_USERS_GROUP ->
+            {ok, {'AllUsers', [Permission]}};
+        ?AUTH_USERS_GROUP ->
+            {ok, {'AuthUsers', [Permission]}}
+    end.
+
+%% @doc Attempt to parse a header into
+%% a list of grant identifiers and strings.
+-type grant_user_identifier() :: 'emailAddress' | 'id' | 'uri'.
+-spec parse_grant_header_value(string()) ->
+    {ok, [{grant_user_identifier(), string()}]} |
+    {error, invalid_argument} |
+    {error, unresolved_grant_email}.
+parse_grant_header_value(HeaderValue) ->
+    Mappings = split_header_values_and_strip(HeaderValue),
+    promote_failure(lists:map(fun parse_mapping/1, Mappings)).
+
+%% @doc split a string like:
+%% `"emailAddress=\"xyz@amazon.com\", emailAddress=\"abc@amazon.com\""'
+%% into:
+%% `["emailAddress=\"xyz@amazon.com\"",
+%%  "emailAddress=\"abc@amazon.com\""]'
+-spec split_header_values_and_strip(string()) -> string().
+split_header_values_and_strip(Value) ->
+    [string:strip(V) || V <- string:tokens(Value, ",")].
+
+%% @doc Attempt to parse a single grant, like:
+%% `"emailAddress=\"name@example.com\""'
+%% If the value can't be parsed, return
+%% `{error, invalid_argument}'.
+-spec parse_mapping(string()) ->
+    {ok, {grant_user_identifier(), Value :: string()}} |
+    {error, invalid_argument}.
+parse_mapping("emailAddress=" ++ QuotedEmail) ->
+    wrap('emailAddress', remove_quotes(QuotedEmail));
+parse_mapping("id=" ++ QuotedID) ->
+    wrap('id', remove_quotes(QuotedID));
+parse_mapping("uri=" ++ QuotedURI) ->
+    case remove_quotes(QuotedURI) of
+        {ok, NoQuote}=OK ->
+            case valid_uri(NoQuote) of
+                true ->
+                    wrap('uri', OK);
+                false ->
+                    {error, 'invalid_argument'}
+            end;
+        {error, invalid_argument}=E ->
+            E
+    end;
+parse_mapping(_Else) ->
+    {error, invalid_argument}.
+
+%% @doc Return true if `URI' is a valid group grant URI.
+-spec valid_uri(string()) -> boolean().
+valid_uri(URI) ->
+    %% log delivery is not yet a supported option
+    lists:member(URI, [?ALL_USERS_GROUP, ?AUTH_USERS_GROUP]).
+
+%% @doc Combine the first and second argument, if the second
+%% is wrapped in `ok'. Otherwise return the second argugment.
+-spec wrap(atom(), {'ok', term()} | {'error', atom()}) ->
+    {'error', atom()} | {ok, {atom(), term()}}.
+wrap(_Atom, {error, invalid_argument}=E) ->
+    E;
+wrap(Atom, {ok, Value}) ->
+    {ok, {Atom, Value}}.
+
+%% If `String' is enclosed in quotation marks, remove them. Otherwise
+%% return an error.
+-spec remove_quotes(string()) -> {error, invalid_argument} | {ok, string()}.
+remove_quotes(String) ->
+    case starts_and_ends_with_quotes(String) of
+        false ->
+            {error, invalid_argument};
+        true ->
+            {ok, string:sub_string(String, 2, length(String) - 1)}
+    end.
+
+%% @doc Return true if `String' is enclosed in quotation
+%% marks.
+-spec starts_and_ends_with_quotes(string()) -> boolean().
+starts_and_ends_with_quotes(String) ->
+    hd(String) =:= 34 andalso lists:last(String) =:= 34.
+
+%% @doc Attempt to turn a list of grants that use email addresses
+%% into a list of grants that only use canonical ids. Returns an error
+%% if any of the emails cannot be turned into canonical ids.
+-spec emails_to_ids(list(), pid()) -> {ok, list()} | {error, unresolved_grant_email}.
+emails_to_ids(Grants, RiakcPid) ->
+    {EmailGrants, RestGrants} = lists:partition(fun email_grant/1, Grants),
+    Ids = [canonical_for_email(EmailAddress, RiakcPid) ||
+            {emailAddress, EmailAddress} <- EmailGrants],
+    case promote_failure(Ids) of
+        {error, unresolved_grant_email}=E ->
+            E;
+        {ok, AllIds} ->
+            {ok, RestGrants ++ [{id, ID} || ID <- AllIds]}
+    end.
+
+-spec email_grant({atom(), term}) -> boolean().
+email_grant({Atom, _Val}) ->
+    Atom =:= 'emailAddress'.
+
+%% @doc Turn a list of ok-values or errors into either
+%% an ok of list, or an error. Returns the latter is any
+%% of the values in the input list are an error.
+-spec promote_failure(list({ok, A} | {error, term()})) ->
+    {ok, list(A)} | {'error', term()}.
+promote_failure(List) ->
+    %% this will reverse the list, but we don't care
+    %% about order
+    case lists:foldl(fun fail_either/2, {ok, []}, List) of
+        {{error, _Reason}=E, _Acc} ->
+            E;
+        {ok, _Acc}=Ok ->
+            Ok
+    end.
+
+%% @doc Return an error if either argument is an error. Otherwise,
+%% cons the value from the first argument onto the accumulator
+%% in the second.
+-spec fail_either({ok, term()} | {error, term()},
+                  {{error, term()} | 'ok', list()}) ->
+    {ok | {error, term()}, list()}.
+fail_either(_Elem, {{error, _Reason}=E, Acc}) ->
+    {E, Acc};
+fail_either(E={error, _Reason}, {_OkOrError, Acc}) ->
+    %% don't cons the error onto the acc
+    {E, Acc};
+fail_either({ok, Val}, {_OkOrError, Acc}) ->
+    {ok, [Val | Acc]}.
+
 %% @doc Convert an XML document representing an ACL into
 %% an internal representation.
 -spec acl_from_xml(string(), string(), pid()) -> {ok, #acl_v2{}} |
-                                                 {error, 'invalid_argument'} |
-                                                 {error, 'unresolved_grant_email'}.
+    {error, 'invalid_argument'} |
+    {error, 'unresolved_grant_email'}.
 acl_from_xml(Xml, KeyId, RiakPid) ->
     {ParsedData, _Rest} = xmerl_scan:string(Xml, []),
     BareAcl = ?ACL{owner={[], [], KeyId}},
@@ -95,42 +310,42 @@ acl_from_xml(Xml, KeyId, RiakPid) ->
 -spec empty_acl_xml() -> binary().
 empty_acl_xml() ->
     XmlDoc =
-        [{'AccessControlPolicy',
-          [
-          ]}],
+             [{'AccessControlPolicy',
+               [
+                    ]}],
     unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
+        xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
 
 %% @doc Map a request type to the type of ACL permissions needed
 %% to complete the request.
 -type request_method() :: 'GET' | 'HEAD' | 'PUT' | 'POST' |
-                          'DELETE' | 'Dialyzer happiness'.
+    'DELETE' | 'Dialyzer happiness'.
 -spec requested_access(request_method(), boolean()) -> acl_perm().
 requested_access(Method, AclRequest) ->
     if
         Method == 'GET'
-        andalso
-        AclRequest == true->
+                andalso
+                AclRequest == true->
             'READ_ACP';
         (Method == 'GET'
          orelse
          Method == 'HEAD') ->
             'READ';
         Method == 'PUT'
-        andalso
-        AclRequest == true->
+                andalso
+                AclRequest == true->
             'WRITE_ACP';
         (Method == 'POST'
          orelse
          Method == 'DELETE')
-        andalso
-        AclRequest == true->
+                andalso
+                AclRequest == true->
             undefined;
         Method == 'PUT'
-        orelse
-        Method == 'POST'
-        orelse
-        Method == 'DELETE' ->
+                orelse
+                Method == 'POST'
+                orelse
+                Method == 'DELETE' ->
             'WRITE';
         Method == 'Dialyzer happiness' ->
             'FULL_CONTROL';
@@ -139,12 +354,12 @@ requested_access(Method, AclRequest) ->
     end.
 
 -spec check_grants(undefined | rcs_user(), binary(), atom(), pid()) ->
-                          boolean() | {true, string()}.
+    boolean() | {true, string()}.
 check_grants(User, Bucket, RequestedAccess, RiakPid) ->
     check_grants(User, Bucket, RequestedAccess, RiakPid, undefined).
 
 -spec check_grants(undefined | rcs_user(), binary(), atom(), pid(), acl()|undefined) ->
-                          boolean() | {true, string()}.
+    boolean() | {true, string()}.
 check_grants(undefined, Bucket, RequestedAccess, RiakPid, BucketAcl) ->
     riak_cs_acl:anonymous_bucket_access(Bucket, RequestedAccess, RiakPid, BucketAcl);
 check_grants(User, Bucket, RequestedAccess, RiakPid, BucketAcl) ->
@@ -155,7 +370,7 @@ check_grants(User, Bucket, RequestedAccess, RiakPid, BucketAcl) ->
                               BucketAcl).
 
 -spec validate_acl({ok, acl()} | {error, term()}, string()) ->
-                          {ok, acl()} | {error, access_denied}.
+    {ok, acl()} | {error, access_denied}.
 validate_acl({ok, Acl=?ACL{owner={_, Id, _}}}, Id) ->
     {ok, Acl};
 validate_acl({ok, _}, _) ->
@@ -174,10 +389,10 @@ validate_acl({error, _}=Error, _) ->
 add_grant(NewGrant, Grants) ->
     {NewGrantee, NewPerms} = NewGrant,
     SplitFun = fun(G) ->
-                       {Grantee, _} = G,
-                       Grantee =:= NewGrantee
-               end,
-    {GranteeGrants, OtherGrants} = lists:splitwith(SplitFun, Grants),
+            {Grantee, _} = G,
+            Grantee =:= NewGrantee
+    end,
+    {GranteeGrants, OtherGrants} = lists:partition(SplitFun, Grants),
     case GranteeGrants of
         [] ->
             [NewGrant | Grants];
@@ -187,11 +402,11 @@ add_grant(NewGrant, Grants) ->
             %% The combined list of perms should be small so
             %% using usort should not be too expensive.
             FoldFun = fun({_, Perms}, Acc) ->
-                              lists:usort(Perms ++ Acc)
-                      end,
+                    lists:usort(Perms ++ Acc)
+            end,
             UpdPerms = lists:foldl(FoldFun, NewPerms, GranteeGrants),
             [{NewGrantee, UpdPerms} | OtherGrants]
-        end.
+    end.
 
 %% @doc Get the list of grants for a canned ACL
 -spec canned_acl_grants(string(),
@@ -230,11 +445,11 @@ owner_grant({Name, CanonicalId, _}) ->
 %% @doc Get the canonical id of the user associated with
 %% a given email address.
 -spec canonical_for_email(string(), pid()) -> {ok, string()} |
-                                              {error, unresolved_grant_email} .
+    {error, unresolved_grant_email} .
 canonical_for_email(Email, RiakPid) ->
     case riak_cs_utils:get_user_by_index(?EMAIL_INDEX,
-                                           list_to_binary(Email),
-                                           RiakPid) of
+                                         list_to_binary(Email),
+                                         RiakPid) of
         {ok, {User, _}} ->
             {ok, User?RCS_USER.canonical_id};
         {error, Reason} ->
@@ -245,11 +460,11 @@ canonical_for_email(Email, RiakPid) ->
 %% @doc Get the display name of the user associated with
 %% a given canonical id.
 -spec name_for_canonical(string(), pid()) -> {ok, string()} |
-                                             {error, 'invalid_argument'}.
+    {error, 'invalid_argument'}.
 name_for_canonical(CanonicalId, RiakPid) ->
     case riak_cs_utils:get_user_by_index(?ID_INDEX,
-                                           list_to_binary(CanonicalId),
-                                           RiakPid) of
+                                         list_to_binary(CanonicalId),
+                                         RiakPid) of
         {ok, {User, _}} ->
             {ok, User?RCS_USER.display_name};
         {error, _} ->
@@ -258,9 +473,9 @@ name_for_canonical(CanonicalId, RiakPid) ->
 
 %% @doc Process the top-level elements of the
 -spec process_acl_contents([xmlElement()], acl(), pid()) ->
-                                  {ok, #acl_v2{}} |
-                                  {error, invalid_argument} |
-                                  {error, unresolved_grant_email}.
+    {ok, #acl_v2{}} |
+    {error, invalid_argument} |
+    {error, unresolved_grant_email}.
 process_acl_contents([], Acl, _) ->
     {ok, Acl};
 process_acl_contents([HeadElement | RestElements], Acl, RiakPid) ->
@@ -268,15 +483,15 @@ process_acl_contents([HeadElement | RestElements], Acl, RiakPid) ->
     _ = lager:debug("Element name: ~p", [HeadElement#xmlElement.name]),
     ElementName = HeadElement#xmlElement.name,
     UpdAclRes =
-        case ElementName of
-            'Owner' ->
-                process_owner(Content, Acl, RiakPid);
-            'AccessControlList' ->
-                process_grants(Content, Acl, RiakPid);
-            _ ->
-                _ = lager:debug("Encountered unexpected element: ~p", [ElementName]),
-                Acl
-        end,
+                case ElementName of
+        'Owner' ->
+            process_owner(Content, Acl, RiakPid);
+        'AccessControlList' ->
+            process_grants(Content, Acl, RiakPid);
+        _ ->
+            _ = lager:debug("Encountered unexpected element: ~p", [ElementName]),
+            Acl
+    end,
     case UpdAclRes of
         {ok, UpdAcl} ->
             process_acl_contents(RestElements, UpdAcl, RiakPid);
@@ -318,28 +533,28 @@ process_owner([HeadElement | RestElements], Acl, RiakPid) ->
 
 %% @doc Process an XML element containing the grants for the acl.
 -spec process_grants([xmlElement()], acl(), pid()) ->
-                            {ok, #acl_v2{}} |
-                            {error, invalid_argument} |
-                            {error, unresolved_grant_email}.
+    {ok, #acl_v2{}} |
+    {error, invalid_argument} |
+    {error, unresolved_grant_email}.
 process_grants([], Acl, _) ->
     {ok, Acl};
 process_grants([HeadElement | RestElements], Acl, RiakPid) ->
     Content = HeadElement#xmlElement.content,
     ElementName = HeadElement#xmlElement.name,
     UpdAcl =
-        case ElementName of
-            'Grant' ->
-                Grant = process_grant(Content, {{"", ""}, []}, Acl?ACL.owner, RiakPid),
-                case Grant of
-                    {error, _} ->
-                        Grant;
-                    _ ->
-                        Acl?ACL{grants=add_grant(Grant, Acl?ACL.grants)}
-                end;
-            _ ->
-                _ = lager:debug("Encountered unexpected grants element: ~p", [ElementName]),
-                Acl
-        end,
+             case ElementName of
+        'Grant' ->
+            Grant = process_grant(Content, {{"", ""}, []}, Acl?ACL.owner, RiakPid),
+            case Grant of
+                {error, _} ->
+                    Grant;
+                _ ->
+                    Acl?ACL{grants=add_grant(Grant, Acl?ACL.grants)}
+            end;
+        _ ->
+            _ = lager:debug("Encountered unexpected grants element: ~p", [ElementName]),
+            Acl
+    end,
     case UpdAcl of
         {error, _} ->
             UpdAcl;
@@ -349,7 +564,7 @@ process_grants([HeadElement | RestElements], Acl, RiakPid) ->
 
 %% @doc Process an XML element containing the grants for the acl.
 -spec process_grant([xmlElement()], acl_grant(), acl_owner(), pid()) ->
-                           acl_grant() | {error, atom()}.
+    acl_grant() | {error, atom()}.
 process_grant([], Grant, _, _) ->
     Grant;
 process_grant([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
@@ -358,15 +573,15 @@ process_grant([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
     _ = lager:debug("ElementName: ~p", [ElementName]),
     _ = lager:debug("Content: ~p", [Content]),
     UpdGrant =
-        case ElementName of
-            'Grantee' ->
-                process_grantee(Content, Grant, AclOwner, RiakPid);
-            'Permission' ->
-                process_permission(Content, Grant);
-            _ ->
-                _ = lager:debug("Encountered unexpected grant element: ~p", [ElementName]),
-                Grant
-        end,
+               case ElementName of
+        'Grantee' ->
+            process_grantee(Content, Grant, AclOwner, RiakPid);
+        'Permission' ->
+            process_permission(Content, Grant);
+        _ ->
+            _ = lager:debug("Encountered unexpected grant element: ~p", [ElementName]),
+            Grant
+    end,
     case UpdGrant of
         {error, _}=Error ->
             Error;
@@ -377,9 +592,9 @@ process_grant([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
 %% @doc Process an XML element containing information about
 %% an ACL permission grantee.
 -spec process_grantee([xmlElement()], acl_grant(), acl_owner(), pid()) ->
-                             acl_grant() |
-                             {error, invalid_argument} |
-                             {error, unresolved_grant_email}.
+    acl_grant() |
+    {error, invalid_argument} |
+    {error, unresolved_grant_email}.
 process_grantee([], {{[], CanonicalId}, _Perms}, {DisplayName, CanonicalId, _}, _) ->
     {{DisplayName, CanonicalId}, _Perms};
 process_grantee([], {{[], CanonicalId}, _Perms}, _, RiakPid) ->
@@ -405,15 +620,15 @@ process_grantee([HeadElement | RestElements], Grant, AclOwner, RiakPid) ->
         'EmailAddress' ->
             _ = lager:debug("Email value: ~p", [Value]),
             UpdGrant =
-                case canonical_for_email(Value, RiakPid) of
-                    {ok, Id} ->
-                        %% Get the canonical id for a given email address
-                        _ = lager:debug("ID value: ~p", [Id]),
-                        {{Name, _}, Perms} = Grant,
-                        {{Name, Id}, Perms};
-                    {error, _}=Error ->
-                        Error
-                end;
+                       case canonical_for_email(Value, RiakPid) of
+                {ok, Id} ->
+                    %% Get the canonical id for a given email address
+                    _ = lager:debug("ID value: ~p", [Id]),
+                    {{Name, _}, Perms} = Grant,
+                    {{Name, Id}, Perms};
+                {error, _}=Error ->
+                    Error
+            end;
         'URI' ->
             {_, Perms} = Grant,
             case Value of

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -309,10 +309,7 @@ acl_from_xml(Xml, KeyId, RiakPid) ->
 %% into XML.
 -spec empty_acl_xml() -> binary().
 empty_acl_xml() ->
-    XmlDoc =
-             [{'AccessControlPolicy',
-               [
-                    ]}],
+    XmlDoc = [{'AccessControlPolicy',[]}],
     unicode:characters_to_binary(
         xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
 

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -22,12 +22,12 @@
 
 -module(riak_cs_acl_utils).
 
--compile(export_all).
-
 -include("riak_cs.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
 
 -ifdef(TEST).
+
+-compile(export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -86,6 +86,8 @@ error_message(invalid_argument) -> "Invalid Argument";
 error_message(unresolved_grant_email) -> "The e-mail address you provided does not match any account on record.";
 error_message(invalid_range) -> "The requested range is not satisfiable";
 error_message(invalid_bucket_name) -> "The specified bucket is not valid.";
+error_message(unexpected_content) -> "This request does not support content";
+error_message(canned_acl_and_header_grant) -> "Specifying both Canned ACLs and Header Grants is not allowed";
 error_message(_) -> "Please reduce your request rate.".
 
 error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
@@ -119,6 +121,8 @@ error_code(invalid_argument) -> "InvalidArgument";
 error_code(invalid_range) -> "InvalidRange";
 error_code(invalid_bucket_name) -> "InvalidBucketName";
 error_code(unresolved_grant_email) -> "UnresolvableGrantByEmailAddress";
+error_code(unexpected_content) -> "UnexpectedContent";
+error_code(canned_acl_and_header_grant) -> "InvalidRequest";
 error_code(ErrorName) ->
     ok = lager:debug("Unknown Error Name: ~p", [ErrorName]),
     "ServiceUnavailable".
@@ -161,6 +165,8 @@ status_code(invalid_argument) -> 400;
 status_code(unresolved_grant_email) -> 400;
 status_code(invalid_range) -> 416;
 status_code(invalid_bucket_name) -> 400;
+status_code(unexpected_content) -> 400;
+status_code(canned_acl_and_header_grant) -> 400;
 status_code(_) -> 503.
 
 -spec respond(term(), #wm_reqdata{}, #context{}) ->

--- a/src/riak_cs_wm_bucket.erl
+++ b/src/riak_cs_wm_bucket.erl
@@ -23,6 +23,7 @@
 -export([content_types_provided/2,
          to_xml/2,
          allowed_methods/0,
+         malformed_request/2,
          content_types_accepted/2,
          accept_body/2,
          delete_resource/2,
@@ -35,6 +36,16 @@
 -spec allowed_methods() -> [atom()].
 allowed_methods() ->
     ['HEAD', 'PUT', 'DELETE'].
+
+-spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
+malformed_request(RD, Ctx) ->
+    case riak_cs_wm_utils:has_canned_acl_and_header_grant(RD) of
+        true ->
+            riak_cs_s3_response:api_error(canned_acl_and_header_grant,
+                                          RD, Ctx);
+        false ->
+            {false, RD, Ctx}
+    end.
 
 -spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
 content_types_provided(RD, Ctx) ->
@@ -52,7 +63,7 @@ content_types_accepted(CT, RD, Ctx) when CT =:= undefined;
     content_types_accepted("application/octet-stream", RD, Ctx);
 content_types_accepted(CT, RD, Ctx) ->
     {Media, _Params} = mochiweb_util:parse_header(CT),
-    {[{Media, accept_body}], RD, Ctx}.
+    {[{Media, add_acl_to_context_then_accept}], RD, Ctx}.
 
 -spec authorize(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 authorize(RD, #context{user=User}=Ctx) ->
@@ -104,25 +115,18 @@ handle_read_request(RD, Ctx=#context{user=User,
 %% @doc Process request body on `PUT' request.
 -spec accept_body(#wm_reqdata{}, #context{}) -> {{halt, integer()}, #wm_reqdata{}, #context{}}.
 accept_body(RD, Ctx=#context{user=User,
+                             acl=ACL,
                              user_object=UserObj,
                              bucket=Bucket,
                              response_module=ResponseMod,
                              riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_create">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    %% Check for `x-amz-acl' header to support
-    %% non-default ACL at bucket creation time.
-    ACL = riak_cs_acl_utils:canned_acl(
-            wrq:get_req_header("x-amz-acl", RD),
-            {User?RCS_USER.display_name,
-             User?RCS_USER.canonical_id,
-             User?RCS_USER.key_id},
-            undefined),
     case riak_cs_utils:create_bucket(User,
-                                       UserObj,
-                                       Bucket,
-                                       ACL,
-                                       RiakPid) of
+                                     UserObj,
+                                     Bucket,
+                                     ACL,
+                                     RiakPid) of
         ok ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_create">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),

--- a/src/riak_cs_wm_bucket_acl.erl
+++ b/src/riak_cs_wm_bucket_acl.erl
@@ -23,6 +23,7 @@
 -export([content_types_provided/2,
          to_xml/2,
          allowed_methods/0,
+         malformed_request/2,
          content_types_accepted/2,
          accept_body/2]).
 
@@ -39,6 +40,16 @@
 allowed_methods() ->
     ['GET', 'PUT'].
 
+-spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
+malformed_request(RD, Ctx) ->
+    case riak_cs_wm_utils:has_acl_header_and_body(RD) of
+        true ->
+            riak_cs_s3_response:api_error(unexpected_content,
+                                          RD, Ctx);
+        false ->
+            {false, RD, Ctx}
+    end.
+
 -spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
 content_types_provided(RD, Ctx) ->
     {[{"application/xml", to_xml}], RD, Ctx}.
@@ -48,10 +59,10 @@ content_types_provided(RD, Ctx) ->
 content_types_accepted(RD, Ctx) ->
     case wrq:get_req_header("content-type", RD) of
         undefined ->
-            {[{"application/octet-stream", accept_body}], RD, Ctx};
+            {[{"application/octet-stream", add_acl_to_context_then_accept}], RD, Ctx};
         CType ->
             {Media, _Params} = mochiweb_util:parse_header(CType),
-            {[{Media, accept_body}], RD, Ctx}
+            {[{Media, add_acl_to_context_then_accept}], RD, Ctx}
     end.
 
 -spec authorize(#wm_reqdata{}, #context{}) -> {boolean() | {halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.
@@ -86,6 +97,7 @@ to_xml(RD, Ctx=#context{start_time=StartTime,
 -spec accept_body(#wm_reqdata{}, #context{}) -> {{halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.
 accept_body(RD, Ctx=#context{user=User,
                              user_object=UserObj,
+                             acl=AclFromHeadersOrDefault,
                              bucket=Bucket,
                              riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_put_acl">>,
@@ -94,15 +106,7 @@ accept_body(RD, Ctx=#context{user=User,
     AclRes =
         case Body of
             [] ->
-                %% Check for `x-amz-acl' header to support
-                %% the use of a canned ACL.
-                CannedAcl = riak_cs_acl_utils:canned_acl(
-                              wrq:get_req_header("x-amz-acl", RD),
-                              {User?RCS_USER.display_name,
-                               User?RCS_USER.canonical_id,
-                               User?RCS_USER.key_id},
-                              riak_cs_wm_utils:bucket_owner(Bucket, RiakPid)),
-                {ok, CannedAcl};
+                {ok, AclFromHeadersOrDefault};
             _ ->
                 riak_cs_acl_utils:validate_acl(
                   riak_cs_acl_utils:acl_from_xml(Body,

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -37,6 +37,7 @@
          process_post/2,
          resp_body/2,
          multiple_choices/2,
+         add_acl_to_context_then_accept/2,
          accept_body/2,
          produce_body/2,
          allowed_methods/2,
@@ -328,6 +329,16 @@ multiple_choices(RD, Ctx=#context{submodule=Mod,
         resource_call(Mod, multiple_choices, [RD, Ctx], ExportsFun)
     catch _:_ ->
             {false, RD, Ctx}
+    end.
+
+%% @doc Add an ACL (or default ACL) to the context, parsed from headers. If
+%% parsing the headers fails, halt the request.
+add_acl_to_context_then_accept(RD, Ctx) ->
+    case riak_cs_wm_utils:maybe_update_context_with_acl_from_headers(RD, Ctx) of
+        {ok, ContextWithAcl} ->
+            accept_body(RD, ContextWithAcl);
+        {error, HaltResponse} ->
+            HaltResponse
     end.
 
 -spec accept_body(#wm_reqdata{}, #context{}) ->

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -41,20 +41,22 @@ init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
-malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
-    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    %% need to unquote twice since we re-urlencode the string during rewrite in
-    %% order to trick webmachine dispatching
-    Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
-    LocalCtx = LocalCtx0#key_context{bucket=Bucket, key=Key},
-    {false, RD, Ctx#context{local_context=LocalCtx}}.
+malformed_request(RD, Ctx) ->
+    ContextWithKey = riak_cs_wm_utils:extract_key(RD, Ctx),
+    case riak_cs_wm_utils:has_canned_acl_and_header_grant(RD) of
+        true ->
+            riak_cs_s3_response:api_error(canned_acl_and_header_grant,
+                                          RD, ContextWithKey);
+        false ->
+            {false, RD, ContextWithKey}
+    end.
 
 %% @doc Get the type of access requested and the manifest with the
 %% object ACL and compare the permission requested with the permission
 %% granted, and allow or deny access. Returns a result suitable for
 %% directly returning from the {@link forbidden/2} webmachine export.
 -spec authorize(#wm_reqdata{}, #context{}) ->
-                       {boolean() | {halt, term()}, #wm_reqdata{}, #context{}}.
+    {boolean() | {halt, term()}, #wm_reqdata{}, #context{}}.
 authorize(RD, Ctx0=#context{local_context=LocalCtx0,
                             response_module=ResponseMod,
                             riakc_pid=RiakPid}) ->
@@ -268,7 +270,7 @@ content_types_accepted(CT, RD, Ctx=#context{local_context=LocalCtx0}) ->
         [_Type, _Subtype] ->
             %% accept whatever the user says
             LocalCtx = LocalCtx0#key_context{putctype=Media},
-            {[{Media, accept_body}], RD, Ctx#context{local_context=LocalCtx}};
+            {[{Media, add_acl_to_context_then_accept}], RD, Ctx#context{local_context=LocalCtx}};
         _ ->
             %% TODO:
             %% Maybe we should have caught
@@ -306,12 +308,14 @@ accept_body(RD, Ctx=#context{local_context=LocalCtx,
     end;
 accept_body(RD, Ctx=#context{local_context=LocalCtx,
                              user=User,
+                             acl=ACL,
                              riakc_pid=RiakcPid}) ->
     #key_context{bucket=Bucket,
                  key=Key,
                  putctype=ContentType,
                  size=Size,
                  get_fsm_pid=GetFsmPid} = LocalCtx,
+
     BFile_str = [Bucket, $,, Key],
     UserName = riak_cs_wm_utils:extract_name(User),
     riak_cs_dtrace:dt_object_entry(?MODULE, <<"object_put">>,
@@ -320,14 +324,6 @@ accept_body(RD, Ctx=#context{local_context=LocalCtx,
     Metadata = riak_cs_wm_utils:extract_user_metadata(RD),
     BlockSize = riak_cs_lfs_utils:block_size(),
 
-    %% Check for `x-amz-acl' header to support
-    %% non-default ACL at bucket creation time.
-    ACL = riak_cs_acl_utils:canned_acl(
-            wrq:get_req_header("x-amz-acl", RD),
-            {User?RCS_USER.display_name,
-             User?RCS_USER.canonical_id,
-             User?RCS_USER.key_id},
-            riak_cs_wm_utils:bucket_owner(Bucket, RiakcPid)),
     Args = [{Bucket, list_to_binary(Key), Size, list_to_binary(ContentType),
              Metadata, BlockSize, ACL, timer:seconds(60), self(), RiakcPid}],
     {ok, Pid} = riak_cs_put_fsm_sup:start_put_fsm(node(), Args),

--- a/src/riak_cs_wm_object_acl.erl
+++ b/src/riak_cs_wm_object_acl.erl
@@ -35,14 +35,16 @@
 init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
 
-%% TODO: copy/pasted from from wm_object, move somewhere common
-malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
-    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    %% need to unquote twice since we re-urlencode the string during rewrite in
-    %% order to trick webmachine dispatching
-    Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
-    LocalCtx = LocalCtx0#key_context{bucket=Bucket, key=Key},
-    {false, RD, Ctx#context{local_context=LocalCtx}}.
+-spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
+malformed_request(RD,Ctx) ->
+    case riak_cs_wm_utils:has_acl_header_and_body(RD) of
+        true ->
+            riak_cs_s3_response:api_error(unexpected_content,
+                                          RD, Ctx);
+        false ->
+            NewCtx = riak_cs_wm_utils:extract_key(RD, Ctx),
+            {false, RD, NewCtx}
+    end.
 
 %% @doc Get the type of access requested and the manifest with the
 %% object ACL and compare the permission requested with the permission
@@ -113,7 +115,7 @@ content_types_accepted(RD, Ctx=#context{local_context=LocalCtx0}) ->
         undefined ->
             DefaultCType = "application/octet-stream",
             LocalCtx = LocalCtx0#key_context{putctype=DefaultCType},
-            {[{DefaultCType, accept_body}],
+            {[{DefaultCType, add_acl_to_context_then_accept}],
              RD,
              Ctx#context{local_context=LocalCtx}};
         %% This was shamelessly ripped out of
@@ -124,7 +126,7 @@ content_types_accepted(RD, Ctx=#context{local_context=LocalCtx0}) ->
                 [_Type, _Subtype] ->
                     %% accept whatever the user says
                     LocalCtx = LocalCtx0#key_context{putctype=Media},
-                    {[{Media, accept_body}], RD, Ctx#context{local_context=LocalCtx}};
+                    {[{Media, add_acl_to_context_then_accept}], RD, Ctx#context{local_context=LocalCtx}};
                 _ ->
                     %% TODO:
                     %% Maybe we should have caught
@@ -175,6 +177,7 @@ accept_body(RD, Ctx=#context{local_context=#key_context{get_fsm_pid=GetFsmPid,
                                                         key=KeyStr,
                                                         bucket=Bucket},
                              user=User,
+                             acl=AclFromHeadersOrDefault,
                              requested_perm='WRITE_ACP',
                              riakc_pid=RiakPid})  when Bucket /= undefined,
                                                         KeyStr /= undefined,
@@ -189,15 +192,7 @@ accept_body(RD, Ctx=#context{local_context=#key_context{get_fsm_pid=GetFsmPid,
     AclRes =
         case Body of
             [] ->
-                %% Check for `x-amz-acl' header to support
-                %% the use of a canned ACL.
-                CannedAcl = riak_cs_acl_utils:canned_acl(
-                              wrq:get_req_header("x-amz-acl", RD),
-                              {User?RCS_USER.display_name,
-                               User?RCS_USER.canonical_id,
-                               User?RCS_USER.key_id},
-                              riak_cs_wm_utils:bucket_owner(Bucket, RiakPid)),
-                {ok, CannedAcl};
+                {ok, AclFromHeadersOrDefault};
             _ ->
                 riak_cs_acl_utils:validate_acl(
                   riak_cs_acl_utils:acl_from_xml(Body,

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -40,14 +40,15 @@ init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
-malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
-    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    %% need to unquote twice since we re-urlencode the string during rewrite in
-    %% order to trick webmachine dispatching
-    %% NOTE: Bucket::binary(), *but* Key::string()
-    Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
-    LocalCtx = LocalCtx0#key_context{bucket=Bucket, key=Key},
-    {false, RD, Ctx#context{local_context=LocalCtx}}.
+malformed_request(RD,Ctx) ->
+    ContextWithKey = riak_cs_wm_utils:extract_key(RD, Ctx),
+    case riak_cs_wm_utils:has_canned_acl_and_header_grant(RD) of
+        true ->
+            riak_cs_s3_response:api_error(canned_acl_and_header_grant,
+                                          RD, ContextWithKey);
+        false ->
+            {false, RD, ContextWithKey}
+    end.
 
 %% @doc Get the type of access requested and the manifest with the
 %% object ACL and compare the permission requested with the permission
@@ -73,8 +74,17 @@ allowed_methods() ->
 post_is_create(RD, Ctx) ->
     {false, RD, Ctx}.
 
-process_post(RD, Ctx=#context{local_context=LocalCtx,
-                              riakc_pid=RiakcPid}) ->
+process_post(RD, Ctx) ->
+    case riak_cs_wm_utils:maybe_update_context_with_acl_from_headers(RD, Ctx) of
+        {ok, ContextWithAcl} ->
+            process_post_helper(RD, ContextWithAcl);
+        {error, HaltResponse} ->
+            HaltResponse
+    end.
+
+process_post_helper(RD, Ctx=#context{local_context=LocalCtx,
+                                     acl=ACL,
+                                     riakc_pid=RiakcPid}) ->
     #key_context{bucket=Bucket, key=Key} = LocalCtx,
     ContentType = try
                       list_to_binary(wrq:get_req_header("Content-Type", RD))
@@ -83,10 +93,6 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                           <<"binary/octet-stream">>
                   end,
     User = riak_cs_mp_utils:user_rec_to_3tuple(Ctx#context.user),
-    ACL = riak_cs_acl_utils:canned_acl(
-            wrq:get_req_header("x-amz-acl", RD),
-            User,
-            riak_cs_wm_utils:bucket_owner(Bucket, RiakcPid)),
     Metadata = riak_cs_wm_utils:extract_user_metadata(RD),
     Opts = [{acl, ACL}, {meta_data, Metadata}],
 

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -45,14 +45,9 @@ init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
-malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->
-    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
-    %% need to unquote twice since we re-urlencode the string during rewrite in
-    %% order to trick webmachine dispatching
-    %% NOTE: Bucket::binary(), *but* Key::string()
-    Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
-    LocalCtx = LocalCtx0#key_context{bucket=Bucket, key=Key},
-    {false, RD, Ctx#context{local_context=LocalCtx}}.
+malformed_request(RD,Ctx) ->
+    NewCtx = riak_cs_wm_utils:extract_key(RD, Ctx),
+    {false, RD, NewCtx}.
 
 %% @doc Get the type of access requested and the manifest with the
 %% object ACL and compare the permission requested with the permission

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -37,9 +37,20 @@
          ensure_doc/2,
          deny_access/2,
          deny_invalid_key/2,
+         extract_key/2,
          extract_name/1,
-         normalize_headers/1,
+         maybe_update_context_with_acl_from_headers/2,
+         maybe_acl_from_context_and_request/2,
+         acl_from_headers/4,
+         extract_acl_headers/1,
+         has_acl_header_and_body/1,
+         has_acl_header/1,
+         has_canned_acl_and_header_grant/1,
+         has_canned_acl_header/1,
+         has_specific_acl_header/1,
+         has_body/1,
          extract_amazon_headers/1,
+         normalize_headers/1,
          extract_user_metadata/1,
          shift_to_owner/4,
          bucket_access_authorize_helper/4,
@@ -53,6 +64,10 @@
 
 -define(QS_KEYID, "AWSAccessKeyId").
 -define(QS_SIGNATURE, "Signature").
+
+-type acl_or_error() ::  {ok, #acl_v2{}} |
+                         {error, 'invalid_argument'} |
+                         {error, 'unresolved_grant_email'}.
 
 %% ===================================================================
 %% Public API
@@ -331,12 +346,161 @@ iso_8601_to_erl_date(Date)  ->
     {{b2i(Yr), b2i(Mo), b2i(Da)},
      {b2i(Hr), b2i(Mn), b2i(Sc)}}.
 
+%% @doc Return a new context where the bucket and key for the s3 object
+%% have been inserted.
+-spec extract_key(#wm_reqdata{}, #context{}) -> #context{}.
+extract_key(RD,Ctx=#context{local_context=LocalCtx0}) ->
+    Bucket = list_to_binary(wrq:path_info(bucket, RD)),
+    %% need to unquote twice since we re-urlencode the string during rewrite in
+    %% order to trick webmachine dispatching
+    Key = mochiweb_util:unquote(mochiweb_util:unquote(wrq:path_info(object, RD))),
+    LocalCtx = LocalCtx0#key_context{bucket=Bucket, key=Key},
+    Ctx#context{bucket=Bucket,
+                local_context=LocalCtx}.
+
 extract_name(User) when is_list(User) ->
     User;
 extract_name(?RCS_USER{name=Name}) ->
     Name;
 extract_name(_) ->
     "-unknown-".
+
+%% @doc Add an ACL to the context, from parsing the headers. If there is
+%% an error parsing the header, halt the request. If there is no ACL
+%% information in the headers, use the default ACL.
+-spec maybe_update_context_with_acl_from_headers(#wm_reqdata{}, #context{}) ->
+    {error, {{halt, term()}, #wm_reqdata{}, #context{}}} |
+    {ok, #context{}}.
+maybe_update_context_with_acl_from_headers(RD, Ctx=#context{user=User}) ->
+    case maybe_acl_from_context_and_request(RD, Ctx) of
+        {ok, {error, BadAclReason}} ->
+            {error, riak_cs_s3_response:api_error(BadAclReason, RD, Ctx)};
+        %% pattern match on the ACL record type for a data-type
+        %% sanity-check
+        {ok, {ok, Acl=?ACL{}}} ->
+            {ok, Ctx#context{acl=Acl}};
+        error ->
+            DefaultAcl = riak_cs_acl_utils:default_acl(User?RCS_USER.display_name,
+                                                       User?RCS_USER.canonical_id,
+                                                       User?RCS_USER.key_id),
+            {ok, Ctx#context{acl=DefaultAcl}}
+    end.
+
+%% @doc Return an ACL if one can be parsed from the headers. If there
+%% are no ACL headers, return `error'. In this case, it's not unexpected
+%% to get the `error' value back, but it's name is used for convention.
+%% It could also reasonable be called `nothing'.
+-spec maybe_acl_from_context_and_request(#wm_reqdata{}, #context{}) ->
+    {ok, acl_or_error()} | error.
+maybe_acl_from_context_and_request(RD, #context{user=User,
+                                                bucket=Bucket,
+                                                riakc_pid=RiakcPid}) ->
+    case has_acl_header(RD) of
+        true ->
+            Headers = normalize_headers(RD),
+            BucketOwner = bucket_owner(Bucket, RiakcPid),
+            Owner = {User?RCS_USER.display_name,
+                     User?RCS_USER.canonical_id,
+                     User?RCS_USER.key_id},
+            {ok, acl_from_headers(Headers, Owner, BucketOwner, RiakcPid)};
+        false ->
+            error
+    end.
+
+%% TODO: not sure if this should live here or in
+%% `riak_cs_acl_utils'
+%% @doc Create an acl from the request headers. At this point, we should
+%% have already verified that there is only a canned acl header or specific
+%% header grants.
+-spec acl_from_headers(Headers :: list(),
+                       Owner :: acl_owner(),
+                       BucketOwner :: undefined | acl_owner(),
+                       Pid :: pid()) ->
+    acl_or_error().
+acl_from_headers(Headers, Owner, BucketOwner, Pid) ->
+    %% TODO: time to make a macro for `"x-amz-acl"'
+    %% `Headers' is an ordset. Is there a faster way to retrieve this? Or
+    %% maybe a better data structure?
+    case proplists:get_value("x-amz-acl", Headers, {error, undefined}) of
+        {error, undefined} ->
+            RenamedHeaders = extract_acl_headers(Headers),
+            case RenamedHeaders of
+                [] ->
+                    {DisplayName, CanonicalId, KeyID} = Owner,
+                    {ok, riak_cs_acl_utils:default_acl(DisplayName, CanonicalId, KeyID)};
+                _Else ->
+                    riak_cs_acl_utils:specific_acl_grant(Owner, RenamedHeaders, Pid)
+            end;
+        Value ->
+            {ok, riak_cs_acl_utils:canned_acl(Value, Owner, BucketOwner)}
+    end.
+
+
+%% @doc Extract the ACL-related headers from a list of headers.
+-spec extract_acl_headers(term()) -> [{acl_perm(), string()}].
+extract_acl_headers(Headers) ->
+    lists:foldl(fun({HeaderName, Value}, Acc) ->
+                case header_name_to_perm(HeaderName) of
+                    undefined ->
+                        Acc;
+                    HeaderAtom ->
+                        [{HeaderAtom, Value} | Acc]
+                end
+        end,
+                [], Headers).
+
+%% @doc Turn a ACL header into the corresponding
+%% atom.
+-spec header_name_to_perm(list()) -> atom().
+header_name_to_perm("x-amz-grant-read") ->
+    'READ';
+header_name_to_perm("x-amz-grant-write") ->
+    'WRITE';
+header_name_to_perm("x-amz-grant-read-acp") ->
+    'READ_ACP';
+header_name_to_perm("x-amz-grant-write-acp") ->
+    'WRITE_ACP';
+header_name_to_perm("x-amz-grant-full-control") ->
+    'FULL_CONTROL';
+header_name_to_perm(_Else) ->
+    undefined.
+
+%% @doc Return true if the request has both:
+%% 1. an ACL-related header
+%% 2. a non-empty request body
+-spec has_acl_header_and_body(#wm_reqdata{}) -> boolean().
+has_acl_header_and_body(RD) ->
+    has_acl_header(RD) andalso has_body(RD).
+
+%% @doc Return true if the request has either
+%% a canned ACL header, or a specific-grant header.
+-spec has_acl_header(#wm_reqdata{}) -> boolean().
+has_acl_header(RD) ->
+    has_canned_acl_header(RD) orelse has_specific_acl_header(RD).
+
+%% @doc Return true if the request has _both_ a
+%% a canned header ACL and a specific-grant header.
+-spec has_canned_acl_and_header_grant(#wm_reqdata{}) -> boolean().
+has_canned_acl_and_header_grant(RD) ->
+    has_canned_acl_header(RD) andalso has_specific_acl_header(RD).
+
+%% @doc Return true if the request uses a canned ACL header.
+-spec has_canned_acl_header(#wm_reqdata{}) -> boolean().
+has_canned_acl_header(RD) ->
+    wrq:get_req_header("x-amz-acl", RD) =/= undefined.
+
+%% @doc Return true if the request has at least one
+%% specific-grant header.
+-spec has_specific_acl_header(#wm_reqdata{}) -> boolean().
+has_specific_acl_header(RD) ->
+    Headers = normalize_headers(RD),
+    extract_acl_headers(Headers) =/= [].
+
+%% @doc Return true if the request has a non-empty body.
+-spec has_body(#wm_reqdata{}) -> boolean().
+%% TODO: should we just check if the content-length is 0 instead?
+has_body(RD) ->
+    wrq:req_body(RD) =/= <<>>.
 
 extract_amazon_headers(Headers) ->
     FilterFun =

--- a/test/riak_cs_acl_utils_eqc.erl
+++ b/test/riak_cs_acl_utils_eqc.erl
@@ -1,0 +1,103 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Quickcheck test module for `riak_cs_acl_utils'.
+
+-module(riak_cs_acl_utils_eqc).
+-compile(export_all).
+
+-include("riak_cs.hrl").
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% eqc property
+-export([prop_add_grant_idempotent/0]).
+
+%% Helpers
+-export([test/0,
+         test/1]).
+
+-define(QC_OUT(P),
+        eqc:on_output(fun(Str, Args) ->
+                              io:format(user, Str, Args) end, P)).
+-define(TEST_ITERATIONS, 1000).
+
+%%====================================================================
+%% Eunit tests
+%%====================================================================
+
+eqc_test_() ->
+    {spawn,
+     [
+      {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_add_grant_idempotent()))))}
+     ]
+    }.
+
+%% ====================================================================
+%% EQC Properties
+%% ====================================================================
+
+prop_add_grant_idempotent() ->
+    %% For all grants, adding the same grant twice with `add_grant'
+    %% should be idempotent.
+    ?FORALL({Grants, RandomGrant}, ?LET(Grants, non_empty(list(grant())),
+                                        {Grants, elements(Grants)}),
+            begin
+                CombinedGrants = lists:foldl(fun riak_cs_acl_utils:add_grant/2, [], Grants),
+                lists:sort(CombinedGrants) =:= lists:sort(riak_cs_acl_utils:add_grant(RandomGrant, CombinedGrants))
+            end).
+
+prop_grant_gives_permission() ->
+    ?FORALL({Grants, RandomGrant}, ?LET(Grants, non_empty(list(grant())),
+                                        {Grants, elements(Grants)}),
+            begin
+                CombinedGrants = lists:foldl(fun riak_cs_acl_utils:add_grant/2, [], Grants),
+                {{_DisplayName, CanonicalID}, [RequestedAccess]} = RandomGrant,
+                riak_cs_acl:has_permission(CombinedGrants, RequestedAccess, CanonicalID)
+            end).
+
+
+%%====================================================================
+%% Generators
+%%====================================================================
+
+grantee() ->
+    elements([{"a", 1}, {"b", 2}, {"c", 3}, {"d", 4}]).
+
+permission() ->
+    elements(['READ', 'WRITE', 'READ_ACP', 'WRITE_ACP', 'FULL_CONTROL']).
+
+grant() ->
+    {grantee(), [permission()]}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+test() ->
+    test(?TEST_ITERATIONS).
+
+test(Iterations) ->
+    eqc:quickcheck(eqc:numtests(Iterations, prop_add_grant_idempotent())),
+    eqc:quickcheck(eqc:numtests(Iterations, prop_grant_gives_permission())).
+
+-endif.

--- a/test/riak_cs_acl_utils_eqc.erl
+++ b/test/riak_cs_acl_utils_eqc.erl
@@ -48,7 +48,8 @@
 eqc_test_() ->
     {spawn,
      [
-      {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_add_grant_idempotent()))))}
+      {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_add_grant_idempotent()))))},
+      {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_grant_gives_permission()))))}
      ]
     }.
 

--- a/xref.ignore-warnings
+++ b/xref.ignore-warnings
@@ -2,6 +2,7 @@
 Warning object_size_map/3 calls undefined function riak_object:get_values/1
 Warning map_keys_and_manifests/3 calls undefined function riak_object:get_values/1
 Warning map_keys_and_manifests/3 calls undefined function riak_object:key/1
+Warning map_keys_and_manifests/3 calls undefined function riak_object:bucket/1
 ######## kv backends calling into kv/core code
 src/riak_cs_kv_multi_backend.erl:[0-9]+: Warning get_backend_bucketprops/2 calls undefined function riak_core_bucket:get_bucket/1
 src/riak_cs_kv_multi_backend.erl:[0-9]+: Warning start/2 calls undefined function app_helper:get_prop_or_env/4


### PR DESCRIPTION
Originally [reported](http://lists.basho.com/pipermail/riak-users_lists.basho.com/2013-July/012795.html) by Eugene Doudine via the riak-users mailing list.

Attempts to set ACLs via `x-amz-grant-*` headers during object creation (`PUT`) are ignored. Setting them after an object is created via the XML body of a `PUT` with the query string parameter `?acl` appended works.

Test case using the AWS Ruby SDK:

``` ruby
require "aws-sdk"
require "logger"

AWS.config(
  logger: Logger.new($stdout),
  log_formatter: AWS::Core::LogFormatter.debug,
  log_level: :debug
)

s3 = AWS::S3.new(
  # Credentials for admin@admin.com.
  access_key_id: "T3J4N9T8PNLAJMYLSWXB",
  secret_access_key: "oWl6LH9BJumR6tFMvzc8KduClDKfFYxi3ADXPA==",
  proxy_uri: "http://localhost:8888", # 8888 is for Charles Proxy
  use_ssl: false,
  http_read_timeout: 2000,
  max_retries: 0
)

timestamp   = Time.now.to_i
bucket_name = "acl-test-bucket-#{timestamp}"
object_name = "acl-test-object-#{timestamp}"

bucket = s3.buckets.create(bucket_name)

# Attempt to set ACLs at object creation time.
s3.buckets[bucket_name].objects[object_name].write("Joker",
  grant_full_control: "emailAddress\"admin@admin.com\"",
  grant_read: "emailAddress=\"acl_test@basho.com\""
)

# List ACLs to see if it worked -- it doesn't.
s3.buckets[bucket_name].objects[object_name].acl

# Create similar ACLs to those above.
acl = AWS::S3::AccessControlList.new
acl.grant(:full_control).to(amazon_customer_email: "admin@admin.com")
acl.grant(:read).to(amazon_customer_email: "acl_test@basho.com")

# Apply those ACLs after the object is created.
s3.buckets[bucket_name].objects[object_name].acl = acl

# List ACLs to see if it worked -- it did.
s3.buckets[bucket_name].objects[object_name].acl
```

Debugging output of the above script running against a local Riak CS instance with two active users:

```
+-------------------------------------------------------------------------------
| AWS us-east-1 S3 create_bucket 0.028978 0 retries
+-------------------------------------------------------------------------------
|   REQUEST
+-------------------------------------------------------------------------------
|    METHOD: PUT
|       URL: http://acl-test-bucket-1375233769.s3.amazonaws.com::80:/
|   HEADERS: {"user-agent"=>"aws-sdk-ruby/1.14.1 ruby/1.9.3 x86_64-darwin12.4.0", "date"=>"Wed, 31 Jul 2013 01:22:49 GMT", "authorization"=>"AWS T3J4N9T8PNLAJMYLSWXB:xoSN9EAmxvEl1LugYMfPpk6ic0c="}
|      BODY:
+-------------------------------------------------------------------------------
|  RESPONSE
+-------------------------------------------------------------------------------
|    STATUS: 200
|   HEADERS: {"server"=>["Riak CS"], "date"=>["Wed, 31 Jul 2013 01:22:49 GMT"], "content-type"=>["application/xml"], "content-length"=>["0"], "proxy-connection"=>["Keep-alive"]}
|      BODY:
+-------------------------------------------------------------------------------
| AWS us-east-1 S3 put_object 0.018525 0 retries
+-------------------------------------------------------------------------------
|   REQUEST
+-------------------------------------------------------------------------------
|    METHOD: PUT
|       URL: http://acl-test-bucket-1375233769.s3.amazonaws.com::80:/acl-test-object-1375233769
|   HEADERS: {"content-length"=>5, "x-amz-grant-read"=>"emailAddress=\"acl_test@basho.com\"", "x-amz-grant-full-control"=>"emailAddress\"admin@admin.com\"", "user-agent"=>"aws-sdk-ruby/1.14.1 ruby/1.9.3 x86_64-darwin12.4.0", "date"=>"Wed, 31 Jul 2013 01:22:49 GMT", "authorization"=>"AWS T3J4N9T8PNLAJMYLSWXB:yqhecCmkheKGsuIscKP1HSMU/sg="}
|      BODY:
+-------------------------------------------------------------------------------
|  RESPONSE
+-------------------------------------------------------------------------------
|    STATUS: 200
|   HEADERS: {"server"=>["Riak CS"], "etag"=>["\"e55318040a854ebdc8d0508d2522bee5\""], "date"=>["Wed, 31 Jul 2013 01:22:49 GMT"], "content-type"=>["text/plain"], "content-length"=>["0"], "proxy-connection"=>["Keep-alive"]}
|      BODY:
+-------------------------------------------------------------------------------
| AWS us-east-1 S3 get_object_acl 0.013928 0 retries
+-------------------------------------------------------------------------------
|   REQUEST
+-------------------------------------------------------------------------------
|    METHOD: GET
|       URL: http://acl-test-bucket-1375233769.s3.amazonaws.com::80:/acl-test-object-1375233769?acl
|   HEADERS: {"user-agent"=>"aws-sdk-ruby/1.14.1 ruby/1.9.3 x86_64-darwin12.4.0", "date"=>"Wed, 31 Jul 2013 01:22:49 GMT", "authorization"=>"AWS T3J4N9T8PNLAJMYLSWXB:QW094CPm9FHBaQZk5CcjgAwT58g="}
|      BODY:
+-------------------------------------------------------------------------------
|  RESPONSE
+-------------------------------------------------------------------------------
|    STATUS: 200
|   HEADERS: {"server"=>["Riak CS"], "date"=>["Wed, 31 Jul 2013 01:22:49 GMT"], "content-type"=>["application/octet-stream"], "content-length"=>["495"], "proxy-connection"=>["Keep-alive"]}
|      BODY: <?xml version="1.0" encoding="UTF-8"?><AccessControlPolicy><Owner><ID>51e365ea87a8cfb147ed24533cc36493f6664880c6960f5e378b1dcfe5d43039</ID><DisplayName>admin</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>51e365ea87a8cfb147ed24533cc36493f6664880c6960f5e378b1dcfe5d43039</ID><DisplayName>admin</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
+-------------------------------------------------------------------------------
| AWS us-east-1 S3 put_object_acl 0.041236 0 retries
+-------------------------------------------------------------------------------
|   REQUEST
+-------------------------------------------------------------------------------
|    METHOD: PUT
|       URL: http://acl-test-bucket-1375233769.s3.amazonaws.com::80:/acl-test-object-1375233769?acl
|   HEADERS: {"content-length"=>529, "user-agent"=>"aws-sdk-ruby/1.14.1 ruby/1.9.3 x86_64-darwin12.4.0", "date"=>"Wed, 31 Jul 2013 01:22:49 GMT", "authorization"=>"AWS T3J4N9T8PNLAJMYLSWXB:mhdmPbILw1l3XqSdatQTTpeqiyE="}
|      BODY: <AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AmazonCustomerByEmail"><EmailAddress>admin@admin.com</EmailAddress></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AmazonCustomerByEmail"><EmailAddress>acl_test@basho.com</EmailAddress></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
+-------------------------------------------------------------------------------
|  RESPONSE
+-------------------------------------------------------------------------------
|    STATUS: 200
|   HEADERS: {"server"=>["Riak CS"], "date"=>["Wed, 31 Jul 2013 01:22:49 GMT"], "content-type"=>["text/plain"], "content-length"=>["0"], "proxy-connection"=>["Keep-alive"]}
|      BODY:
+-------------------------------------------------------------------------------
| AWS us-east-1 S3 get_object_acl 0.010334 0 retries
+-------------------------------------------------------------------------------
|   REQUEST
+-------------------------------------------------------------------------------
|    METHOD: GET
|       URL: http://acl-test-bucket-1375233769.s3.amazonaws.com::80:/acl-test-object-1375233769?acl
|   HEADERS: {"user-agent"=>"aws-sdk-ruby/1.14.1 ruby/1.9.3 x86_64-darwin12.4.0", "date"=>"Wed, 31 Jul 2013 01:22:49 GMT", "authorization"=>"AWS T3J4N9T8PNLAJMYLSWXB:QW094CPm9FHBaQZk5CcjgAwT58g="}
|      BODY:
+-------------------------------------------------------------------------------
|  RESPONSE
+-------------------------------------------------------------------------------
|    STATUS: 200
|   HEADERS: {"server"=>["Riak CS"], "date"=>["Wed, 31 Jul 2013 01:22:49 GMT"], "content-type"=>["application/octet-stream"], "content-length"=>["676"], "proxy-connection"=>["Keep-alive"]}
|      BODY: <?xml version="1.0" encoding="UTF-8"?><AccessControlPolicy><Owner><ID></ID><DisplayName></DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>51e365ea87a8cfb147ed24533cc36493f6664880c6960f5e378b1dcfe5d43039</ID><DisplayName>admin</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>d9fc95243a15bcb0253977cb65a8ed51204ed16c848241eb409a04c1e196bf07</ID><DisplayName>acl_test</DisplayName></Grantee><Permission>READ</Permission></Grant></AccessControlList></AccessControlPolicy>
```
