### PR TITLE
Add cluster-info command

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,5 +40,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "4bb0fd664ff065c4082ca8dd2e0683e920537d15"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
+        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "1.2.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}}
        ]}.

--- a/rel/files/riak-cs-access
+++ b/rel/files/riak-cs-access
@@ -1,26 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    flush)
-        # Make sure the local node IS running
-        node_up_check
-
-        shift
-
-        $NODETOOL rpc riak_cs_access_console flush $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { flush }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin access "$@"

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -1,0 +1,39 @@
+#!/bin/sh
+# -*- tab-width:4;indent-tabs-mode:nil -*-
+# ex: ts=4 sw=4 et
+
+# Pull environment for this install
+. "{{runner_base_dir}}/lib/env.sh"
+
+# Make sure the user running this script is the owner and/or su to that user
+check_user $@
+
+# Make sure CWD is set to runner run dir
+cd $RUNNER_BASE_DIR
+
+# Identify the script name
+SCRIPT=`basename $0`
+
+usage() {
+    echo "Usage: $SCRIPT { cluster-info }"
+}
+
+# Check the first argument for instructions
+case "$1" in
+    cluster[_-]info)
+        if [ $# -lt 2 ]; then
+            echo "Usage: $SCRIPT $1 <output_file>"
+            exit 1
+        fi
+        shift
+
+        # Make sure the local node is running
+        node_up_check
+
+        $NODETOOL rpc_infinity riak_cs_console cluster_info $@
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { cluster-info }"
+    echo "Usage: $SCRIPT { cluster-info|gc|access|storage|stanchion }"
 }
 
 # Check the first argument for instructions
@@ -31,6 +31,67 @@ case "$1" in
         node_up_check
 
         $NODETOOL rpc_infinity riak_cs_console cluster_info $@
+        ;;
+    gc)
+        case "$2" in
+            batch|status|pause|resume|cancel|set-interval|set-leeway)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_gc_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
+                    "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
+                exit 1
+                ;;
+        esac
+        ;;
+    storage)
+        case "$2" in
+            batch|status|pause|resume|cancel)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_storage_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { batch|status|pause|resume|cancel }"
+                exit 1
+                ;;
+        esac
+        ;;
+    access)
+        case "$2" in
+            flush)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_access_console flush $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { flush }"
+                exit 1
+                ;;
+        esac
+        ;;
+    stanchion)
+        case "$2" in
+            switch|show)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_stanchion_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { switch HOST PORT | show }"
+                exit 1
+                ;;
+        esac
         ;;
     *)
         usage

--- a/rel/files/riak-cs-gc
+++ b/rel/files/riak-cs-gc
@@ -1,25 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    batch|status|pause|resume|cancel|set-interval|set-leeway)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_gc_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
-            "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin gc "$@"

--- a/rel/files/riak-cs-stanchion
+++ b/rel/files/riak-cs-stanchion
@@ -1,24 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    switch|show)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_stanchion_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { switch HOST PORT | show }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin stanchion "$@"

--- a/rel/files/riak-cs-storage
+++ b/rel/files/riak-cs-storage
@@ -1,24 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    batch|status|pause|resume|cancel)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_storage_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { batch|status|pause|resume|cancel }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin storage "$@"

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -18,6 +18,7 @@
          lager_syslog,
          poolboy,
          folsom,
+         cluster_info,
          riak_cs
         ]},
        {rel, "start_clean", "",
@@ -71,5 +72,6 @@
            {template, "files/riak-cs-storage", "bin/riak-cs-storage"},
            {template, "files/riak-cs-gc", "bin/riak-cs-gc"},
            {template, "files/riak-cs-stanchion", "bin/riak-cs-stanchion"},
+           {template, "files/riak-cs-admin", "bin/riak-cs-admin"},
            {mkdir, "lib/basho-patches"}
           ]}.

--- a/src/riak_cs.app.src
+++ b/src/riak_cs.app.src
@@ -14,6 +14,7 @@
                   webmachine,
                   poolboy,
                   lager,
+                  cluster_info,
                   folsom
                  ]},
   {mod, { riak_cs_app, []}},

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -1,0 +1,51 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_console).
+
+-export([
+         cluster_info/1
+        ]).
+
+%%%===================================================================
+%%% Public API
+%%%===================================================================
+
+%% in progress.
+cluster_info([OutFile]) ->
+    try
+        cluster_info:dump_local_node(OutFile)
+    catch
+        error:{badmatch, {error, eacces}} ->
+            io:format("Cluster_info failed, permission denied writing to ~p~n", [OutFile]);
+        error:{badmatch, {error, enoent}} ->
+            io:format("Cluster_info failed, no such directory ~p~n", [filename:dirname(OutFile)]);
+        error:{badmatch, {error, enotdir}} ->
+            io:format("Cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
+        Exception:Reason ->
+            lager:error("Cluster_info failed ~p:~p",
+                [Exception, Reason]),
+            io:format("Cluster_info failed, see log for details~n"),
+            error
+    end.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================


### PR DESCRIPTION
`cluster-info` is so helpful for debugging. So I'd like to add it to riak-cs.
And also this commit includes `riak-cs-admin` command like `riak-admin`.
I'm wondering if riak-cs-gc, riak-cs-storage, riak-cs-access and riak-cs-stanchion merge into riak-cs-admin that calls riak_cs_xxxx_console. If it makes sense I can refactor that later. if not, I'll rename these file names.
