### PR TITLE
Fix missing xml fields on storage usage.

### DIFF
--- a/include/rts.hrl
+++ b/include/rts.hrl
@@ -26,16 +26,16 @@
 -type usage_field_type() :: 'Count' | 'UserErrorCount' | 'SystemErrorCount'
                           | 'BytesIn' | 'UserErrorBytesIn' | 'SystemErrorBytesIn'
                           | 'BytesOut' | 'UserErrorBytesOut' | 'SystemErrorBytesOut'
-                          | 'BytesOutIncomplete'.
+                          | 'BytesOutIncomplete' | 'Objects'| 'Bytes'.
 
 -define(SUPPORTED_USAGE_FIELD,
         ['Count' , 'UserErrorCount' , 'SystemErrorCount',
          'BytesIn' , 'UserErrorBytesIn' , 'SystemErrorBytesIn',
          'BytesOut' , 'UserErrorBytesOut' , 'SystemErrorBytesOut',
-         'BytesOutIncomplete']).
+         'BytesOutIncomplete', 'Objects', 'Bytes']).
 
 -define(SUPPORTED_USAGE_FIELD_BIN,
         [<<"Count">> , <<"UserErrorCount">> , <<"SystemErrorCount">>,
          <<"BytesIn">> , <<"UserErrorBytesIn">> , <<"SystemErrorBytesIn">>,
          <<"BytesOut">> , <<"UserErrorBytesOut">> , <<"SystemErrorBytesOut">>,
-         <<"BytesOutIncomplete">>]).
+         <<"BytesOutIncomplete">>, <<"Objects">>, <<"Bytes">>]).

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -636,7 +636,7 @@ make_authorization(Method, Resource, ContentType, Config, Date) ->
 
 datetime() ->
     {{YYYY,MM,DD}, {H,M,S}} = calendar:universal_time(),
-    io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [YYYY, MM, DD, H, M, S]).
+    lists:flatten(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [YYYY, MM, DD, H, M, S])).
 
 
 

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -25,6 +25,7 @@
 -export([confirm/0]).
 
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(BUCKET1, "storage-stats-test-1").
@@ -40,8 +41,10 @@ confirm() ->
                  delete_object(?BUCKET2, UserConfig),
                  store_objects(?BUCKET3, UserConfig)],
     {Begin, End} = calc_storage_stats(),
+    {JsonStat, XmlStat} = storage_stats_request(UserConfig, Begin, End),
     lists:map(fun(Spec) ->
-                      assert_storage_stats(UserConfig, Spec, {Begin, End})
+                      assert_storage_json_stats(Spec, JsonStat),
+                      assert_storage_xml_stats(Spec, XmlStat)
               end, TestSpecs),
     pass.
 
@@ -83,6 +86,8 @@ store_objects(Bucket, UserConfig) ->
 
 calc_storage_stats() ->
     Begin = rtcs:datetime(),
+    %% TODO workaround to #766
+    timer:sleep(1000),
     Res = rtcs:calculate_storage(1),
     lager:info("riak-cs-storage batch result: ~s", [Res]),
     ExpectRegexp = "Batch storage calculation started.\n$",
@@ -92,24 +97,71 @@ calc_storage_stats() ->
     End = rtcs:datetime(),
     {Begin, End}.
 
-assert_storage_stats(UserConfig, {Bucket, ExpectedObjects, ExpectedBytes}, {Begin, End}) ->
-    Samples = samples_from_json_request(UserConfig, {Begin, End}),
-    lager:debug("Storage samples: ~p", [Samples]),
-    ?assertEqual(1, length(Samples)),
-    [Sample|_] = Samples,
-    lager:info("Storage sample: ~p", [Sample]),
-
+assert_storage_json_stats({Bucket, ExpectedObjects, ExpectedBytes}, Sample) ->
     ?assertEqual(ExpectedObjects, rtcs:json_get([list_to_binary(Bucket), <<"Objects">>],   Sample)),
     ?assertEqual(ExpectedBytes,   rtcs:json_get([list_to_binary(Bucket), <<"Bytes">>],     Sample)),
     ?assert(rtcs:json_get([<<"StartTime">>], Sample) =/= notfound),
     ?assert(rtcs:json_get([<<"EndTime">>],   Sample) =/= notfound),
     pass.
 
+assert_storage_xml_stats({Bucket, ExpectedObjects, ExpectedBytes}, Sample) ->
+    ?assertEqual(ExpectedObjects, proplists:get_value('Objects', proplists:get_value(Bucket, Sample))),
+    ?assertEqual(ExpectedBytes,   proplists:get_value('Bytes', proplists:get_value(Bucket, Sample))),
+    ?assert(proplists:get_value('StartTime', Sample) =/= notfound),
+    ?assert(proplists:get_value('EndTime', Sample)   =/= notfound),
+    pass.
+
+storage_stats_request(UserConfig, Begin, End) ->
+    {storage_stats_json_request(UserConfig, Begin, End),
+     storage_stats_xml_request(UserConfig, Begin, End)}.
+
+storage_stats_json_request(UserConfig, Begin, End) ->
+    Samples = samples_from_json_request(UserConfig, {Begin, End}),
+    lager:debug("Storage samples[json]: ~p", [Samples]),
+    ?assertEqual(1, length(Samples)),
+    [Sample] = Samples,
+    lager:info("Storage sample[json]: ~p", [Sample]),
+    Sample.
+
+storage_stats_xml_request(UserConfig, Begin, End) ->
+    Samples = samples_from_xml_request(UserConfig, {Begin, End}),
+    lager:debug("Storage samples[xml]: ~p", [Samples]),
+    ?assertEqual(1, length(Samples)),
+    [Sample] = Samples,
+    ParsedSample = to_proplist_stats(Sample),
+    lager:info("Storage sample[xml]: ~p", [ParsedSample]),
+    ParsedSample.
+
 samples_from_json_request(UserConfig, {Begin, End}) ->
     KeyId = UserConfig#aws_config.access_key_id,
-    StatsKey = filename:join(["usage", KeyId, "bj", Begin, End]),
+    StatsKey = string:join(["usage", KeyId, "bj", Begin, End], "/"),
     GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, UserConfig),
-    lager:debug("GET Storage stats response: ~p", [GetResult]),
+    lager:debug("GET Storage stats response[json]: ~p", [GetResult]),
     Usage = mochijson2:decode(proplists:get_value(content, GetResult)),
-    lager:debug("Usage Response: ~p", [Usage]),
+    lager:debug("Usage Response[json]: ~p", [Usage]),
     rtcs:json_get([<<"Storage">>, <<"Samples">>], Usage).
+
+samples_from_xml_request(UserConfig, {Begin, End}) ->
+    KeyId = UserConfig#aws_config.access_key_id,
+    StatsKey = string:join(["usage", KeyId, "bx", Begin, End], "/"),
+    GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, UserConfig),
+    lager:debug("GET Storage stats response[xml]: ~p", [GetResult]),
+    {Usage, _Rest} = xmerl_scan:string(binary_to_list(proplists:get_value(content, GetResult))),
+    lager:debug("Usage Response[xml]: ~p", [Usage]),
+    xmerl_xpath:string("//Storage/Samples/Sample",Usage).
+
+to_proplist_stats(Sample) ->
+    lists:foldl(fun extract_bucket/2, [], Sample#xmlElement.content)
+        ++ lists:foldl(fun extract_slice/2, [], Sample#xmlElement.attributes).
+
+extract_bucket(#xmlElement{name='Bucket', attributes=[#xmlAttribute{value=Bucket}], content=Content}, Acc) ->
+    [{Bucket, lists:foldl(fun extract_usage/2,[], Content)}|Acc].
+
+extract_slice(#xmlAttribute{name=Name, value=Value}, Acc) ->
+    [{Name, Value}|Acc].
+
+extract_usage(#xmlElement{name=Name, content=[Content]}, Acc) ->
+    [{Name, extract_value(Content)}|Acc].
+
+extract_value(#xmlText{value=Content}) ->
+    list_to_integer(Content).


### PR DESCRIPTION
Problem: Storage usage api responds 500 internal error on xml request.
Fix: Add missing supported xml fields to the definitions.
Reported by: #797

This PR includes:
- update supported xml fields
- add riak_test to xml response on storage usage.
