### PR TITLE
Bugfix/eqc process leak

### DIFF
--- a/src/riak_cs_get_fsm.erl
+++ b/src/riak_cs_get_fsm.erl
@@ -289,6 +289,8 @@ perhaps_send_to_user(From, #state{got_blocks=Got,
             end
     end.
 
+waiting_chunks(stop, State) ->
+    {stop, normal, State};
 waiting_chunks(timeout, State = #state{got_blocks = Got}) ->
     GotSize = orddict:size(Got),
     _ = lager:debug("starting fetch again with ~p left in queue", [GotSize]),
@@ -382,9 +384,8 @@ terminate(_Reason, _StateName, #state{test=false,
     riak_cs_manifest_fsm:maybe_stop_manifest_fsm(ManiPid),
     riak_cs_block_server:maybe_stop_block_servers(BlockServerPids),
     ok;
-terminate(_Reason, _StateName, #state{test=true,
-                                      free_readers=ReaderPids}) ->
-    [catch exit(Pid, kill) || Pid <- ReaderPids].
+terminate(_Reason, _StateName, #state{test=true}) ->
+    ok.
 
 %% @private
 code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.

--- a/test/riak_cs_dummy_reader.erl
+++ b/test/riak_cs_dummy_reader.erl
@@ -81,6 +81,7 @@ get_manifest(Pid) ->
 %% @doc Initialize the server.
 -spec init([pid()] | {test, [pid()]}) -> {ok, state()} | {stop, term()}.
 init([CallerPid, Bucket, Key, ContentLength, BlockSize]) ->
+    process_flag(trap_exit, true),
     %% Get a connection to riak
     random:seed(now()),
     {ok, #state{content_length=ContentLength,


### PR DESCRIPTION
Fix process leak found in #761 
- Stop riak_cs_get_fsm and riak_cs_dummy_reader processes after single command sequence
- Refactoring

Increasing beam.smp's memory size can be seen by, for instance:

```
$ ./rebar eunit skip_deps=true compile_only=true && \
    ERL_LIBS=$ERL_LIBS:deps erl -pa .eunit
> spawn(fun() -> riak_cs_get_fsm_eqc:test(1000) end).
```
