### PR TITLE
Remove zero-width spaces

### DIFF
--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -571,8 +571,8 @@ extract_amazon_headers(Headers) ->
 
 %% @doc Extract user metadata from request header
 %% Expires, Content-Disposition, Content-Encoding and x-amz-meta-*
-%% TODO: pass in x-amz-server-side​-encryption?
-%% TODO: pass in x-amz-storage-​class?
+%% TODO: pass in x-amz-server-side-encryption?
+%% TODO: pass in x-amz-storage-class?
 %% TODO: pass in x-amz-grant-* headers?
 extract_user_metadata(RD) ->
     extract_user_metadata(get_request_headers(RD), []).


### PR DESCRIPTION
There exist some zero-width spaces[1] in a source file.
They are harmless because in comments, but a little bit uncomfortable.

Maybe it's hard to see from the diff, the output passed to `less` in
my environment is as follows:

```
$ git --no-pager show | less
commit fc468612f63ccb6ce3bf60a96c99a680ab0bbddf
[snip]
--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -571,8 +571,8 @@ extract_amazon_headers(Headers) ->

 %% @doc Extract user metadata from request header
 %% Expires, Content-Disposition, Content-Encoding and x-amz-meta-*
-%% TODO: pass in x-amz-server-side<U+200B>-encryption?
-%% TODO: pass in x-amz-storage-<U+200B>class?
+%% TODO: pass in x-amz-server-side-encryption?
+%% TODO: pass in x-amz-storage-class?
```

Also, I grep'ped non-ASCII characters in repository [2] and
other than above are ones from binary files or intentional ones.

[1] http://en.wikipedia.org/wiki/Zero-width_space
[2] https://gist.github.com/shino/97be7e66cec1a77ff42f
