### PR TITLE
Feature/list objects eqc addition (squashed)

### DIFF
--- a/src/riak_cs_list_objects_fsm_v2.erl
+++ b/src/riak_cs_list_objects_fsm_v2.erl
@@ -37,7 +37,8 @@
 -endif.
 
 %% API
--export([start_link/2]).
+-export([start_link/2,
+         start_link/3]).
 
 %% Observability
 -export([]).
@@ -73,7 +74,7 @@
 -record(state, {riakc_pid :: pid(),
                 req :: list_object_request(),
                 reply_ref :: undefined | {pid(), any()},
-                key_multiplier :: float(),
+                fold_objects_batch_size :: pos_integer(),
                 object_list_req_id :: undefined | reference(),
                 reached_end_of_keyspace=false :: boolean(),
                 object_buffer=[] :: list(),
@@ -111,22 +112,24 @@
 -spec start_link(pid(), list_object_request()) ->
     {ok, pid()} | {error, term()}.
 start_link(RiakcPid, ListKeysRequest) ->
-    gen_fsm:start_link(?MODULE, [RiakcPid, ListKeysRequest], []).
+    FoldObjectsBatchSize = 2,
+    start_link(RiakcPid, ListKeysRequest, FoldObjectsBatchSize).
+
+-spec start_link(pid(), list_object_request(), pos_integer()) ->
+    {ok, pid()} | {error, term()}.
+start_link(RiakcPid, ListKeysRequest, FoldObjectsBatchSize) ->
+    BatchSize2 = max(2, FoldObjectsBatchSize),
+    gen_fsm:start_link(?MODULE, [RiakcPid, ListKeysRequest, BatchSize2], []).
 
 %%%===================================================================
 %%% gen_fsm callbacks
 %%%===================================================================
 
 -spec init(list()) -> {ok, prepare, state(), 0}.
-init([RiakcPid, Request]) ->
-    %% TODO: this should not be hardcoded. Maybe there should
-    %% be two `start_link' arities, and one will use a default
-    %% val from app.config and the other will explicitly
-    %% take a val
-    KeyMultiplier = riak_cs_list_objects_utils:get_key_list_multiplier(),
+init([RiakcPid, Request, FoldObjectsBatchSize]) ->
 
     State = #state{riakc_pid=RiakcPid,
-                   key_multiplier=KeyMultiplier,
+                   fold_objects_batch_size=FoldObjectsBatchSize,
                    req=Request},
     {ok, prepare, State, 0}.
 
@@ -284,18 +287,18 @@ response_from_manifests_and_common_prefixes(Request,
 
 -spec make_2i_request(pid(), state()) ->
                              {state(), {ok, reference()} | {error, term()}}.
-make_2i_request(RiakcPid, State=#state{req=?LOREQ{name=BucketName}}) ->
+make_2i_request(RiakcPid, State=#state{req=?LOREQ{name=BucketName},
+                                       fold_objects_batch_size=BatchSize}) ->
     ManifestBucket = riak_cs_utils:to_bucket_name(objects, BucketName),
     StartKey = make_start_key(State),
     EndKey = big_end_key(128),
-    NumResults = 1002,
     NewStateData = State#state{last_request_start_key=StartKey,
-                               last_request_num_keys_requested=NumResults},
+                               last_request_num_keys_requested=BatchSize},
     NewStateData2 = update_profiling_state_with_start(NewStateData,
                                                       StartKey,
                                                       EndKey,
                                                       os:timestamp()),
-    Opts = [{max_results, NumResults},
+    Opts = [{max_results, BatchSize},
             {start_key, StartKey},
             {end_key, EndKey}],
     FoldResult = riakc_pb_socket:cs_bucket_fold(RiakcPid,

--- a/test/riak_cs_dummy_riakc_list_objects_v2.erl
+++ b/test/riak_cs_dummy_riakc_list_objects_v2.erl
@@ -1,0 +1,166 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc Module to return manifests for cs_bucket_fold requests
+
+-module(riak_cs_dummy_riakc_list_objects_v2).
+
+-behaviour(gen_server).
+
+-include_lib("riak_pb/include/riak_pb.hrl").
+-include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include("riak_cs.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-endif.
+
+%% API
+-export([start_link/1, stop/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {
+          manifests :: [term()],
+          reqid :: term(),
+          caller :: pid(),
+          max_results :: integer(),
+          replied_at_least_once=false :: boolean()
+         }).
+
+-type state() :: #state{}.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Start a dummy `riakc_pb_socket'.
+-spec start_link(list()) -> {ok, pid()} | {error, term()}.
+start_link(Args) ->
+    gen_server:start_link(?MODULE, Args, []).
+
+%% @doc Stop the process
+-spec stop(pid()) -> ok.
+stop(Pid) ->
+    gen_server:call(Pid, stop).
+
+%% ===================================================================
+%% gen_server callbacks
+%% ===================================================================
+
+%% @doc Initialize the server.
+-spec init([term()]) -> {ok, state()} | {stop, term()}.
+init([Manifests]) ->
+    {ok, #state{manifests=Manifests}}.
+
+%% @doc Unused
+-spec handle_call(term(), {pid(), term()}, state()) ->
+                         {reply, ok, state()}.
+handle_call({req, #rpbcsbucketreq{start_key = <<0>>} = _Req,
+             _Timeout, _Ctx}, _From,
+            #state{replied_at_least_once=true}=State) ->
+    %% Already replied first set of manifests but requested again from the beginning
+    %% Forbit repeated call so that EQC does not fall into infinite loop.
+    {reply, {error, second_list_request}, State};
+handle_call({req, #rpbcsbucketreq{max_results=MaxResults,
+                                  start_key=StartKey} = _Req,
+             _Timeout, {ReqId, Caller}=_Ctx}, _From,
+            State) ->
+    %% io:format("================= handle_call (req)~n"),
+    %% io:format("_Caller: ~p~n", [Caller]),
+    %% io:format("_Ctx: ~p~n", [_Ctx]),
+    %% io:format("MaxResults: ~p~n", [MaxResults]),
+    gen_server:cast(self(), {send_manifests, StartKey}),
+    {reply, {ok, ReqId}, State#state{reqid=ReqId, caller=Caller,
+                                     max_results=MaxResults,
+                                     replied_at_least_once=true}};
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State};
+handle_call(_Msg, _From, State) ->
+    io:format("=============== Received unknown call message: ~p~n", [_Msg]),
+    {reply, ok, State}.
+
+handle_cast({send_manifests, StartKey},
+            #state{manifests=Manifests, reqid=ReqId, caller=Caller,
+                   max_results=MaxResults} = State) ->
+    %% io:format("================ handle_cast (send_manifests)~n"),
+    _Rest = send_manifests_and_done(Caller, ReqId, StartKey, MaxResults, Manifests),
+    {noreply, State};
+handle_cast(Event, State) ->
+    lager:warning("Received unknown cast event: ~p", [Event]),
+    {noreply, State}.
+
+%% @doc @TODO
+-spec handle_info(term(), state()) ->
+                         {noreply, state()}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @doc Unused.
+-spec terminate(term(), state()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%% @doc Unused.
+-spec code_change(term(), state(), term()) ->
+                         {ok, state()}.
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+send_manifests_and_done(Caller, ReqId, StartKey, MaxResults, Manifests) ->
+    %% io:format("{Caller, ReqId, StartKey, MaxResults}: ~p~n",
+    %%           [{Caller, ReqId, StartKey, MaxResults}]),
+    {Head, Rest} = take_n(StartKey, MaxResults, Manifests),
+    RiakcObjs = manifests_to_robjs(Head),
+    Msg = {ok, RiakcObjs},
+    Caller ! {ReqId, Msg},
+    DoneMsg = {done, continuation_ignored},
+    Caller ! {ReqId, DoneMsg},
+    Rest.
+
+take_n(StartKey, N, Manifests) ->
+    Remaining = lists:dropwhile(fun(?MANIFEST{bkey={_,Key}}) ->
+                                        Key =< StartKey
+                                end, Manifests),
+    take_n(N, Remaining).
+
+take_n(N, Manifests) ->
+    try lists:split(N, Manifests) of
+        {Head, Rest} ->
+            {Head, Rest}
+    catch error:badarg ->
+            {Manifests, []}
+    end.
+
+manifests_to_robjs(Manifests) ->
+    [manifest_to_robj(M) || M <- Manifests].
+
+%% TODO: Metadatas
+manifest_to_robj(?MANIFEST{bkey={Bucket, Key}, uuid=UUID}=M) ->
+    Dict = riak_cs_manifest_utils:new_dict(UUID, M),
+    ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    riakc_obj:new(ManifestBucket, Key, riak_cs_utils:encode_term(Dict)).

--- a/test/riak_cs_dummy_riakc_list_objects_v2.erl
+++ b/test/riak_cs_dummy_riakc_list_objects_v2.erl
@@ -84,7 +84,7 @@ handle_call({req, #rpbcsbucketreq{start_key = <<0>>} = _Req,
              _Timeout, _Ctx}, _From,
             #state{replied_at_least_once=true}=State) ->
     %% Already replied first set of manifests but requested again from the beginning
-    %% Forbit repeated call so that EQC does not fall into infinite loop.
+    %% Forbid repeated call so that EQC does not fall into infinite loop.
     {reply, {error, second_list_request}, State};
 handle_call({req, #rpbcsbucketreq{max_results=MaxResults,
                                   start_key=StartKey} = _Req,

--- a/test/riak_cs_list_objects_fsm_v2_eqc.erl
+++ b/test/riak_cs_list_objects_fsm_v2_eqc.erl
@@ -311,8 +311,7 @@ list_manifests_to_the_end(DummyRiakc, Opts, UserPage, BatchSize, CPrefixesAcc, C
     %% io:format("is_truncated: ~p~n", [ListResp?LORESP.is_truncated]),
     case ListResp?LORESP.is_truncated of
         true ->
-            LastEntry = lists:last(Contents),
-            Marker = LastEntry#list_objects_key_content_v1.key,
+            Marker = create_marker(ListResp),
             list_manifests_to_the_end(DummyRiakc, update_marker(Marker, Opts),
                                       UserPage, BatchSize,
                                       NewCPrefixAcc, NewContentsAcc,
@@ -324,6 +323,13 @@ list_manifests_to_the_end(DummyRiakc, Opts, UserPage, BatchSize, CPrefixesAcc, C
             {lists:append(lists:reverse(NewCPrefixAcc)),
              lists:append(lists:reverse(NewContentsAcc))}
     end.
+
+create_marker(?LORESP{next_marker=undefined,
+                      contents=Contents}) ->
+    LastEntry = lists:last(Contents),
+    LastEntry#list_objects_key_content_v1.key;
+create_marker(?LORESP{next_marker=NextMarker}) ->
+    NextMarker.
 
 update_marker(Marker, Opts) ->
     lists:keystore(marker, 1, Opts, {marker, Marker}).


### PR DESCRIPTION
This PR adds two EQC properties for listing all objects.
- Two EQC properties for listing objects (GET Bucket),
  one without delimiter and one with delimiter "/".
  Those properties assert following two are equal:
  1. keys from listing objects by repetitive usage of
     riak_cs_list_objects_fsm_v2
  2. active keys from generated [{State, Key},...]
- When counterexample is found, states and keys are
  written to file `$PWD/.riak_cs_list_objects_fsm_v2_eqc.txt`.
  Each line consists of line number, status and key.
  Example output:
  
  ```
  1,active,0123456/10
  2,scheduled_delete,0123456/1000
  ```
- To generate manifests, generator of whole manifests is avoided
  and generate only states and keys of manifests.
  The property list-all-objects generates several thousands of nested tuples,
  #lfs_manifest_v3 and #acl_v2 in this case.
  But generators of nested tuples seem not so fast.

TODOs remaining (not this PR's TODOs but ones for future)
- prefix of request parameter
- non-default max-keys
