### PR TITLE
Add lock-deps functionality to riak_cs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,19 @@ clean-riak-test:
 deps:
 	@./rebar get-deps
 
+##
+## Lock Targets
+##
+##  see https://github.com/seth/rebar_lock_deps_plugin
+lock: deps compile
+	./rebar lock-deps
+
+locked-all: locked-deps compile
+
+locked-deps:
+	@echo "Using rebar.config.lock file to fetch dependencies"
+	./rebar -C rebar.config.lock get-deps
+
 clean:
 	@./rebar clean
 

--- a/rebar.config
+++ b/rebar.config
@@ -39,5 +39,5 @@
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}},
-        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "911481ee8a20f59"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,4 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 {sub_dirs, ["rel"]}.
 
 {require_otp_vsn, "R15|R16"}.
@@ -11,7 +12,8 @@
 {reset_after_eunit, true}.
 
 {plugin_dir, ".plugins"}.
-{plugins, [rebar_test_plugin]}.
+{plugins, [rebar_test_plugin, rebar_lock_deps_plugin]}.
+
 {client_test, [
     {test_paths, ["client_tests/erlang"]},
     {test_output, ".client_test"}
@@ -36,5 +38,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "a86516db2da6890b6931fe5e831c305114c3af08"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.3"}}},
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}}
        ]}.


### PR DESCRIPTION
This adds the ability to lock rebar deps for builds that aren't currently pinned to tags.
