### PR TITLE
Automated code formatting [includes RFC]

### DIFF
--- a/priv/erlfmt.el
+++ b/priv/erlfmt.el
@@ -1,0 +1,36 @@
+(defun find-erlang-el (erl)
+  (concat
+   (car (file-expand-wildcards
+         (concat
+          (concat
+           (file-name-directory (directory-file-name
+                                 (file-name-directory erl)))
+           "lib")
+          "/erlang/lib/tools-*")))
+   "/emacs/"))
+
+(setq erlang-el (find-erlang-el (executable-find "erl")))
+(print erlang-el)
+
+(setq load-path (cons erlang-el load-path))
+(require 'erlang-start)
+
+(setq-default tab-width 4 indent-tabs-mode nil)
+
+(print argv)
+
+(defun fmt (filename)
+  (find-file filename)
+  (erlang-indent-region (point-min) (point-max))
+  (delete-trailing-whitespace)
+  (save-buffer)
+  (kill-buffer))
+
+(defun fmtall (files)
+  (when files
+    (fmt (car files))
+    (print (car files))
+    (fmtall (cdr files))))
+
+(fmtall argv)
+

--- a/tools.mk
+++ b/tools.mk
@@ -1,6 +1,12 @@
 test: compile
 	./rebar eunit skip_deps=true
 
+fmt:
+	emacs --script priv/erlfmt.el src/*.erl include/*.hrl
+	emacs --script priv/erlfmt.el test/*.erl
+	emacs --script priv/erlfmt.el riak_test/src/*.erl
+	emacs --script priv/erlfmt.el riak_test/tests/*.erl
+
 docs:
 	./rebar doc skip_deps=true
 


### PR DESCRIPTION
Inspired by `go fmt` and triggered by the discussion in https://github.com/basho/riak_kv/pull/822 , I hit on a way of automated Erlang code formatting. This just applies `(erlang-indent-region)` and `(delete-trailing-whitespaces)` to _ALL_ files included in the repository.

The points of discussions will be:
1. Is the autoprocesses formatting good? - The results are included in This PR.
2. Is the automatic indentation enough to do strict formatting?
3. Is the emacs lisp code valid? - where to find `erlang-start.el` ?

At my first trial to riak_cs repository, there were a lot of good re-formatting.
Give me your thoughts.

Current way to hack this, just type `make fmt` with your emacs and `erlang-mode` ready at `"/usr/local/erlang/R16B03/lib/erlang/lib/tools-2.6.13/emacs/"` .
