### PR TITLE
Improve handling of block read request timeouts

### DIFF
--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -276,14 +276,14 @@ try_local_get(RiakcPid, FullBucket, FullKey, GetOptions1, GetOptions2,
             ProceedFun(Success);
         {error, {insufficient_vnodes,_,need,_}} ->
             RetryFun(NumRetries + 2);
-        {error, Why} when Why == notfound; Why == timeout;
-                          Why == <<"{insufficient_vnodes,0,need,1}">> ->
+        {error, Why} when Why == notfound;
+                          Why == timeout;
+                          Why == disconnected;
+                          Why == <<"{insufficient_vnodes,0,need,1}">>;
+                          Why == {insufficient_vnodes,0,need,1} ->
             handle_local_notfound(RiakcPid, FullBucket, FullKey, GetOptions2,
                                   ProceedFun, RetryFun, NumRetries, UseProxyGet,
                                   ProxyActive, ClusterID);
-        {error, disconnected} ->
-            _ = lager:error("do_get_block: socket disconnected"),
-            RetryFun(NumRetries + 1);
         {error, Other} ->
             _ = lager:error("do_get_block: other error 1: ~p\n", [Other]),
             RetryFun(failure)
@@ -296,7 +296,9 @@ handle_local_notfound(RiakcPid, FullBucket, FullKey, GetOptions2,
     case get_block_local(RiakcPid, FullBucket, FullKey, GetOptions2, 60*1000) of
         {ok, _} = Success ->
             ProceedFun(Success);
-        {error, Why} when Why == notfound; Why == timeout ->
+        {error, Why} when Why == notfound;
+                          Why == timeout;
+                          Why == disconnected ->
             case UseProxyGet of
                 true when ProxyActive ->
                     case get_block_remote(RiakcPid, FullBucket, FullKey,
@@ -315,9 +317,6 @@ handle_local_notfound(RiakcPid, FullBucket, FullKey, GetOptions2,
                 false ->
                     RetryFun(failure)
             end;
-        {error, disconnected} ->
-            _ = lager:error("do_get_block: socket disconnected"),
-            RetryFun(NumRetries + 1);
         {error, Other} ->
             _ = lager:error("do_get_block: other error 2: ~p\n", [Other]),
             RetryFun(failure)


### PR DESCRIPTION
Block read requests that take longer than the timeout results in an
`{error, disconnected}` tuple being returned instead of `{error, timeout}`. 
The current code is written such that when `n_val=1` requests are enabled and
a timeout occurs that returns `{error, disconnected}`, the request is retried
again with `n_val=1` set. This means that the request is sent to the same
vnode again. In the case of a severely backed-up vnode queue this likely
results in another timeout and `{error, disconnected}` result from the pb
client.  This continues until the retry limit is reached and an eventual
`{error, notfound}` is returned to the process that called the block server.
Change the block server code to add `disconnected` as a reason to trigger a
read attempt that does not use the `n_val=1` option. This should allow the
read request to complete and not cause downloads to stall in the case of one
or more very slow responding Riak vnodes.
