### PR TITLE
Ignore Owner with an empty ID in AccessControlPolicy blob

### DIFF
--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -298,23 +298,27 @@ process_owner([], Acl, _) ->
     {ok, Acl};
 process_owner([HeadElement | RestElements], Acl, RiakPid) ->
     Owner = Acl?ACL.owner,
-    [Content] = HeadElement#xmlElement.content,
-    Value = Content#xmlText.value,
-    ElementName = HeadElement#xmlElement.name,
-    case ElementName of
-        'ID' ->
-            _ = lager:debug("Owner ID value: ~p", [Value]),
-            {OwnerName, _, OwnerKeyId} = Owner,
-            UpdOwner = {OwnerName, Value, OwnerKeyId};
-        'DisplayName' ->
-            _ = lager:debug("Owner Name content: ~p", [Value]),
-            {_, OwnerId, OwnerKeyId} = Owner,
-            UpdOwner = {Value, OwnerId, OwnerKeyId};
-        _ ->
-            _ = lager:debug("Encountered unexpected element: ~p", [ElementName]),
-            UpdOwner = Owner
-    end,
-    process_owner(RestElements, Acl?ACL{owner=UpdOwner}, RiakPid).
+    case HeadElement#xmlElement.content of
+        [Content] ->
+            Value = Content#xmlText.value,
+            ElementName = HeadElement#xmlElement.name,
+            case ElementName of
+                'ID' ->
+                    _ = lager:debug("Owner ID value: ~p", [Value]),
+                    {OwnerName, _, OwnerKeyId} = Owner,
+                    UpdOwner = {OwnerName, Value, OwnerKeyId};
+                'DisplayName' ->
+                    _ = lager:debug("Owner Name content: ~p", [Value]),
+                    {_, OwnerId, OwnerKeyId} = Owner,
+                    UpdOwner = {Value, OwnerId, OwnerKeyId};
+                _ ->
+                    _ = lager:debug("Encountered unexpected element: ~p", [ElementName]),
+                    UpdOwner = Owner
+            end,
+            process_owner(RestElements, Acl?ACL{owner=UpdOwner}, RiakPid);
+        [] ->
+            process_owner(RestElements, Acl, RiakPid)
+    end.
 
 %% @doc Process an XML element containing the grants for the acl.
 -spec process_grants([xmlElement()], acl(), pid()) ->


### PR DESCRIPTION
Some clients (eg. Cyberduck) are a bit special and can send AccessControlPolicy with an Owner element that has an empty ID element inside, when they are only meant to be updating the ACL. Currently we handle the case where an empty Owner element is sent, but not if it has an empty ID inside it (results in a 500 error at present, due to a badmatch).

I propose that we simply ignore an Owner with an empty element inside, instead of crashing out -- it's what the Amazon S3 seems to do, and it seems vaguely sensible.

For completeness' sake this patch handles any empty child inside the Owner, not just an ID (although I've only ever seen an empty ID sent on its own in the wild so far). It will still crash out in the case that we get an owner with a non-element child or a child with more than one child inside it, which I think is fine for now (as these cases are very clearly malformed).
