### PR TITLE
handle timeout error on sum_bucket/2

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -625,3 +625,21 @@ make_authorization(Method, Resource, ContentType, Config, Date) ->
     StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n, Resource],
     Signature = base64:encode_to_string(crypto:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
     lists:flatten(["AWS ", Config#aws_config.access_key_id, $:, Signature]).
+
+datetime() ->
+    {{YYYY,MM,DD}, {H,M,S}} = calendar:universal_time(),
+    io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [YYYY, MM, DD, H, M, S]).
+
+
+
+json_get(Key, Json) when is_binary(Key) ->
+    json_get([Key], Json);
+json_get([], Json) ->
+    Json;
+json_get([Key | Keys], {struct, JsonProps}) ->
+    case lists:keyfind(Key, 1, JsonProps) of
+        false ->
+            notfound;
+        {Key, Value} ->
+            json_get(Keys, Value)
+    end.

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -1,0 +1,74 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(cs743_regression_test).
+
+%% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/286">
+%% issue 286</a>.
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(TEST_BUCKET, "riak-test-bucket").
+
+confirm() ->
+    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
+
+              {cs,
+               [{riakc, [{mapred_timeout,1}]}] %% make storage calc timeout
+               ++ rtcs:cs_config()}],
+    {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(4, Config),
+
+
+    run_storage_batch(hd(CSNodes)),
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    N = 1024,
+    lager:info("creating ~p objects in ~p", [N, ?TEST_BUCKET]),
+    ok = etoomanyobjects(N, UserConfig),
+
+    run_storage_batch(hd(CSNodes)),
+    pass.
+
+run_storage_batch(CSNode) ->
+    {ok, Status0} = rpc:call(CSNode, riak_cs_storage_d, status, []),
+    lager:info("~p", [Status0]),
+    ok = rpc:call(CSNode, riak_cs_storage_d, start_batch, [[{recalc,true}]]),
+    {ok, Status1} = rpc:call(CSNode, riak_cs_storage_d, status, []),
+    lager:info("~p", [Status1]),
+    %%{ok,
+    %% {calculating,[{schedule,[]},{last,undefined},{current,{{2013,12,26},{3,55,29}}},
+    %% {next,undefined},{elapsed,0},{users_done,1},{users_skipped,0},{users_left,0}]}}
+
+    {_Status, Result} = Status1,
+    1 = proplists:get_value(users_done,Result),
+    0 = proplists:get_value(users_skipped,Result),
+    0 = proplists:get_value(users_left,Result).
+
+etoomanyobjects(N, UserConfig) ->
+    SingleBlock = crypto:rand_bytes(400),
+    lists:map(fun(I) ->
+                      R = erlcloud_s3:put_object(?TEST_BUCKET, integer_to_list(I),
+                                                 SingleBlock, UserConfig),
+                      [{version_id,"null"}] = R
+              end,
+              lists:seq(1,N)),
+    ok.

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -58,10 +58,11 @@ sum_user(Riak, User) when is_list(User) ->
 %%      there are no other way for operator to know a calculation
 %%      which riak_cs_storage_d failed.
 -spec maybe_sum_bucket(pid(), string(), string()) ->
-                              {string(), non_neg_integer()|string()}.
+                              {string(), term()|string()}.
 maybe_sum_bucket(Riak, User, Bucket) ->
     case sum_bucket(Riak, Bucket) of
-        {ok, BucketUsage} -> BucketUsage;
+        {struct, _} = BucketUsage -> BucketUsage;
+
         {error, _} = E ->
             _ = lager:error("failed to calculate usage of "
                             "bucket '~s' of user '~s'. Reason: ~p",


### PR DESCRIPTION
addresses #743.
from commit message:

```
add error handling when sum_bucket failed with timeout, which
causes dirty error message and no way to know which bucket was
failed in usage calculation mapreduce. This commit adds two ways
to know that:

- outputs an error log that prints user key id and bucket name
  with error reason.
- stores the result into moss.storage with reason like:
    { "bucket_name" : "{error,{timeout,[]}}" }

The latter log proves and indicated there existed a bucket at
that time even though its usage size was unknown. Better than
ignored, which operator can't tell non-existent from calculation
failure.
```
