### PR TITLE
Allow objects to be reaped sooner than leeway interval.

### DIFF
--- a/include/riak_cs_gc_d.hrl
+++ b/include/riak_cs_gc_d.hrl
@@ -21,7 +21,7 @@
 -record(state, {
           interval :: 'infinity' | non_neg_integer(),
           last :: undefined | non_neg_integer(), % the last time a deletion was scheduled
-          next :: undefined | non_neg_integer(), % the next scheduled gc time
+          next :: undefined | calendar:datetime(), % the next scheduled gc time
           riak :: undefined | pid(), % Riak connection pid
           current_files :: [lfs_manifest()],
           current_fileset :: twop_set:twop_set(),
@@ -37,5 +37,6 @@
           timer_ref :: reference(),
           delete_fsm_pid :: pid(),
           initial_delay :: non_neg_integer(),
+          leeway :: non_neg_integer(),
           continuation :: undefined | binary() % Used for paginated 2I querying of GC bucket
          }).

--- a/rel/files/riak-cs-gc
+++ b/rel/files/riak-cs-gc
@@ -11,14 +11,15 @@ cd $RUNNER_BASE_DIR
 
 # Check the first argument for instructions
 case "$1" in
-    batch|status|pause|resume|cancel|set-interval)
+    batch|status|pause|resume|cancel|set-interval|set-leeway)
         # Make sure the local node IS running
         node_up_check
 
         $NODETOOL rpc riak_cs_gc_console $@
         ;;
     *)
-        echo "Usage: $SCRIPT { batch|status|pause|resume|cancel|set-interval }"
+        echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
+            "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
         exit 1
         ;;
 esac

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -728,7 +728,7 @@ move_dead_parts_to_gc(Bucket, Key, PartsToDelete, RiakcPid) ->
                     ?PART_MANIFEST{part_id=P_UUID,
                                    content_length=ContentLength,
                                    block_size=P_BlockSize} <- PartsToDelete],
-    ok = riak_cs_gc:move_manifests_to_gc_bucket(PartDelMs, RiakcPid, false).
+    ok = riak_cs_gc:move_manifests_to_gc_bucket(PartDelMs, RiakcPid).
 
 enforce_part_size(PartsToKeep) ->
     case riak_cs_config:enforce_multipart_part_size() of

--- a/test/riak_cs_gc_d_eqc.erl
+++ b/test/riak_cs_gc_d_eqc.erl
@@ -155,7 +155,7 @@ idle(_S) ->
      {history, {call, ?GCD_MODULE, resume, []}},
      {history, {call, ?GCD_MODULE, set_interval, [infinity]}},
      {{paused, idle}, {call, ?GCD_MODULE, pause, []}},
-     {fetching_next_batch, {call, ?GCD_MODULE, manual_batch, [[testing]]}}
+     {fetching_next_fileset, {call, ?GCD_MODULE, manual_batch, [[testing]]}}
     ].
 
 fetching_next_batch(_S) ->
@@ -175,6 +175,7 @@ fetching_next_fileset(_S) ->
      {history, {call, ?GCD_MODULE, set_interval, [infinity]}},
      {idle, {call, ?GCD_MODULE, cancel_batch, []}},
      {{paused, fetching_next_fileset}, {call, ?GCD_MODULE, pause, []}},
+     {fetching_next_batch, {call, ?GCD_MODULE, change_state, [fetching_next_batch]}},
      {initiating_file_delete, {call, ?GCD_MODULE, change_state, [initiating_file_delete]}}
     ].
 
@@ -232,9 +233,9 @@ postcondition(idle, {paused, _}, _S ,{call, _M, pause, _}, R) ->
     {ActualState, _} = riak_cs_gc_d:current_state(),
     ?P(ActualState =:= paused andalso R =:= ok);
 %% `fetching_next_batch' state transitions
-postcondition(idle, fetching_next_batch, _S ,{call, _M, manual_batch, _}, R) ->
+postcondition(idle, fetching_next_fileset, _S ,{call, _M, manual_batch, _}, R) ->
     {ActualState, _} = riak_cs_gc_d:current_state(),
-    ?P(ActualState =:= fetching_next_batch andalso R =:= ok);
+    ?P(ActualState =:= fetching_next_fileset andalso R =:= ok);
 postcondition(_From, fetching_next_batch, _S ,{call, _M, manual_batch, _}, R) ->
     {ActualState, _} = riak_cs_gc_d:current_state(),
     ?P(ActualState =:= fetching_next_batch andalso R =:= {error, already_deleting});
@@ -257,6 +258,9 @@ postcondition(fetching_next_fileset, {paused, _}, _S ,{call, _M, pause, _}, R) -
 postcondition(fetching_next_fileset, idle, _S ,{call, _M, cancel_batch, _}, R) ->
     {ActualState, _} = riak_cs_gc_d:current_state(),
     ?P(ActualState =:= idle andalso R =:= ok);
+postcondition(fetching_next_fileset, fetching_next_batch, _S ,{call, _M, change_state, _}, R) ->
+    {ActualState, _} = riak_cs_gc_d:current_state(),
+    ?P(ActualState =:= fetching_next_batch andalso R =:= ok);
 postcondition(fetching_next_fileset, initiating_file_delete, _S ,{call, _M, change_state, _}, R) ->
     {ActualState, _} = riak_cs_gc_d:current_state(),
     ?P(ActualState =:= initiating_file_delete andalso R =:= ok);
@@ -323,8 +327,9 @@ weight(fetching_next_fileset,fetching_next_fileset,{call,riak_cs_gc_d,resume,[]}
 weight(fetching_next_fileset,fetching_next_fileset,{call,riak_cs_gc_d,set_interval,[infinity]}) -> 64;
 weight(fetching_next_fileset,idle,{call,riak_cs_gc_d,cancel_batch,[]}) -> 64;
 weight(fetching_next_fileset,initiating_file_delete,{call,riak_cs_gc_d,change_state,[initiating_file_delete]}) -> 556;
+weight(fetching_next_fileset,fetching_next_batch,{call,riak_cs_gc_d,change_state,[fetching_next_batch]}) -> 330;
 weight(fetching_next_fileset,{paused,fetching_next_fileset},{call,riak_cs_gc_d,pause,[]}) -> 191;
-weight(idle,fetching_next_batch,{call,riak_cs_gc_d,manual_batch,[[testing]]}) -> 798;
+weight(idle,fetching_next_fileset,{call,riak_cs_gc_d,manual_batch,[[testing]]}) -> 798;
 weight(idle,idle,{call,riak_cs_gc_d,cancel_batch,[]}) -> 64;
 weight(idle,idle,{call,riak_cs_gc_d,resume,[]}) -> 64;
 weight(idle,idle,{call,riak_cs_gc_d,set_interval,[infinity]}) -> 64;


### PR DESCRIPTION
Change how manifest delete marking works so that objects may be cleaned up prior to the expiration of the leeway interval. The current scheme works by writing the deleted or overwritten manifest version to a garbage collection bucket with a key that is representative of a timestamp in the future when the blocks of the object represented by the manifest are eligible to actually be deleted. The garbage collection daemon periodically checks the garbage collection bucket for keys that represent a time that is in the past and judges any such key as eligible to be reaped.  

The problem with this is approach is that there is not a way to override the leeway interval in the case of a disk space shortage, bloated manifests, or situations where the system may be under stress. To improve this situation the process should be upended so that the keys written to the GC bucket are representative of the current time and not a future point in time and the enforcement of the `leeway_interval` should be done by the GC daemon. This would allow early cleanup of garbage to be accomplished even after a manifest is written to the GC bucket.

The goals of this work are as follows:
- [x] Change the keys written to the GC bucket to be representative of the current time instead of a time in the future
- [x] Move enforcement of the `leeway_interval` to the GC daemon
- [x] Provide a way to override the default `leeway_interval` from the `riak-cs-gc` tool
