### PR TITLE
Refactor/bucket object in state

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -100,6 +100,7 @@
                       get_fsm_pid :: pid(),
                       putctype :: string(),
                       bucket :: binary(),
+                      bucket_object :: undefined | notfound | riakc_obj:riakc_obj(),
                       key :: list(),
                       owner :: 'undefined' | string(),
                       size :: non_neg_integer(),

--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -176,7 +176,7 @@ bucket_access(_, RequestedAccess, CanonicalId, RiakPid, Acl) ->
 -type bucket_acl_riak_error() :: {error, 'notfound' | term()}.
 -spec fetch_bucket_acl(binary(), pid()) -> bucket_acl_result() | bucket_acl_riak_error().
 fetch_bucket_acl(Bucket, RiakPid) ->
-    case riak_cs_utils:check_bucket_exists(Bucket, RiakPid) of
+    case riak_cs_utils:fetch_bucket_object(Bucket, RiakPid) of
         {ok, Obj} ->
             bucket_acl(Obj);
         {error, Reason} ->

--- a/src/riak_cs_policy.erl
+++ b/src/riak_cs_policy.erl
@@ -22,6 +22,8 @@
 
 -include("riak_cs.hrl").
 
+-callback fetch_bucket_policy(binary(), pid()) -> {ok, policy()} | {error, term()}.
+-callback bucket_policy(riakc_obj:riakc_obj()) -> {ok, policy()} | {error, term()}.
 -callback eval(access(), policy() | undefined | binary() ) -> boolean() | undefined.
 -callback check_policy(access(), policy()) -> ok | {error, atom()}.
 -callback reqdata_to_access(RD :: term(), Target::atom(), ID::binary()|undefined) -> access().

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -255,7 +255,7 @@ log_supported_actions()->
                                 {'error', 'multiple_bucket_owners'}.
 -spec fetch_bucket_policy(binary(), pid()) -> bucket_policy_result().
 fetch_bucket_policy(Bucket, RiakPid) ->
-    case riak_cs_utils:check_bucket_exists(Bucket, RiakPid) of
+    case riak_cs_utils:fetch_bucket_object(Bucket, RiakPid) of
         {ok, Obj} ->
             %% For buckets there should not be siblings, but in rare
             %% cases it may happen so check for them and attempt to

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -26,7 +26,7 @@
 -export([etag_from_binary/1,
          etag_from_binary/2,
          etag_from_binary_no_quotes/1,
-         check_bucket_exists/2,
+         fetch_bucket_object/2,
          close_riak_connection/1,
          close_riak_connection/2,
          create_bucket/5,
@@ -959,7 +959,7 @@ set_object_acl(Bucket, Key, Manifest, Acl, RiakPid) ->
 % @doc fetch moss.bucket and return acl and policy
 -spec get_bucket_acl_policy(binary(), atom(), pid()) -> {acl(), policy()} | {error, term()}.
 get_bucket_acl_policy(Bucket, PolicyMod, RiakPid) ->
-    case check_bucket_exists(Bucket, RiakPid) of
+    case fetch_bucket_object(Bucket, RiakPid) of
         {ok, Obj} ->
             %% For buckets there should not be siblings, but in rare
             %% cases it may happen so check for them and attempt to
@@ -1116,9 +1116,9 @@ active_to_bool({error, notfound}) ->
 %% @TODO Rename current `bucket_exists' function to
 %% `bucket_exists_for_user' and rename this function
 %% `bucket_exists'.
--spec check_bucket_exists(binary(), pid()) ->
+-spec fetch_bucket_object(binary(), pid()) ->
                                  {ok, riakc_obj:riakc_obj()} | {error, term()}.
-check_bucket_exists(Bucket, RiakPid) ->
+fetch_bucket_object(Bucket, RiakPid) ->
     case riak_cs_utils:get_object(?BUCKETS_BUCKET, Bucket, RiakPid) of
         {ok, Obj} ->
             %% Make sure the bucket has an owner

--- a/src/riak_cs_wm_bucket_acl.erl
+++ b/src/riak_cs_wm_bucket_acl.erl
@@ -67,7 +67,7 @@ to_xml(RD, Ctx=#context{start_time=StartTime,
                         riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_get_acl">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    case riak_cs_acl:bucket_acl(Bucket, RiakPid) of
+    case riak_cs_acl:fetch_bucket_acl(Bucket, RiakPid) of
         {ok, Acl} ->
             X = {riak_cs_xml:to_xml(Acl), RD, Ctx},
             ok = riak_cs_stats:update_with_start(bucket_get_acl, StartTime),
@@ -101,7 +101,7 @@ accept_body(RD, Ctx=#context{user=User,
                               {User?RCS_USER.display_name,
                                User?RCS_USER.canonical_id,
                                User?RCS_USER.key_id},
-                              riak_cs_wm_utils:bucket_owner(Bucket, RiakPid)),
+                              riak_cs_wm_utils:fetch_bucket_owner(Bucket, RiakPid)),
                 {ok, CannedAcl};
             _ ->
                 riak_cs_acl_utils:validate_acl(

--- a/src/riak_cs_wm_bucket_policy.erl
+++ b/src/riak_cs_wm_bucket_policy.erl
@@ -72,7 +72,7 @@ to_json(RD, Ctx=#context{start_time=_StartTime,
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_get_policy">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
 
-    case riak_cs_s3_policy:bucket_policy(Bucket, RiakPid) of
+    case riak_cs_s3_policy:fetch_bucket_policy(Bucket, RiakPid) of
         {ok, PolicyJson} ->
             {PolicyJson, RD, Ctx};
         {error, policy_undefined} ->

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -67,18 +67,13 @@ authorize(RD, Ctx0=#context{local_context=LocalCtx0,
               Method, LocalCtx#key_context.manifest).
 
 authorize(RD, Ctx, notfound = _BucketObj, _Method, _Manifest) ->
-    authorize_error(RD, Ctx, no_such_bucket);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_bucket);
 authorize(RD, Ctx, _BucketObj, 'GET', notfound = _Manifest) ->
-    authorize_error(RD, Ctx, no_such_key);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
-    authorize_error(RD, Ctx, no_such_key);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
     riak_cs_wm_utils:object_access_authorize_helper(object, true, RD, Ctx).
-
-authorize_error(RD, Ctx, ErrorAtom) ->
-    ResponseMod = Ctx#context.response_module,
-    NewRD = riak_cs_access_log_handler:set_user(Ctx#context.user, RD),
-    ResponseMod:api_error(ErrorAtom, NewRD, Ctx).
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_object_acl.erl
+++ b/src/riak_cs_wm_object_acl.erl
@@ -60,28 +60,13 @@ authorize(RD, Ctx0=#context{local_context=LocalCtx0, riakc_pid=RiakPid}) ->
               Method, LocalCtx#key_context.manifest).
 
 authorize(RD, Ctx, notfound = _BucketObj, _Method, _Manifest) ->
-    authorize_error(RD, Ctx, no_such_bucket);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_bucket);
 authorize(RD, Ctx, _BucketObj, 'GET', notfound = _Manifest) ->
-    authorize_error(RD, Ctx, no_such_key);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
-    authorize_error(RD, Ctx, no_such_key);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
     riak_cs_wm_utils:object_access_authorize_helper(object_acl, false, RD, Ctx).
-
-authorize_error(RD, Ctx, ErrorAtom) ->
-    ResponseMod = Ctx#context.response_module,
-    NewRD = maybe_log_user(RD, Ctx),
-    ResponseMod:api_error(ErrorAtom, NewRD, Ctx).
-
-%% @doc Only set the user for the access logger to catch if there is a
-%% user to catch.
-maybe_log_user(RD, Context) ->
-    case Context#context.user of
-        undefined ->
-            RD;
-        User ->
-            riak_cs_access_log_handler:set_user(User, RD)
-    end.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -64,14 +64,9 @@ authorize(RD, Ctx0=#context{local_context=LocalCtx0, riakc_pid=RiakPid}) ->
     authorize(RD, Ctx, LocalCtx#key_context.bucket_object).
 
 authorize(RD, Ctx, notfound = _BucketObj) ->
-    authorize_error(RD, Ctx, no_such_bucket);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_bucket);
 authorize(RD, Ctx, _BucketObj) ->
     riak_cs_wm_utils:object_access_authorize_helper(object_part, false, RD, Ctx).
-
-authorize_error(RD, Ctx, ErrorAtom) ->
-    ResponseMod = Ctx#context.response_module,
-    NewRD = riak_cs_access_log_handler:set_user(Ctx#context.user, RD),
-    ResponseMod:api_error(ErrorAtom, NewRD, Ctx).
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -71,22 +71,17 @@ authorize(RD, Ctx0=#context{local_context=LocalCtx0, riakc_pid=RiakPid}) ->
               Method, LocalCtx#key_context.manifest).
 
 authorize(RD, Ctx, notfound = _BucketObj, _Method, _Manifest) ->
-    authorize_error(RD, Ctx, no_such_bucket);
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_bucket);
+authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
+    riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, 'GET', notfound = _Manifest) ->
     %% List Parts
     %% Object ownership will be checked by riak_cs_mp_utils:do_part_common(),
     %% so we give blanket permission here - Never check ACL but Policy.
     riak_cs_wm_utils:object_access_authorize_helper(object_part, true, true, RD, Ctx);
-authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
-    authorize_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
     %% Initiate/Complete/Abort multipart
     riak_cs_wm_utils:object_access_authorize_helper(object_part, true, false, RD, Ctx).
-
-authorize_error(RD, Ctx, ErrorAtom) ->
-    ResponseMod = Ctx#context.response_module,
-    NewRD = riak_cs_access_log_handler:set_user(Ctx#context.user, RD),
-    ResponseMod:api_error(ErrorAtom, NewRD, Ctx).
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -45,7 +45,8 @@
          bucket_access_authorize_helper/4,
          object_access_authorize_helper/4,
          object_access_authorize_helper/5,
-         bucket_owner/2
+         fetch_bucket_owner/2,
+         bucket_owner/1
         ]).
 
 -include("riak_cs.hrl").
@@ -222,9 +223,20 @@ validate_auth_header(RD, AuthBypass, RiakPid, Ctx) ->
 %%      it again if it's already in the
 %%      Ctx
 -spec ensure_doc(term(), pid()) -> term().
-ensure_doc(KeyCtx=#key_context{get_fsm_pid=undefined,
-                               bucket=Bucket,
-                               key=Key}, RiakcPid) ->
+ensure_doc(KeyCtx=#key_context{bucket_object=undefined,
+                               bucket=Bucket}, RiakcPid) ->
+    %% TODO: function prefix (check_) is misleading
+    case riak_cs_utils:check_bucket_exists(Bucket, RiakcPid) of
+        {ok, Obj} ->
+            setup_manifest(KeyCtx#key_context{bucket_object = Obj}, RiakcPid);
+        {error, Reason} when Reason =:= notfound orelse Reason =:= no_such_bucket ->
+            KeyCtx#key_context{bucket_object = notfound}
+    end;
+ensure_doc(KeyCtx, _) ->
+    KeyCtx.
+
+setup_manifest(KeyCtx=#key_context{bucket=Bucket,
+                                   key=Key}, RiakcPid) ->
     %% start the get_fsm
     BinKey = list_to_binary(Key),
     FetchConcurrency = riak_cs_lfs_utils:fetch_concurrency(),
@@ -234,9 +246,7 @@ ensure_doc(KeyCtx=#key_context{get_fsm_pid=undefined,
                                                   FetchConcurrency,
                                                   BufferFactor),
     Manifest = riak_cs_get_fsm:get_manifest(Pid),
-    KeyCtx#key_context{get_fsm_pid=Pid, manifest=Manifest};
-ensure_doc(KeyCtx, _) ->
-    KeyCtx.
+    KeyCtx#key_context{get_fsm_pid=Pid, manifest=Manifest}.
 
 %% @doc Produce an access-denied error message from a webmachine
 %% resource's `forbidden/2' function.
@@ -513,15 +523,14 @@ object_access_authorize_helper(AccessType, Deletable, RD, Ctx) ->
 object_access_authorize_helper(AccessType, Deletable, SkipAcl,
                                RD, #context{policy_module=PolicyMod,
                                             local_context=LocalCtx,
-                                            response_module=ResponseMod,
-                                            riakc_pid=RiakPid}=Ctx)
+                                            response_module=ResponseMod}=Ctx)
   when ( AccessType =:= object_acl orelse
          AccessType =:= object_part orelse
          AccessType =:= object )
        andalso is_boolean(Deletable)
        andalso is_boolean(SkipAcl) ->
-    #key_context{bucket=Bucket} = LocalCtx,
-    case translate_bucket_policy(PolicyMod, Bucket, RiakPid) of
+    #key_context{bucket_object=BucketObj} = LocalCtx,
+    case translate_bucket_policy(PolicyMod, BucketObj) of
         {error, multiple_bucket_owners=E} ->
             %% We want to bail out early if there are siblings when
             %% retrieving the bucket policy
@@ -540,14 +549,14 @@ check_object_authorization(AccessType, Deletable, SkipAcl, Policy,
                                         local_context=LocalCtx,
                                         riakc_pid=RiakPid}=Ctx) ->
     Method = wrq:method(RD),
-    #key_context{bucket=Bucket, manifest=Manifest} = LocalCtx,
+    #key_context{bucket=_Bucket, bucket_object=BucketObj, manifest=Manifest} = LocalCtx,
     CanonicalId = extract_canonical_id(User),
     RequestedAccess = requested_access_helper(AccessType, Method),
     ObjectAcl = extract_object_acl(Manifest),
     Access = PolicyMod:reqdata_to_access(RD, AccessType, CanonicalId),
     Acl = case SkipAcl of
               true -> true;
-              false -> riak_cs_acl:object_access(Bucket,
+              false -> riak_cs_acl:object_access(BucketObj,
                                                  ObjectAcl,
                                                  RequestedAccess,
                                                  CanonicalId,
@@ -602,13 +611,13 @@ extract_object_acl(notfound) ->
 extract_object_acl(?MANIFEST{acl=Acl}) ->
     Acl.
 
--spec translate_bucket_policy(atom(), binary(), pid()) ->
+-spec translate_bucket_policy(atom(), riakc_obj:riakc_obj()) ->
                                      policy() |
                                      undefined |
                                      {error, multiple_bucket_owners} |
                                      {error, notfound}.
-translate_bucket_policy(PolicyMod, Bucket, RiakPid) ->
-    case PolicyMod:bucket_policy(Bucket, RiakPid) of
+translate_bucket_policy(PolicyMod, BucketObj) ->
+    case PolicyMod:bucket_policy(BucketObj) of
         {ok, P} ->
             P;
         {error, policy_undefined} ->
@@ -697,13 +706,24 @@ just_allowed_by_policy(ObjectAcl, RiakPid, RD, Ctx, LocalCtx) ->
     UpdLocalCtx = LocalCtx#key_context{owner=OwnerId},
     {false, AccessRD, Ctx#context{local_context=UpdLocalCtx}}.
 
--spec bucket_owner(binary(), pid()) -> undefined | acl_owner().
-bucket_owner(Bucket, RiakPid) ->
-    case riak_cs_acl:bucket_acl(Bucket, RiakPid) of
+-spec fetch_bucket_owner(binary(), pid()) -> undefined | acl_owner().
+fetch_bucket_owner(Bucket, RiakPid) ->
+    case riak_cs_acl:fetch_bucket_acl(Bucket, RiakPid) of
         {ok, Acl} ->
             Acl?ACL.owner;
         {error, Reason} ->
             _ = lager:debug("Failed to retrieve owner info for bucket ~p. Reason ~p", [Bucket, Reason]),
+            undefined
+    end.
+
+-spec bucket_owner(riakc_obj:riakc_obj()) -> undefined | acl_owner().
+bucket_owner(BucketObj) ->
+    case riak_cs_acl:bucket_acl(BucketObj) of
+        {ok, Acl} ->
+            Acl?ACL.owner;
+        {error, Reason} ->
+            _ = lager:debug("Failed to retrieve owner info for bucket ~p. Reason ~p",
+                            [riakc_obj:key(BucketObj), Reason]),
             undefined
     end.
 


### PR DESCRIPTION
Some independent logics fetch bucket object from Riak, bucket policy, bucket ACL
and bucket owner retrieval. In object access, e.g. GET Object, we can/should suppress
extra bucket object fetch.

Refactoring plan is simple. Let object-related webmachine callback
resources keep bucket objects (riak objects) in their state.

This PR is motivated mainly by https://github.com/basho/riak_cs/issues/701 .
Also this will be the basis for https://github.com/basho/riak_cs/issues/723 .

In testing this PR, two things found, both are reproduced at current develop branch.
1. Dialyzer outputs some warnings:
2. make test fails at `riak_cs_get_fsm_eqc`
These may/should be treated separated issues.

1 Dialyzer

```
riak_cs_gc.erl:187: The pattern [{UUID, _} | _] can never match the type []
riak_cs_gc_d.erl:173: The call riak_cs_gc_d:fetch_eligible_manifest_keys(RiakPid::'undefined' | pid(),BatchStart::non_neg_integer(),'undefined') will never return since it differs in the 3rd argument from the success typing arguments: (pid(),non_neg_integer(),binary())
riak_cs_gc_d.erl:608: Record construction #state{interval::'undefined' | non_neg_integer(),last::'undefined' | non_neg_integer(),next::{{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),byte()}},current_files::'undefined' | [#lfs_manifest_v3{version::integer(),block_size::'undefined' | integer(),bkey::'undefined' | {binary(),binary()},metadata::'undefined' | [{_,_}],uuid::'undefined' | binary(),content_length::'undefined' | non_neg_integer(),content_type::'undefined' | binary(),state::'active' | 'deleted' | 'pending_delete' | 'scheduled_delete' | 'undefined' | 'writing',write_blocks_remaining::'undefined' | [integer()],delete_blocks_remaining::'undefined' | [integer()],acl::'no_acl_yet' | 'undefined' | #acl_v1{owner::{string(),string()} | {string(),string(),string()},grants::[{'AllUsers' | 'AuthUsers' | {string(),string()},['FULL_CONTROL' | 'READ' | 'READ_ACP' | 'WRITE' | 'WRITE_ACP']}],creation_time::{non_neg_integer(),non_neg_integer(),non_neg_integer()}} | #acl_v2{owner::{string(),string()} | {string(),string(),string()},grants::[{'AllUsers' | 'AuthUsers' | {string(),string()},['FULL_CONTROL' | 'READ' | 'READ_ACP' | 'WRITE' | 'WRITE_ACP']}],creation_time::{non_neg_integer(),non_neg_integer(),non_neg_integer()}},props::'undefined' | [atom() | tuple()],cluster_id::'undefined' | binary()}],current_fileset::'undefined' | {set(),set()},current_riak_object::'undefined' | {'riakc_obj','undefined' | binary(),'undefined' | binary(),'undefined' | binary(),'undefined' | [{dict(),binary()}],'undefined' | dict(),'undefined' | binary()},batch_count::non_neg_integer(),batch_skips::non_neg_integer(),batch::'undefined' | [binary()],manif_count::non_neg_integer(),block_count::non_neg_integer(),pause_state::atom(),interval_remaining::'undefined' | non_neg_integer(),timer_ref::reference(),delete_fsm_pid::'undefined' | pid(),continuation::'undefined' | binary()} violates the declared type of field next::'undefined' | non_neg_integer()
Unknown functions:
  riak_object:bucket/1
Unknown types:
  riakc_pb_socket:index_results/0
 done in 0m28.78s
done (warnings were emitted)
```

2 make test (sudden death, almost no output but failed)

```
$ make test
(SNIP)
.......................
[test] Killed
```
