### PR TITLE
Bugfix/non ascii in xml (reorganized)

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -594,12 +594,12 @@ update_user(UserConfig, Port, Resource, ContentType, UpdateDoc) ->
     lager:debug("Update user output=~p~n",[Output]),
     Output.
 
-list_users(UserConfig, Port, Resource, ContentType) ->
+list_users(UserConfig, Port, Resource, AcceptContentType) ->
     Date = httpd_util:rfc1123_date(),
     Cmd="curl -s -H 'Date: " ++ Date ++
-        "' -H 'Content-Type: " ++ ContentType ++
+        "' -H 'Accept: " ++ AcceptContentType ++
         "' -H 'Authorization: " ++
-        make_authorization("GET", Resource, ContentType, UserConfig, Date) ++
+        make_authorization("GET", Resource, "", UserConfig, Date) ++
         "' http://localhost:" ++ integer_to_list(Port) ++
         Resource,
     Delay = rt_config:get(rt_retry_delay),

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -26,6 +26,7 @@
 -export([confirm/0]).
 
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(BUCKET, "access-stats-test-1").
@@ -37,7 +38,8 @@ confirm() ->
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4, Config),
     {Begin, End} = generate_some_accesses(UserConfig),
     flush_access_stats(),
-    assert_access_stats(UserConfig, {Begin, End}),
+    assert_access_stats(json, UserConfig, {Begin, End}),
+    assert_access_stats(xml, UserConfig, {Begin, End}),
     pass.
 
 generate_some_accesses(UserConfig) ->
@@ -68,48 +70,71 @@ flush_access_stats() ->
     ExpectRegexp = "0 more archives to flush\nAll access logs were flushed.\n$",
     ?assertMatch({match, _}, re:run(Res, ExpectRegexp)).
 
-assert_access_stats(UserConfig, {Begin, End}) ->
+assert_access_stats(Format, UserConfig, {Begin, End}) ->
     KeyId = UserConfig#aws_config.access_key_id,
-    StatsKey = lists:flatten(["usage/", KeyId, "/aj/", Begin, "/", End, "/"]),
+    FormatInstruction = case Format of
+                            json -> "j";
+                            xml -> "x"
+                        end,
+    StatsKey = lists:flatten(["usage/", KeyId, "/a", FormatInstruction, "/",
+                              Begin, "/", End, "/"]),
     GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, UserConfig),
     lager:debug("GET Access stats response: ~p", [GetResult]),
-    Usage = mochijson2:decode(proplists:get_value(content, GetResult)),
-    lager:debug("Usage Response: ~p", [Usage]),
-    Samples = node_samples_from_usage(<<"rcs-dev1@127.0.0.1">>, Usage),
-    lager:info("Access samples: ~p", [Samples]),
+    Content = proplists:get_value(content, GetResult),
+    Samples = node_samples_from_content(Format, "rcs-dev1@127.0.0.1", Content),
+    lager:debug("Access samples (~s): ~p", [Format, Samples]),
 
-    ?assertEqual(  1, sum_samples([<<"BucketCreate">>, <<"Count">>], Samples)),
-    ?assertEqual(  2, sum_samples([<<"KeyWrite">>, <<"Count">>], Samples)),
-    ?assertEqual(200, sum_samples([<<"KeyWrite">>, <<"BytesIn">>], Samples)),
-    ?assertEqual(  0, sum_samples([<<"KeyWrite">>, <<"BytesOut">>], Samples)),
-    ?assertEqual(  1, sum_samples([<<"KeyRead">>, <<"Count">>], Samples)),
-    ?assertEqual(  0, sum_samples([<<"KeyRead">>, <<"BytesIn">>], Samples)),
-    ?assertEqual(100, sum_samples([<<"KeyRead">>, <<"BytesOut">>], Samples)),
-    ?assertEqual(  1, sum_samples([<<"KeyStat">>, <<"Count">>], Samples)),
-    ?assertEqual(  0, sum_samples([<<"KeyStat">>, <<"BytesOut">>], Samples)),
-    ?assertEqual(  1, sum_samples([<<"BucketRead">>, <<"Count">>], Samples)),
-    ?assertEqual(  1, sum_samples([<<"KeyDelete">>, <<"Count">>], Samples)),
-    ?assertEqual(  1, sum_samples([<<"BucketDelete">>, <<"Count">>], Samples)),
+    ?assertEqual(  1, sum_samples(Format, "BucketCreate", "Count", Samples)),
+    ?assertEqual(  2, sum_samples(Format, "KeyWrite",     "Count", Samples)),
+    ?assertEqual(200, sum_samples(Format, "KeyWrite",     "BytesIn", Samples)),
+    ?assertEqual(  0, sum_samples(Format, "KeyWrite",     "BytesOut", Samples)),
+    ?assertEqual(  1, sum_samples(Format, "KeyRead",      "Count", Samples)),
+    ?assertEqual(  0, sum_samples(Format, "KeyRead",      "BytesIn", Samples)),
+    ?assertEqual(100, sum_samples(Format, "KeyRead",      "BytesOut", Samples)),
+    ?assertEqual(  1, sum_samples(Format, "KeyStat",      "Count", Samples)),
+    ?assertEqual(  0, sum_samples(Format, "KeyStat",      "BytesOut", Samples)),
+    ?assertEqual(  1, sum_samples(Format, "BucketRead",   "Count", Samples)),
+    ?assertEqual(  1, sum_samples(Format, "KeyDelete",    "Count", Samples)),
+    ?assertEqual(  1, sum_samples(Format, "BucketDelete", "Count", Samples)),
     pass.
 
-node_samples_from_usage(Node, Usage) ->
+node_samples_from_content(json, Node, Content) ->
+    Usage = mochijson2:decode(Content),
     ListOfNodeStats = rtcs:json_get([<<"Access">>, <<"Nodes">>], Usage),
     lager:debug("ListOfNodeStats: ~p", [ListOfNodeStats]),
-    [NodeStats | _] = lists:dropwhile(fun(NodeStats) ->
-                                              rtcs:json_get(<<"Node">>, NodeStats) =/= Node
-                                      end, ListOfNodeStats),
-    rtcs:json_get(<<"Samples">>, NodeStats).
+    NodeBin = list_to_binary(Node),
+    [NodeStats | _] = lists:dropwhile(
+                        fun(NodeStats) ->
+                                rtcs:json_get(<<"Node">>, NodeStats) =/= NodeBin
+                        end, ListOfNodeStats),
+    rtcs:json_get(<<"Samples">>, NodeStats);
+node_samples_from_content(xml, Node, Content) ->
+    {Usage, _Rest} = xmerl_scan:string(unicode:characters_to_list(Content, utf8)),
+    xmerl_xpath:string("/Usage/Access/Nodes/Node[@name='" ++ Node ++ "']/Sample", Usage).
+
+sum_samples(json, OperationType, StatsKey, Data) ->
+    sum_samples_json([list_to_binary(OperationType), list_to_binary(StatsKey)], Data);
+sum_samples(xml, OperationType, StatsKey, Data) ->
+    sum_samples_xml(OperationType, StatsKey, Data).
 
 %% Sum up statistics entries in possibly multiple samples
-sum_samples(Keys, Samples) ->
-    sum_samples(Keys, Samples, 0).
-sum_samples(_Keys, [], Sum) ->
+sum_samples_json(Keys, Samples) ->
+    sum_samples_json(Keys, Samples, 0).
+sum_samples_json(_Keys, [], Sum) ->
     Sum;
-sum_samples(Keys, [Sample | Samples], Sum) ->
+sum_samples_json(Keys, [Sample | Samples], Sum) ->
     InSample = case rtcs:json_get(Keys, Sample) of
                    notfound ->
                        0;
                    Value when is_integer(Value) ->
                        Value
                   end,
-    sum_samples(Keys, Samples, Sum + InSample).
+    sum_samples_json(Keys, Samples, Sum + InSample).
+
+sum_samples_xml(OperationType, StatsKey, Samples) ->
+    lists:sum([list_to_integer(T#xmlText.value) ||
+                  Sample <- Samples,
+                  T <- xmerl_xpath:string(
+                         "/Sample/Operation[@type='" ++ OperationType ++ "']/" ++
+                             StatsKey ++ " /text()",
+                         Sample)]).

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -245,7 +245,7 @@ parse_user_records(Output, ?JSON) ->
          KeySecret = binary_to_list(proplists:get_value(<<"key_secret">>, UserJson)),
          Status = binary_to_list(proplists:get_value(<<"status">>, UserJson)),
          {Email, Name, KeyId, KeySecret, Status}
-     end || UserJson <- JsonData];
+     end || {struct, UserJson} <- JsonData];
 parse_user_records(Output, ?XML) ->
     {ParsedData, _Rest} = xmerl_scan:string(Output, []),
     [lists:foldl(fun user_fields_from_xml/2,

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -34,38 +34,52 @@ confirm() ->
     {AdminUserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(4),
 
     HeadRiakNode = hd(RiakNodes),
-    AdminUserCreds = {AdminUserConfig#aws_config.access_key_id,
-                      AdminUserConfig#aws_config.secret_access_key},
-    user_listing_json_test_case([AdminUserCreds], AdminUserConfig, HeadRiakNode),
-    user_listing_xml_test_case([AdminUserCreds], AdminUserConfig, HeadRiakNode),
+    AdminUser = {"admin@me.com", "admin",
+                 AdminUserConfig#aws_config.access_key_id,
+                 AdminUserConfig#aws_config.secret_access_key,
+                 "enabled"},
+    user_listing_json_test_case([AdminUser], AdminUserConfig, HeadRiakNode),
+    user_listing_xml_test_case([AdminUser], AdminUserConfig, HeadRiakNode),
 
-    %% Create 2 users and re-run user listing test cases
+    %% Create 3 users and re-run user listing test cases
     Port = rtcs:cs_port(HeadRiakNode),
-    {TestKey1, TestSecret1, _} = rtcs:create_user(Port, "bart@simpsons.com", "bart"),
-    {TestKey2, TestSecret2, _} = rtcs:create_user(Port, "homer@simpsons.com", "homer"),
-    UserCreds = ordsets:from_list([AdminUserCreds,
-                                   {TestKey1, TestSecret1},
-                                   {TestKey2, TestSecret2}]),
-
-    user_listing_json_test_case(UserCreds, AdminUserConfig, HeadRiakNode),
-    user_listing_xml_test_case(UserCreds, AdminUserConfig, HeadRiakNode),
-
+    Users = [AdminUser |
+             create_users(Port, [{"bart@simpsons.com", "bart"},
+                                 {"homer@simpsons.com", "homer"},
+                                 {"taro@example.co.jp", japanese_aiueo()}], [])],
+    user_listing_json_test_case(Users, AdminUserConfig, HeadRiakNode),
+    user_listing_xml_test_case(Users, AdminUserConfig, HeadRiakNode),
     update_user_json_test_case(AdminUserConfig, HeadRiakNode),
     update_user_xml_test_case(AdminUserConfig, HeadRiakNode),
     pass.
 
-user_listing_json_test_case(UserCreds, UserConfig, Node) ->
-    user_listing_test(UserCreds, UserConfig, Node, ?JSON).
+japanese_aiueo() ->
+    %% To avoid dependency on source code encoding, create list from chars.
+    %% These five numbers represents "あいうえお" (A-I-U-E-O in Japanese).
+    %% unicode:characters_to_binary([12354,12356,12358,12360,12362]).
+    Chars = [12354,12356,12358,12360,12362],
+    binary_to_list(unicode:characters_to_binary(Chars)).
 
-user_listing_xml_test_case(UserCreds, UserConfig, Node) ->
-    user_listing_test(UserCreds, UserConfig, Node, ?XML).
+create_users(_Port, [], Acc) ->
+    ordsets:from_list(Acc);
+create_users(Port, [{Email, Name} | Users], Acc) ->
+    {Key, Secret, _Id} = rtcs:create_user(Port, Email, Name),
+    create_users(Port, Users, [{Email, Name, Key, Secret, "enabled"} | Acc]).
 
-user_listing_test(ExpectedUserCreds, UserConfig, Node, ContentType) ->
+user_listing_json_test_case(Users, UserConfig, Node) ->
+    user_listing_test(Users, UserConfig, Node, ?JSON).
+
+user_listing_xml_test_case(Users, UserConfig, Node) ->
+    user_listing_test(Users, UserConfig, Node, ?XML).
+
+user_listing_test(ExpectedUsers, UserConfig, Node, ContentType) ->
     Resource = "/riak-cs/users",
     Port = rtcs:cs_port(Node),
-    UserCreds = parse_user_creds(
-                  rtcs:list_users(UserConfig, Port, Resource, ContentType)),
-    ?assertEqual(ExpectedUserCreds, UserCreds).
+    Users = parse_user_info(
+              rtcs:list_users(UserConfig, Port, Resource, ContentType)),
+    lager:log(warning, self(), "ExpectedUsers: ~p~n", [ExpectedUsers]),
+    lager:log(warning, self(), "Users: ~p~n", [Users]),
+    ?assertEqual(ExpectedUsers, Users).
 
 update_user_json_test_case(AdminConfig, Node) ->
     Users = [{"fergus@brave.sco", "Fergus"},
@@ -262,7 +276,7 @@ user_fields_from_xml(Element, {Email, Name, KeyId, Secret, Status}=Acc) ->
             [Content | _] = Element#xmlElement.content,
             case is_record(Content, xmlText) of
                 true ->
-                    {Content#xmlText.value, Name, KeyId, Secret, Status};
+                    {xml_text_value(Content), Name, KeyId, Secret, Status};
                 false ->
                     Acc
             end;
@@ -270,7 +284,7 @@ user_fields_from_xml(Element, {Email, Name, KeyId, Secret, Status}=Acc) ->
             [Content | _] = Element#xmlElement.content,
             case is_record(Content, xmlText) of
                 true ->
-                    {Email, Content#xmlText.value, KeyId, Secret, Status};
+                    {Email, xml_text_value(Content), KeyId, Secret, Status};
                 false ->
                     Acc
             end;
@@ -302,6 +316,11 @@ user_fields_from_xml(Element, {Email, Name, KeyId, Secret, Status}=Acc) ->
             Acc
     end.
 
+xml_text_value(XmlText) ->
+    %% xmerl return list of UTF-8 characters, each element of it represent
+    %% one character (or codepoint), not one byte.
+    binary_to_list(unicode:characters_to_binary(XmlText#xmlText.value)).
+
 parse_error_code(Output) ->
     {ParsedData, _Rest} = xmerl_scan:string(Output, []),
     lists:foldl(fun error_code_from_xml/2,
@@ -324,27 +343,19 @@ error_code_from_xml(Element, Acc) ->
             Acc
     end.
 
-parse_user_creds(Output) ->
+parse_user_info(Output) ->
     [Boundary | Tokens] = string:tokens(Output, "\r\n"),
-    parse_user_creds(Tokens, Boundary, []).
+    parse_user_info(Tokens, Boundary, []).
 
-parse_user_creds([_LastToken], _, UserCreds) ->
-    ordsets:from_list(UserCreds);
-parse_user_creds(["Content-Type: application/xml", RawXml | RestTokens],
-                 Boundary, UserCreds) ->
-    UpdUserCreds = update_user_creds(parse_user_records(RawXml, ?XML),
-                                    UserCreds),
-    parse_user_creds(RestTokens, Boundary, UpdUserCreds);
-parse_user_creds(["Content-Type: application/json", RawJson | RestTokens],
-                 Boundary, UserCreds) ->
-    UpdUserCreds = update_user_creds(parse_user_records(RawJson, ?JSON),
-                                     UserCreds),
-    parse_user_creds(RestTokens, Boundary, UpdUserCreds);
-parse_user_creds([_ | RestTokens], Boundary, UserCreds) ->
-    parse_user_creds(RestTokens, Boundary, UserCreds).
-
-update_user_creds(UserRecords, UserCreds) ->
-    FoldFun = fun({_, _, KeyId, Secret, _}, Acc) ->
-                      [{KeyId, Secret} | Acc]
-              end,
-    lists:foldl(FoldFun, UserCreds, UserRecords).
+parse_user_info([_LastToken], _, Users) ->
+    ordsets:from_list(Users);
+parse_user_info(["Content-Type: application/xml", RawXml | RestTokens],
+                 Boundary, Users) ->
+    UpdUsers = parse_user_records(RawXml, ?XML) ++ Users,
+    parse_user_info(RestTokens, Boundary, UpdUsers);
+parse_user_info(["Content-Type: application/json", RawJson | RestTokens],
+                 Boundary, Users) ->
+    UpdUsers = parse_user_records(RawJson, ?JSON) ++ Users,
+    parse_user_info(RestTokens, Boundary, UpdUsers);
+parse_user_info([_ | RestTokens], Boundary, Users) ->
+    parse_user_info(RestTokens, Boundary, Users).

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -181,7 +181,7 @@ make_special_error(Code, Message, RequestId, HostId) ->
                {'HostId', [HostId]}
               ]
              },
-    riak_cs_xml:export_xml([XmlDoc]).
+    riak_cs_xml:to_xml([XmlDoc]).
 
 list_multipart_uploads(Bucket, Caller, Opts) ->
     list_multipart_uploads(Bucket, Caller, Opts, nopid).

--- a/src/riak_cs_oos_response.erl
+++ b/src/riak_cs_oos_response.erl
@@ -80,7 +80,7 @@ invalid_digest_response(ContentMd5, RD, Ctx) ->
                {'Content-MD5', [ContentMd5]},
                {'HostId', ["host-id"]}
               ]},
-    Body = riak_cs_xml:export_xml([XmlDoc]),
+    Body = riak_cs_xml:to_xml([XmlDoc]),
     UpdRD = wrq:set_resp_body(Body,
                               wrq:set_resp_header("Content-Type",
                                                   ?XML_TYPE,

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -211,7 +211,7 @@ error_response(StatusCode, Code, Message, RD, Ctx) ->
                          {'Message', [Message]},
                          {'Resource', [string:strip(OrigResource, right, $/)]},
                          {'RequestId', [""]}]}],
-    respond(StatusCode, riak_cs_xml:export_xml(XmlDoc), RD, Ctx).
+    respond(StatusCode, riak_cs_xml:to_xml(XmlDoc), RD, Ctx).
 
 copy_object_response(Manifest, RD, Ctx) ->
     LastModified = riak_cs_wm_utils:to_iso_8601(Manifest?MANIFEST.created),
@@ -219,17 +219,17 @@ copy_object_response(Manifest, RD, Ctx) ->
     XmlDoc = [{'CopyObjectResponse',
                [{'LastModified', [LastModified]},
                 {'ETag', [ETag]}]}],
-    respond(200, riak_cs_xml:export_xml(XmlDoc), RD, Ctx).
+    respond(200, riak_cs_xml:to_xml(XmlDoc), RD, Ctx).
 
 no_such_upload_response(UploadId, RD, Ctx) ->
     XmlDoc = {'Error',
               [
                {'Code', [error_code(no_such_upload)]},
                {'Message', [error_message(no_such_upload)]},
-               {'UploadId', [binary_to_list(base64url:encode(UploadId))]},
+               {'UploadId', [base64url:encode(UploadId)]},
                {'HostId', ["host-id"]}
               ]},
-    Body = riak_cs_xml:export_xml([XmlDoc]),
+    Body = riak_cs_xml:to_xml([XmlDoc]),
     respond(status_code(no_such_upload), Body, RD, Ctx).
 
 invalid_digest_response(ContentMd5, RD, Ctx) ->
@@ -240,7 +240,7 @@ invalid_digest_response(ContentMd5, RD, Ctx) ->
                {'Content-MD5', [ContentMd5]},
                {'HostId', ["host-id"]}
               ]},
-    Body = riak_cs_xml:export_xml([XmlDoc]),
+    Body = riak_cs_xml:to_xml([XmlDoc]),
     respond(status_code(invalid_digest), Body, RD, Ctx).
 
 %% @doc Convert an error code string into its corresponding atom

--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -71,8 +71,8 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
         {ok, {Ds, Commons}} ->
             Us = [{'Upload',
                    [
-                    {'Key', [unicode:characters_to_list(D?MULTIPART_DESCR.key, unicode)]},
-                    {'UploadId', [binary_to_list(base64url:encode(D?MULTIPART_DESCR.upload_id))]},
+                    {'Key', [D?MULTIPART_DESCR.key]},
+                    {'UploadId', [base64url:encode(D?MULTIPART_DESCR.upload_id)]},
                     {'Initiator',               % TODO: replace with ARN data?
                      [{'ID', [D?MULTIPART_DESCR.owner_key_id]},
                       {'DisplayName', [D?MULTIPART_DESCR.owner_display]}
@@ -90,27 +90,27 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
             Cs = [{'CommonPrefixes',
                    [
                     % WTH? The pattern [Common | _] can never match the type []
-                    {'Prefix', [binary_to_list(Common)]}
+                    {'Prefix', [Common]}
                    ]} || Common <- Commons],
             Get = fun(Name) -> case proplists:get_value(Name, Opts) of
                                    undefined -> [];
-                                   X         -> binary_to_list(X)
+                                   X         -> X
                                end
                   end,
             XmlDoc = {'ListMultipartUploadsResult',
                        [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                        [
-                        {'Bucket', [binary_to_list(Bucket)]},
+                        {'Bucket', [Bucket]},
                         {'KeyMarker', [Get(key_marker)]},
                         {'NextKeyMarker', []},      % TODO
                         {'NextUploadIdMarker', [Get(upload_id_marker)]},
                         {'Delimiter', [Get(delimiter)]},
                         {'Prefix', [Get(prefix)]},
-                        {'MaxUploads', ["1000"]},     % TODO
+                        {'MaxUploads', [1000]},     % TODO
                         {'IsTruncated', ["false"]}   % TODO
                       ] ++ Us ++ Cs
                      },
-            Body = riak_cs_xml:export_xml([XmlDoc]),
+            Body = riak_cs_xml:to_xml([XmlDoc]),
             {Body, RD, Ctx};
         {error, Reason} ->
             riak_cs_s3_response:api_error(Reason, RD, Ctx)

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -97,12 +97,12 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
             XmlDoc = {'InitiateMultipartUploadResult',
                        [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                        [
-                        {'Bucket', [binary_to_list(Bucket)]},
-                        {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
-                        {'UploadId', [binary_to_list(base64url:encode(UploadId))]}
+                        {'Bucket', [Bucket]},
+                        {'Key', [Key]},
+                        {'UploadId', [base64url:encode(UploadId)]}
                        ]
                      },
-            Body = riak_cs_xml:export_xml([XmlDoc]),
+            Body = riak_cs_xml:to_xml([XmlDoc]),
             RD2 = wrq:set_resp_body(Body, RD),
             {true, RD2, Ctx};
         {error, Reason} ->

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -98,7 +98,7 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                        [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                        [
                         {'Bucket', [binary_to_list(Bucket)]},
-                        {'Key', [Key]},
+                        {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
                         {'UploadId', [binary_to_list(base64url:encode(UploadId))]}
                        ]
                      },

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -107,12 +107,12 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                               [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                               [
                                {'Location', [lists:append(["http://", binary_to_list(Bucket), ".s3.amazonaws.com/", Key])]},
-                               {'Bucket', [binary_to_list(Bucket)]},
-                               {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
-                               {'ETag', [binary_to_list(UploadId64)]}
+                               {'Bucket', [Bucket]},
+                               {'Key', [Key]},
+                               {'ETag', [UploadId64]}
                               ]
                              },
-                    XmlBody = riak_cs_xml:export_xml([XmlDoc]),
+                    XmlBody = riak_cs_xml:to_xml([XmlDoc]),
                     RD2 = wrq:set_resp_body(XmlBody, RD),
                     {true, RD2, Ctx};
                 {error, notfound} ->
@@ -281,10 +281,10 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
         {ok, Ps} ->
             Us = [{'Part',
                    [
-                    {'PartNumber', [integer_to_list(P?PART_DESCR.part_number)]},
+                    {'PartNumber', [P?PART_DESCR.part_number]},
                     {'LastModified', [P?PART_DESCR.last_modified]},
                     {'ETag', [riak_cs_utils:etag_from_binary(P?PART_DESCR.etag)]},
-                    {'Size', [integer_to_list(P?PART_DESCR.size)]}
+                    {'Size', [P?PART_DESCR.size]}
                    ]
                   } || P <- lists:sort(Ps)],
             PartNumbers = [P?PART_DESCR.part_number || P <- Ps],
@@ -295,9 +295,9 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
             XmlDoc = {'ListPartsResult',
                       [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                       [
-                       {'Bucket', [binary_to_list(Bucket)]},
-                       {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
-                       {'UploadId', [binary_to_list(base64url:encode(UploadId))]},
+                       {'Bucket', [Bucket]},
+                       {'Key', [Key]},
+                       {'UploadId', [base64url:encode(UploadId)]},
                        {'Initiator',    % TODO: replace with ARN data?
                         [{'ID', [UserKeyId]},
                          {'DisplayName', [UserDisplay]}
@@ -307,13 +307,13 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
                          {'DisplayName', [UserDisplay]}
                         ]},
                        {'StorageClass', ["STANDARD"]}, % TODO
-                       {'PartNumberMarker', ["1"]},    % TODO
-                       {'NextPartNumberMarker', [integer_to_list(MaxPartNumber)]}, % TODO
-                       {'MaxParts', [integer_to_list(length(Us))]}, % TODO
+                       {'PartNumberMarker', [1]},    % TODO
+                       {'NextPartNumberMarker', [MaxPartNumber]}, % TODO
+                       {'MaxParts', [length(Us)]}, % TODO
                        {'IsTruncated', ["false"]}   % TODO
                       ] ++ Us
                      },
-            Body = riak_cs_xml:export_xml([XmlDoc]),
+            Body = riak_cs_xml:to_xml([XmlDoc]),
             {Body, RD, Ctx};
         {error, notfound} ->
             riak_cs_s3_response:no_such_upload_response(UploadId, RD, Ctx);

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -108,7 +108,7 @@ process_post(RD, Ctx=#context{local_context=LocalCtx,
                               [
                                {'Location', [lists:append(["http://", binary_to_list(Bucket), ".s3.amazonaws.com/", Key])]},
                                {'Bucket', [binary_to_list(Bucket)]},
-                               {'Key', [Key]},
+                               {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
                                {'ETag', [binary_to_list(UploadId64)]}
                               ]
                              },
@@ -296,7 +296,7 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
                       [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                       [
                        {'Bucket', [binary_to_list(Bucket)]},
-                       {'Key', [Key]},
+                       {'Key', [unicode:characters_to_list(list_to_binary(Key), unicode)]},
                        {'UploadId', [binary_to_list(base64url:encode(UploadId))]},
                        {'Initiator',    % TODO: replace with ARN data?
                         [{'ID', [UserKeyId]},

--- a/src/riak_cs_wm_usage.erl
+++ b/src/riak_cs_wm_usage.erl
@@ -321,7 +321,7 @@ produce_xml(RD, #ctx{body=undefined}=Ctx) ->
     Storage = maybe_storage(RD, Ctx),
     Doc = [{?KEY_USAGE, [{?KEY_ACCESS, xml_access(Access)},
                          {?KEY_STORAGE, xml_storage(Storage)}]}],
-    Body = case riak_cs_xml:export_xml(Doc) of
+    Body = case riak_cs_xml:to_xml(Doc) of
                {error, Bin, _}         -> Bin;
                {incomplete, Bin, _}    -> Bin;
                Bin when is_binary(Bin) -> Bin
@@ -477,7 +477,7 @@ xml_error_msg(Message) when is_binary(Message) ->
     xml_error_msg(binary_to_list(Message));
 xml_error_msg(Message) ->
     Doc = [{?KEY_ERROR, [{?KEY_MESSAGE, [Message]}]}],
-    riak_cs_xml:export_xml(Doc).
+    riak_cs_xml:to_xml(Doc).
 
 %% @doc Produce a datetime tuple from a ISO8601 string
 -spec datetime(binary()|string()) -> {ok, calendar:datetime()} | error.

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -244,6 +244,14 @@ make_owner(#list_objects_owner_v1{id=Id, display_name=Name}) ->
     make_internal_node('Owner', Content).
 
 -spec format_value(atom() | integer() | binary() | list()) -> string().
+%% @doc Format value depending on its type
+%% Handling of characters (binaries or lists of integers) are as follows:
+%% - For binaries, we assume that they are encoded by UTF-8.
+%% - For lists, we assume they are converted from UTF-8 encoded binaries
+%%   by applying binary_to_list/1.
+%%   This is tricky point but binary_to_list/1 treats binaries as if it is
+%%   Latin-1 encoded, so we should turn them back by list_to_binary first.
+%%   Then we can apply unicode:characters_to_binary safely.
 format_value(undefined) ->
     [];
 format_value(Val) when is_atom(Val) ->
@@ -253,7 +261,7 @@ format_value(Val) when is_binary(Val) ->
 format_value(Val) when is_integer(Val) ->
     integer_to_list(Val);
 format_value(Val) when is_list(Val) ->
-    Val.
+    format_value(list_to_binary(Val)).
 
 %% @doc Map a ACL group atom to its corresponding URI.
 -spec uri_for_group(atom()) -> string().

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -82,8 +82,8 @@ export_xml(XmlDoc) ->
 -spec to_xml(term()) -> binary().
 to_xml(undefined) ->
     [];
-to_xml([]) ->
-    [];
+to_xml(SimpleForm) when is_list(SimpleForm) ->
+    simple_form_to_xml(SimpleForm);
 to_xml(?ACL{}=Acl) ->
     acl_to_xml(Acl);
 to_xml(#acl_v1{}=Acl) ->
@@ -100,6 +100,21 @@ to_xml({users, Users}) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+%% @doc Convert simple form into XML.
+simple_form_to_xml(Elements) ->
+    XmlDoc = format_elements(Elements),
+    export_xml(XmlDoc).
+
+format_elements(Elements) ->
+    [format_element(E) || E <- Elements].
+
+format_element({Tag, Elements}) ->
+    {Tag, format_elements(Elements)};
+format_element({Tag, Attrs, Elements}) ->
+    {Tag, Attrs, format_elements(Elements)};
+format_element(Value) ->
+    format_value(Value).
 
 %% @doc Convert an internal representation of an ACL
 %% into XML.


### PR DESCRIPTION
Yet another PR for non-ASCII and XML related issues #787 and #628 (reorganized version of #796 ).

The previous PR #796 is some shortcut approach to the bugs, so
this PR reorganizes the diffs into smaller/step-by-step pieces.
(The total diffs of these PRs are identical.)

The reviewer(s) can choose from some options:
- Review #796 only, without looking at this. (yes, they are identical :) )
- Approve this PR (this or #796).
- Approve only first two commits (449d099 and c7eed7c). #628 will not be fixed in this case.
- Decline both. :P

Additional comments (which is not proper for commit messages), in chronological order:
- 449d099 \* Unicode-aware handling of non-ASCII object keys in multipart uploads
  
  Direct/honest/strait fix of #787
- c7eed7c \* Add tests of multipart upload with non-ASCII objet key and listing uploads
  
  Boto tests for the previous commit 449d099
- 48be327 \* Add Unicode handling of lists in the same manner as binaries
  
  As commit message says. :)
- 84a821c \* Generarize riak_cs_xml:to_xml/1 to convert xmerl's simple form
  
  To utilize riak_cs_xml's automatic conversion logic, extends `riak_cs_xml:to_xml/1`
  to accept xmerl's simple forms and generate XMLs.
- d35d74a \* Use XML export of simple forms of riak_cs_xml:to_xml in multipart uploads
  
  Use the to_xml in previous commit 84a821c. For multipart related logic.
  This commit overwrites the changes in the first commit 449d099.
- d215335 \* Use XML export of simple forms of riak_cs_xml:to_xml instead of export_xml/1
  
  Same as previous one, but other than multipart related ones.
- 9f1d2cd \* Fix bug of accept content type
  
  Not related to non-ASCII bug. Just a bug fix of test case.
- 863a87a \* Add test case of listing users which has non-ASCII UTF-8 characters
  
  As commit message says.
- d78cb66 \* origin/bugfix/non-ascii-in-xml-reorganized bugfix/non-ascii-in-xml-reorganized Add test case of access stats with xml format
  
  As commit message says.
