### PR TITLE
Only a single access archiver can run at a time

### DIFF
--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -67,7 +67,7 @@
 %% @end
 %%--------------------------------------------------------------------
 start_link() ->
-    gen_fsm:start_link({local, ?MODULE}, ?MODULE, [], []).
+    gen_fsm:start_link(?MODULE, [], []).
 
 %% @doc Find out what the archiver is up to.  Should return `{ok,
 %% State, Props}' where `State' is `idle' or `archiving' if the


### PR DESCRIPTION
The `riak_cs_access_archiver` module incorrectly uses a local process name when starting which effectively restricts the maximum number of archiver processes that can be running to 1.
