### PR TITLE
Consider manifests for pruning based on count

### DIFF
--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -37,6 +37,7 @@
          gc_specific_manifests/5,
          epoch_start/0,
          leeway_seconds/0,
+         max_scheduled_delete_manifests/0,
          move_manifests_to_gc_bucket/3,
          timestamp/0]).
 
@@ -255,6 +256,19 @@ leeway_seconds() ->
             ?DEFAULT_LEEWAY_SECONDS;
         {ok, LeewaySeconds} ->
             LeewaySeconds
+    end.
+
+%% @doc Return the maximimum number of manifests that can be in the
+%% `scheduled_delete' state for a given key. `unlimited' means there
+%% is no maximum, and pruning will not happen based on count. This is
+%% the default.
+-spec max_scheduled_delete_manifests() -> non_neg_integer() | unlimited.
+max_scheduled_delete_manifests() ->
+    case application:get_env(riak_cs, max_scheduled_delete_manifests) of
+        undefined ->
+            unlimited;
+        {ok, MaxCount} ->
+            MaxCount
     end.
 
 %% @doc Generate a key for storing a set of manifests for deletion.

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -40,7 +40,7 @@
          mark_scheduled_delete/2,
          manifests_to_gc/2,
          prune/1,
-         prune/2,
+         prune/3,
          upgrade_wrapped_manifests/1,
          upgrade_manifest/1]).
 
@@ -240,12 +240,35 @@ retry_from_marked_time(MarkedTime, Now) ->
 %%      see needs_pruning() for definition of needing pruning.
 -spec prune(orddict:orddict()) -> orddict:orddict().
 prune(Dict) ->
-    prune(Dict, erlang:now()).
+    MaxCount = riak_cs_gc:max_scheduled_delete_manifests(),
+    prune(Dict, erlang:now(), MaxCount).
 
--spec prune(orddict:orddict(), erlang:timestamp()) -> orddict:orddict().
-prune(Dict, Time) ->
-     orddict:filter(fun (_Key, Value) -> not needs_pruning(Value, Time) end,
-                    Dict).
+-spec prune(orddict:orddict(),
+            erlang:timestamp(),
+            unlimited | non_neg_integer()) -> orddict:orddict().
+prune(Dict, Time, MaxCount) ->
+    Filtered = orddict:filter(fun (_Key, Value) -> not needs_pruning(Value, Time) end,
+                              Dict),
+    prune_count(Filtered, MaxCount).
+
+-spec prune_count(orddict:orddict(), unlimited | non_neg_integer()) ->
+    orddict:orddict().
+prune_count(Manifests, unlimited) ->
+    Manifests;
+prune_count(Manifests, MaxCount) ->
+    ScheduledDelete = filter_manifests_by_state(Manifests, [scheduled_delete]),
+    UUIDAndTime = [{M?MANIFEST.uuid, M?MANIFEST.scheduled_delete_time} ||
+                   {_UUID, M} <- ScheduledDelete],
+    case length(UUIDAndTime) > MaxCount of
+        true ->
+            SortedByTimeRecentFirst = lists:keysort(2, UUIDAndTime),
+            UUIDsToPrune = sets:from_list([UUID || {UUID, _ScheduledDeleteTime} <-
+                                           lists:nthtail(MaxCount, SortedByTimeRecentFirst)]),
+            orddict:filter(fun (UUID, _Value) -> not sets:is_element(UUID, UUIDsToPrune) end,
+                       Manifests);
+        false ->
+            Manifests
+    end.
 
 -spec upgrade_wrapped_manifests([orddict:orddict()]) -> [orddict:orddict()].
 upgrade_wrapped_manifests(ListofOrdDicts) ->


### PR DESCRIPTION
If the `riak_cs` application env `max_scheduled_delete_manifests` is set
to an integer (default is `unlimited`), manifests will not only be
pruned based on `scheduled_delete_time`, but based on the number of
`scheduled_delete` manifests there are. If there are more than
`max_scheduled_delete_manifests`, they will be sorted by time (more
recent first), and then cut-off at `max_scheduled_delete_manifests`.
This means that in cases where a key is overwritten frequently, we have
the option of pruning manifests more frequently than just the leeway
time.
