### PR TITLE
Performance optimization for object listing requests using a prefix

### DIFF
--- a/src/riak_cs_list_objects_fsm_v2.erl
+++ b/src/riak_cs_list_objects_fsm_v2.erl
@@ -217,14 +217,40 @@ handle_done(State=#state{object_buffer=ObjectBuffer,
 
     {NewManis, NewPrefixes} =
     riak_cs_list_objects_utils:filter_prefix_keys(ObjectPrefixTuple, Request),
-    ReachedEnd = ObjectBufferLength < NumKeysRequested,
 
+    ReachedEnd = reached_end_of_keyspace(ObjectBufferLength,
+                                         NumKeysRequested,
+                                         Active,
+                                         Request?LOREQ.prefix),
 
     NewStateData = RangeUpdatedStateData#state{objects=NewManis,
                                                common_prefixes=NewPrefixes,
                                                reached_end_of_keyspace=ReachedEnd,
                                                object_buffer=[]},
+    _ = lager:debug("Ranges: ~p", [NewStateData#state.object_list_ranges]),
     respond(NewStateData, NewManis, NewPrefixes).
+
+-spec reached_end_of_keyspace(non_neg_integer(),
+                              undefined | pos_integer(),
+                              list(lfs_manifest()),
+                              undefined | binary()) -> boolean().
+reached_end_of_keyspace(BufferLength, NumKeysRequested, _, _)
+  when BufferLength < NumKeysRequested ->
+    true;
+reached_end_of_keyspace(_, _, _ActiveObjects, undefined) ->
+    false;
+reached_end_of_keyspace(_BufferLength, _NumKeysRequested, [], _) ->
+    false;
+reached_end_of_keyspace(_, _, ActiveObjects, Prefix) ->
+    M = lists:last(ActiveObjects),
+    {_, LastKey} = M?MANIFEST.bkey,
+    PrefixLen = byte_size(Prefix),
+    case LastKey of
+        << Prefix:PrefixLen/binary, _/binary >> ->
+            false;
+        _ ->
+            LastKey > Prefix
+    end.
 
 -spec update_profiling_and_last_request(state(), list(), integer()) ->
     state().
@@ -399,7 +425,7 @@ common_prefix_from_key(Key, Prefix, Delimiter) ->
 
 -spec make_start_key(state()) -> binary().
 make_start_key(#state{object_list_ranges=[], req=Request}) ->
-    make_start_key_from_marker(Request);
+    make_start_key_from_marker_and_prefix(Request);
 make_start_key(State=#state{object_list_ranges=PrevRanges,
                             common_prefixes=CommonPrefixes,
                             req=?LOREQ{prefix=Prefix,
@@ -418,14 +444,18 @@ make_start_key(State=#state{object_list_ranges=PrevRanges,
             Key
     end.
 
--spec make_start_key_from_marker(list_object_request()) -> binary().
-make_start_key_from_marker(?LOREQ{marker=undefined}) ->
+-spec make_start_key_from_marker_and_prefix(list_object_request()) -> binary().
+make_start_key_from_marker_and_prefix(?LOREQ{marker=undefined,
+                                             prefix=undefined}) ->
     <<0:8/integer>>;
-make_start_key_from_marker(?LOREQ{marker=Marker,
-                                  delimiter=undefined}) ->
+make_start_key_from_marker_and_prefix(?LOREQ{marker=undefined,
+                                             prefix=Prefix}) ->
+    Prefix;
+make_start_key_from_marker_and_prefix(?LOREQ{marker=Marker,
+                                             delimiter=undefined}) ->
     Marker;
-make_start_key_from_marker(?LOREQ{marker=Marker,
-                                  delimiter=Delimiter}) ->
+make_start_key_from_marker_and_prefix(?LOREQ{marker=Marker,
+                                             delimiter=Delimiter}) ->
     DelSize = byte_size(Delimiter),
     case binary:longest_common_suffix([Marker, Delimiter]) of
         DelSize ->

--- a/test/riak_cs_list_objects_fsm_v2_eqc.erl
+++ b/test/riak_cs_list_objects_fsm_v2_eqc.erl
@@ -48,18 +48,33 @@
 %%====================================================================
 
 eqc_test_() ->
-    [
-     ?_assert(quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_skip_past_prefix_and_delimiter())))),
-     ?_assert(quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_prefix_must_be_in_between())))),
-     {timeout, 10*60, % 10min.
-      ?_assert(quickcheck(numtests(
-                            ?TEST_ITERATIONS,
-                            ?QC_OUT(prop_list_all_active_keys_without_delimiter()))))},
-     {timeout, 10*60, % 10min.
-      ?_assert(quickcheck(numtests(
-                            ?TEST_ITERATIONS,
-                            ?QC_OUT(prop_list_all_active_keys_with_delimiter()))))}
-    ].
+    {spawn,
+     [
+      {setup,
+       fun setup/0,
+       fun cleanup/1,
+       [
+        ?_assert(quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_skip_past_prefix_and_delimiter())))),
+        ?_assert(quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_prefix_must_be_in_between())))),
+        {timeout, 10*60, % 10min.
+         ?_assert(quickcheck(numtests(
+                               ?TEST_ITERATIONS,
+                               ?QC_OUT(prop_list_all_active_keys_without_delimiter()))))},
+        {timeout, 10*60, % 10min.
+         ?_assert(quickcheck(numtests(
+                               ?TEST_ITERATIONS,
+                               ?QC_OUT(prop_list_all_active_keys_with_delimiter()))))}
+       ]
+      }
+     ]}.
+
+setup() ->
+    error_logger:tty(false),
+    error_logger:logfile({open, "riak_cs_list_objects_fsm_v2_eqc.log"}),
+    ok.
+
+cleanup(_) ->
+    ok.
 
 %% ====================================================================
 %% EQC Properties


### PR DESCRIPTION
- Use prefix in start key calculation when appropriate to avoid
  iterating over unnecessary keys that lexicographically sort less
  than the prefix. The make_start_key_from_marker function in
  riak_cs_list_objects_fsm_v2 is renamed to
  make_start_key_from_marker_and_prefix.
- Terminate processing early when a prefix is specified and a key is
  reached that lexicographically sorts greater than the prefix, but
  does not begin with the prefix. The results come back in sorted key
  order so it can be assumed that once any keys that begin with the
  prefix are processed it is appropriate to cease processing without
  requesting any more data. This is accomplished by the addition of
  the reached_end-of_keyspace/4 function to the
  riak_cs_list_objects_fsm_v2 module.
- Silence extraneous console logging in riak_cs_list_objects_fsm_v2_eqc test
