### PR TITLE
Improve access log handler to handle HEAD method.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,5 +37,5 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "da7bdcb3a7583cd80ec988268d2cf5c1636dde87"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.2"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}}
        ]}.

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -51,6 +51,8 @@ generate_some_accesses(UserConfig) ->
     _ = erlcloud_s3:put_object(?BUCKET, ?KEY, Block, UserConfig),
     %% Get 100-byte object, once
     _ = erlcloud_s3:get_object(?BUCKET, ?KEY, UserConfig),
+    %% Head Object
+    _ = erlcloud_s3:head_object(?BUCKET, ?KEY, UserConfig),
     %% List objects (GET bucket)
     _ = erlcloud_s3:list_objects(?BUCKET, UserConfig),
     %% Delete object
@@ -83,6 +85,8 @@ assert_access_stats(UserConfig, {Begin, End}) ->
     ?assertEqual(  1, sum_samples([<<"KeyRead">>, <<"Count">>], Samples)),
     ?assertEqual(  0, sum_samples([<<"KeyRead">>, <<"BytesIn">>], Samples)),
     ?assertEqual(100, sum_samples([<<"KeyRead">>, <<"BytesOut">>], Samples)),
+    ?assertEqual(  1, sum_samples([<<"KeyStat">>, <<"Count">>], Samples)),
+    ?assertEqual(  0, sum_samples([<<"KeyStat">>, <<"BytesOut">>], Samples)),
     ?assertEqual(  1, sum_samples([<<"BucketRead">>, <<"Count">>], Samples)),
     ?assertEqual(  1, sum_samples([<<"KeyDelete">>, <<"Count">>], Samples)),
     ?assertEqual(  1, sum_samples([<<"BucketDelete">>, <<"Count">>], Samples)),


### PR DESCRIPTION
This fix prevents to include BytesOut element on Head Object(KeyStat) request the same as Head Bucket(BucketStat).

Requires the latest erlcloud commit: https://github.com/basho/erlcloud/pull/12/commits
Fix #789 
