### PR TITLE
riak_cs_access_archiver_manager always fails to throttle access archiver

### DIFF
--- a/src/riak_cs_access_archiver_manager.erl
+++ b/src/riak_cs_access_archiver_manager.erl
@@ -145,7 +145,7 @@ handle_call(status, _From, State=#state{backlog=Backlog, workers=Workers}) ->
     Props = [{backlog, length(Backlog)},
              {workers, Workers}],
         {reply, {ok, Props}, State};
-handle_call({archive, _, _}, _From, State=#state{workers=Workers,
+handle_call(archive, _From, State=#state{workers=Workers,
                                                  max_workers=MaxWorkers})
   when length(Workers) >= MaxWorkers ->
     %% All workers are busy so the manager takes ownership and adds an

--- a/xref.ignore-warnings
+++ b/xref.ignore-warnings
@@ -2,6 +2,7 @@
 Warning object_size_map/3 calls undefined function riak_object:get_values/1
 Warning map_keys_and_manifests/3 calls undefined function riak_object:get_values/1
 Warning map_keys_and_manifests/3 calls undefined function riak_object:key/1
+Warning map_keys_and_manifests/3 calls undefined function riak_object:bucket/1
 ######## kv backends calling into kv/core code
 src/riak_cs_kv_multi_backend.erl:[0-9]+: Warning get_backend_bucketprops/2 calls undefined function riak_core_bucket:get_bucket/1
 src/riak_cs_kv_multi_backend.erl:[0-9]+: Warning start/2 calls undefined function app_helper:get_prop_or_env/4


### PR DESCRIPTION
even when the number of active workers exceeded max_workers, because the `handle_call({archive, _, _}, ...)` never matches to the message called from `riak_cs_access_archiver_manager:archive/2`.

Not sure what to test here, or how to reproduce, probably I can write riak_test by setting `access_archiver_max_workers` as 0. I'd be happy
write the test if it's not trivial.
