### PR TITLE
WIP: Introduce riak-cs-admin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,5 +40,6 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "4bb0fd664ff065c4082ca8dd2e0683e920537d15"}},
         {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
+        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "1.2.4"}}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}}
        ]}.

--- a/rel/files/riak-cs-access
+++ b/rel/files/riak-cs-access
@@ -1,26 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    flush)
-        # Make sure the local node IS running
-        node_up_check
-
-        shift
-
-        $NODETOOL rpc riak_cs_access_console flush $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { flush }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin access "$@"

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -1,0 +1,39 @@
+#!/bin/sh
+# -*- tab-width:4;indent-tabs-mode:nil -*-
+# ex: ts=4 sw=4 et
+
+# Pull environment for this install
+. "{{runner_base_dir}}/lib/env.sh"
+
+# Make sure the user running this script is the owner and/or su to that user
+check_user $@
+
+# Make sure CWD is set to runner run dir
+cd $RUNNER_BASE_DIR
+
+# Identify the script name
+SCRIPT=`basename $0`
+
+usage() {
+    echo "Usage: $SCRIPT { cluster-info }"
+}
+
+# Check the first argument for instructions
+case "$1" in
+    cluster[_-]info)
+        if [ $# -lt 2 ]; then
+            echo "Usage: $SCRIPT $1 <output_file>"
+            exit 1
+        fi
+        shift
+
+        # Make sure the local node is running
+        node_up_check
+
+        $NODETOOL rpc_infinity riak_cs_console cluster_info $@
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -6,7 +6,7 @@
 . "{{runner_base_dir}}/lib/env.sh"
 
 # Make sure the user running this script is the owner and/or su to that user
-check_user $@
+check_user "$@"
 
 # Make sure CWD is set to runner run dir
 cd $RUNNER_BASE_DIR
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { cluster-info|gc|access|storage|stanchion }"
+    echo "Usage: $SCRIPT { cluster-info | gc | access | storage | stanchion }"
 }
 
 # Check the first argument for instructions
@@ -30,65 +30,65 @@ case "$1" in
         # Make sure the local node is running
         node_up_check
 
-        $NODETOOL rpc_infinity riak_cs_console cluster_info $@
+        $NODETOOL rpc_infinity riak_cs_console cluster_info "$@"
         ;;
     gc)
-        case "$2" in
+        shift
+        case "$1" in
             batch|status|pause|resume|cancel|set-interval|set-leeway)
                 # Make sure the local node IS running
                 node_up_check
-                shift
 
-                $NODETOOL rpc riak_cs_gc_console $@
+                $NODETOOL rpc riak_cs_gc_console "$@"
                 ;;
             *)
-                echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
-                    "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
+                echo "Usage: $SCRIPT gc { batch [<leeway_seconds>] | status | pause | resume | cancel |"
+                echo "                          set-interval <interval_seconds> | set-leeway <leeway_seconds> }"
                 exit 1
                 ;;
         esac
         ;;
     storage)
-        case "$2" in
+        shift
+        case "$1" in
             batch|status|pause|resume|cancel)
                 # Make sure the local node IS running
                 node_up_check
-                shift
 
-                $NODETOOL rpc riak_cs_storage_console $@
+                $NODETOOL rpc riak_cs_storage_console "$@"
                 ;;
             *)
-                echo "Usage: $SCRIPT $1 { batch|status|pause|resume|cancel }"
+                echo "Usage: $SCRIPT storage $1 { batch | status | pause | resume | cancel }"
                 exit 1
                 ;;
         esac
         ;;
     access)
-        case "$2" in
+        shift
+        case "$1" in
             flush)
                 # Make sure the local node IS running
                 node_up_check
-                shift
 
-                $NODETOOL rpc riak_cs_access_console flush $@
+                $NODETOOL rpc riak_cs_access_console flush "$@"
                 ;;
             *)
-                echo "Usage: $SCRIPT $1 { flush }"
+                echo "Usage: $SCRIPT access $1 { flush }"
                 exit 1
                 ;;
         esac
         ;;
     stanchion)
-        case "$2" in
+        shift
+        case "$1" in
             switch|show)
                 # Make sure the local node IS running
                 node_up_check
-                shift
 
-                $NODETOOL rpc riak_cs_stanchion_console $@
+                $NODETOOL rpc riak_cs_stanchion_console "$@"
                 ;;
             *)
-                echo "Usage: $SCRIPT $1 { switch HOST PORT | show }"
+                echo "Usage: $SCRIPT stanchion $1 { switch HOST PORT | show }"
                 exit 1
                 ;;
         esac

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,11 +15,16 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { cluster-info | gc | access | storage | stanchion }"
+    echo "Usage: $SCRIPT { status | cluster-info | gc | access | storage | stanchion }"
 }
 
 # Check the first argument for instructions
 case "$1" in
+    status)
+        node_up_check
+
+        $NODETOOL rpc_infinity riak_cs_console status
+        ;;
     cluster[_-]info)
         if [ $# -lt 2 ]; then
             echo "Usage: $SCRIPT $1 <output_file>"

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { cluster-info }"
+    echo "Usage: $SCRIPT { cluster-info|gc|access|storage|stanchion }"
 }
 
 # Check the first argument for instructions
@@ -31,6 +31,67 @@ case "$1" in
         node_up_check
 
         $NODETOOL rpc_infinity riak_cs_console cluster_info $@
+        ;;
+    gc)
+        case "$2" in
+            batch|status|pause|resume|cancel|set-interval|set-leeway)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_gc_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
+                    "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
+                exit 1
+                ;;
+        esac
+        ;;
+    storage)
+        case "$2" in
+            batch|status|pause|resume|cancel)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_storage_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { batch|status|pause|resume|cancel }"
+                exit 1
+                ;;
+        esac
+        ;;
+    access)
+        case "$2" in
+            flush)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_access_console flush $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { flush }"
+                exit 1
+                ;;
+        esac
+        ;;
+    stanchion)
+        case "$2" in
+            switch|show)
+                # Make sure the local node IS running
+                node_up_check
+                shift
+
+                $NODETOOL rpc riak_cs_stanchion_console $@
+                ;;
+            *)
+                echo "Usage: $SCRIPT $1 { switch HOST PORT | show }"
+                exit 1
+                ;;
+        esac
         ;;
     *)
         usage

--- a/rel/files/riak-cs-debug
+++ b/rel/files/riak-cs-debug
@@ -1,0 +1,498 @@
+#!/bin/sh
+
+## -------------------------------------------------------------------
+##
+## riak-cs-debug: Gather info from a node for troubleshooting.
+##
+## Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+##
+## This file is provided to you under the Apache License,
+## Version 2.0 (the "License"); you may not use this file
+## except in compliance with the License.  You may obtain
+## a copy of the License at
+##
+##   http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+##
+## -------------------------------------------------------------------
+
+###
+### Function declarations
+###
+
+echoerr () { echo "$@" 1>&2; }
+
+mkdir_or_die () {
+    # If the dir already exists, just return
+    [ -d "$1" ] && return
+
+    mkdir -p "$1"
+    if [ 0 -ne $? ]; then
+        echoerr "Error creating riak-cs-debug directories. Aborting."
+        echoerr "$1"
+        exit 1
+    fi
+}
+
+dump () {
+    # first argument is the filename to hold the command output
+    out=$1
+    shift
+
+    # next argument is the base command to execute. skip dump if not available.
+    [ -z "`command -v $1`" ] && return
+
+    # execute the rest of the arguments as the command
+    $* >> "$out" 2>&1
+
+    # grab the return value
+    retval=$?
+
+    # put the command and the retval in the .info/$out file to aid automation.
+    # note: this will miss some escaping for, e.g., find, but it's not critical.
+    # get command that was run with `head -1 .info/$out`
+    # get return value from command with `tail -1 .info/$out`
+    echo "$*" > .info/"$out"
+    echo $retval >> .info/"$out"
+
+    if [ 0 -eq $retval ]; then
+        printf '.' 1>&2
+    else
+        printf 'E' 1>&2
+    fi
+
+    return $retval
+}
+
+usage () {
+cat << 'EOF'
+riak-cs-debug: Gather info from a node for troubleshooting. See 'man riak-cs-debug'.
+
+Usage: riak-cs-debug [-c] [-l] [-r] [-s] [-e] [FILENAME | -]
+
+-c, --cfgs      Gather Riak CS configuration information.
+-l, --logs      Gather Riak CS logs.
+-r, --riakcmds  Gather Riak CS information and command output.
+-s, --syscmds   Gather general system commands.
+-e, --extracmds Gather extra command output. These commands are too intense to
+                run on all nodes in a cluster but appropriate for a single node.
+FILENAME        Output filename for the tar.gz archive. Use - to specify stdout.
+
+Defaults: Get configs, logs, riak-cs commands, and system commands.
+          Output in current directory to NODE_NAME-riak-cs-debug.tar.gz or
+          HOSTNAME-riak-cs-debug.tar.gz if NODE_NAME cannot be found.
+EOF
+exit
+}
+
+###
+### Set up variables
+###
+
+# These paths may be overridden with environment variables.
+RUNNER_BASE_DIR={{runner_base_dir}}
+cs_base_dir={{runner_base_dir}}
+cs_bin_dir={{runner_script_dir}}
+cs_etc_dir={{runner_etc_dir}}
+cs_log_dir="$cs_base_dir"/{{platform_log_dir}}
+
+get_cfgs=0
+get_logs=0
+get_riakcmds=0
+get_syscmds=0
+get_extracmds=0
+
+###
+### Parse options
+###
+
+while [ -n "$1" ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            ;;
+        -c|--cfgs)
+            get_cfgs=1
+            ;;
+        -l|--logs)
+            get_logs=1
+            ;;
+        -r|--riakcmds)
+            get_riakcmds=1
+            ;;
+        -s|--syscmds)
+            get_syscmds=1
+            ;;
+        -e|--extracmds)
+            get_extracmds=1
+            ;;
+        -)
+            # If truly specifying stdout as the output file, it should be last
+            if [ $# -gt 1 ]; then
+                echoerr "Trailing options following filename $1. Aborting."
+                echoerr "See 'riak-cs-debug -h' and manpage for help."
+                exit 1
+            fi
+
+            outfile="-"
+            ;;
+        *)
+            # Shouldn't get here until the last option, the output filename.
+            if [ '-' = "$outfile" ]; then
+                echoerr "Filename $1 given but stdout, -, already specified."
+                echoerr "Aborting. See 'riak-cs-debug -h' and manpage for help."
+                exit 1
+            fi
+
+            # The filename shouldn't start with a '-'. The single character '-'
+            # is handled as a special case above.
+            if [ '-' =  `echo "$1" | awk 'BEGIN {FS=""} {print $1}'` ]; then
+                echoerr "Unrecognized option $1. Aborting"
+                echoerr "See 'riak-cs-debug -h' and manpage for help."
+                exit 1
+            fi
+
+            if [ $# -gt 1 ]; then
+                echoerr "Trailing options following filename $1. Aborting."
+                echoerr "See 'riak-cs-debug -h' and manpage for help." 
+                exit 1
+            fi
+            
+            outfile="$1"
+            ;;
+    esac
+    shift
+done
+
+###
+### Finish setting up variables and overrides
+###
+
+if [ 0 -eq $(( $get_cfgs + $get_logs + $get_riakcmds + $get_syscmds + $get_extracmds )) ]; then
+    # Nothing specific was requested, so get everything except extracmds
+    get_cfgs=1
+    get_logs=1
+    get_riakcmds=1
+    get_syscmds=1
+    get_extracmds=0
+fi
+
+if [ 0 -ne $(( $get_cfgs + $get_logs + $get_riakcmds + $get_extracmds )) ]; then
+    # Information specific to Riak requested. Need app_epath.sh and must have
+    # valid base and etc paths defined.
+
+    # app_epath.sh provides make_app_epaths and epath functions.
+    # Allow overriding with APP_EPATH
+    if [ -n "$APP_EPATH" ]; then
+        epath_file="$APP_EPATH"
+    else
+        epath_file="${cs_base_dir}/lib/app_epath.sh"
+    fi
+
+    if [ ! -f "$epath_file" ]; then
+        echoerr "Required file app_epath.sh not found. Expected here:"
+        echoerr "$epath_file" 
+        echoerr "See 'riak-cs-debug -h' and manpage for help."
+        exit 1
+    fi
+    . "$epath_file"
+
+    # Allow overriding cs_base_dir and cs_etc_dir from the environment
+    if [ -n "$cs_base_dir" ]; then
+        cs_base_dir="$cs_base_dir"
+        if [ "/" != "`echo "$cs_base_dir" | awk 'BEGIN {FS=""} {print $1}'`" ]; then
+            echoerr "Riak base directory should be an absolute path."
+            echoerr "$cs_base_dir" 
+            echoerr "See 'riak-cs-debug -h' and manpage for help."
+            exit 1
+        fi
+    fi
+
+    if [ -n "$cs_bin_dir" ]; then
+        cs_bin_dir="$cs_bin_dir"
+        if [ "/" != "`echo "$cs_bin_dir" | awk 'BEGIN {FS=""} {print $1}'`" ]; then
+            echoerr "Riak bin directory should be an absolute path."
+            echoerr "$cs_bin_dir" 
+            echoerr "See 'riak-cs-debug -h' and manpage for help."
+            exit 1
+        fi
+    fi
+
+    if [ -n "$cs_etc_dir" ]; then
+        cs_etc_dir="$cs_etc_dir"
+        if [ "/" != "`echo "$cs_etc_dir" | awk 'BEGIN {FS=""} {print $1}'`" ]; then
+            echoerr "Riak etc directory should be an absolute path."
+            echoerr "$cs_etc_dir" 
+            echoerr "See 'riak-cs-debug -h' and manpage for help."
+            exit 1
+        fi
+    fi
+fi
+
+if [ -f "${cs_etc_dir}"/vm.args ]; then
+    node_name="`egrep '^\-s?name' "${cs_etc_dir}"/vm.args 2>/dev/null | cut -d ' ' -f 2`"
+fi
+
+if [ -z "$node_name" ]; then
+    # Couldn't figure out node name. Fallback to hostname.
+    node_name="`hostname`"
+fi
+
+start_dir="$TMPDIR"
+
+if [ -z "$start_dir" ]; then
+    start_dir=/tmp
+fi
+
+# Strip any trailing slash from TMPDIR
+start_dir="`echo $start_dir | sed 's#/$##'`"
+
+debug_dir="${node_name}-riak-cs-debug"
+
+if [ -d "${start_dir}"/"${debug_dir}" ]; then
+    echoerr "Temporary directory already exists. Aborting."
+    echoerr "${start_dir}"/"${debug_dir}" 
+    exit 1
+fi
+
+if [ -z "$outfile" ]; then
+    # If output file not specified, output to the default
+    outfile="`pwd`"/"${debug_dir}".tar.gz
+fi
+
+if [ '-' != "$outfile" ] && [ -f "$outfile" ]; then
+    echoerr "Output file already exists. Aborting."
+    echoerr "$outfile" 
+    exit 1
+fi
+
+###
+### Gather system commands
+###
+
+if [ 1 -eq $get_syscmds ]; then
+    mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/.info
+    cd "${start_dir}"/"${debug_dir}"/commands
+
+    # System info
+    dump date date
+    dump w w
+    dump last last
+    dump hostname hostname
+    dump uname uname -a
+    dump lsb_release lsb_release
+    dump ps ps aux
+    dump vmstat vmstat
+    dump free free -m
+    dump df df
+    dump df_i df -i
+    dump dmesg dmesg
+    dump mount mount
+    dump sysctl sysctl -a
+    dump rpm rpm -qa
+    dump dpkg dpkg -l
+    dump pkg_info pkg_info
+    dump sestatus sestatus -v
+    dump ifconfig ifconfig -a
+    dump netstat_i netstat -i
+    dump netstat_an netstat -an
+    dump netstat_rn netstat -rn
+    dump pfctl_rules pfctl -s rules
+    dump pfctl_nat pfctl -s nat
+
+    # If swapctl exists, prefer it over swapon
+    if [ -n "`command -v swapctl`" ]; then
+        dump swapctl swapctl -s
+    else
+        dump swapon swapon -s
+    fi
+
+    # Running iptables commands if the module is not loaded can automatically
+    # load them. This is rarely desired and can even cause connectivity
+    # problems if, e.g., nf_conntrack gets autoloaded and autoenabled.
+    if [ -n "`command -v lsmod`" ]; then
+        if [ -n "`lsmod 2>/dev/null | awk '{print $1}' | grep iptable_filter`" ]; then
+            dump iptables_rules iptables -n -L
+        else
+            dump iptables_rules echo "iptables module not loaded"
+        fi
+
+        if [ -n "`lsmod 2>/dev/null | awk '{print $1}' | grep nf_conntrack`" ]; then
+            dump iptables_nat iptables -t nat -n -L
+        else
+            dump iptables_nat echo "nf_conntrack module not loaded"
+        fi
+    fi
+
+    if [ -f /proc/diskstats ]; then
+        # Linux iostat
+        dump iostat_linux iostat -mx 1 5
+    elif [ -d /proc ]; then
+        # No diskstats, but proc, probably Solaris or SmartOS
+        dump iostat_smartos iostat -xnz 1 5
+    else
+        # BSD style iostat
+        dump iostat_bsd iostat -dIw 1 -c 5
+    fi
+
+    # Dump files
+    [ -f /etc/release ] && dump release cat /etc/release
+    [ -f /etc/redhat-release ] && dump redhat_release cat /etc/redhat-release
+    [ -f /etc/debian_version ] && dump debian_version cat /etc/debian_version
+    [ -f /etc/security/limits.conf ] && dump limits.conf cat /etc/security/limits.conf
+    [ -f /var/log/messages ] && dump messages cat /var/log/messages
+    [ -f /var/log/syslog ] && dump messages cat /var/log/syslog
+    [ -f /proc/diskstats ] && dump diskstats cat /proc/diskstats
+    [ -f /proc/cpuinfo ] && dump cpuinfo cat /proc/cpuinfo
+    [ -f /proc/meminfo ] && dump meminfo cat /proc/meminfo
+
+    # Dump directories and finds
+    [ -d /dev/disk/by-id ] && dump disk_by_id ls -l /dev/disk/by-id
+    [ -d /sys/block ] && dump schedulers find /sys/block/ -type l -print -exec cat {}/queue/scheduler \;
+    [ -d /proc/net/bonding ] && dump bonding find /proc/net/bonding/ -type f -print -exec cat {} \;
+    [ -d /sys/class/net ] && dump rx_crc_errors find /sys/class/net/ -type l -print -exec cat {}/statistics/rx_crc_errors \;
+
+    # A bit more complicated, but let's get all of limits.d if it's there
+    if [ -d /etc/security/limits.d ]; then
+        # check to ensure there is at least something to get
+        if [ -n "`find /etc/security/limits.d -maxdepth 1 -name '*.conf' -print -quit`" ]; then
+            mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/limits.d
+
+            # Mirror the directory, only copying files that match the pattern
+            cd /etc/security/limits.d
+            find . -type f -name '*.conf' -exec sh -c '
+                mkdir -p "$0/${1%/*}";
+                cp "$1" "$0/$1"
+                ' "${start_dir}"/"${debug_dir}"/commands/limits.d {} \;
+        fi
+    fi
+fi
+
+###
+### Gather Riak commands and info
+###
+
+if [ 1 -eq $get_riakcmds ]; then
+    mkdir_or_die "${start_dir}"/"${debug_dir}"/commands/.info
+    cd "${start_dir}"/"${debug_dir}"/commands
+
+    # Note that 'riak-admin status' and 'riak-admin transfers' are heavy
+    # commands on Riak<=1.2.0 and should not be executed in a loop against all
+    # nodes in a cluster.
+
+    dump riak_cs_ping "$cs_bin_dir"/riak-cs ping
+    dump riak_cs_version "$cs_bin_dir"/riak-cs version
+    dump riak_cs_status "$cs_bin_dir"/riak-cs-admin status
+    dump riak_cs_gc_status "$cs_bin_dir"/riak-cs-admin gc status
+    dump riak_cs_storage_status "$cs_bin_dir"/riak-cs-admin storage status
+
+    CI=`pwd`/cluster-info.html
+    touch $CI
+    chmod 666 $CI
+    dump cluster-info "$cs_bin_dir"/riak-cs-admin cluster-info $CI
+    chmod 444 $CI
+fi
+
+###
+### Gather Riak logs
+###
+
+if [ 1 -eq $get_logs ]; then
+    mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/.info
+    cd "${start_dir}"/"${debug_dir}"/logs
+
+    # if not already made, make a flat, searchable version of the app.config
+    [ -z "$riak_epaths" ] && riak_epaths=`make_app_epaths "${cs_etc_dir}/app.config"`
+
+    # grab a listing of the log directory to show if there are crash dumps
+    dump ls_log_dir ls -lhR $cs_log_dir
+
+    # Get any logs in the platform_log_dir
+    if [ -d "${cs_log_dir}" ]; then
+        # check to ensure there is at least something to get
+        if [ -n "`find "${cs_log_dir}" -maxdepth 1 -name '*log*' -print -quit`" ]; then
+            mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/platform_log_dir
+
+            # Mirror the directory, only copying files that match the pattern
+            cd "$cs_log_dir"
+            find . -type f -name '*log*' -exec sh -c '
+                mkdir -p "$0/${1%/*}";
+                cp "$1" "$0/$1"
+                ' "${start_dir}"/"${debug_dir}"/logs/platform_log_dir {} \;
+        fi
+    fi
+
+    # Lager files
+    lager_paths="`epath 'lager handlers lager_file_backend file' "$riak_epaths" \
+                         | sed -e 's/^"//' -e 's/".*$//'`"
+    lager_num=0
+    for lager_path in $lager_paths; do
+        # Get lager logs if they weren't in platform_log_dir
+        if [ -n "$lager_path" ]; then
+            if [ '.' = `echo "$lager_path" | awk 'BEGIN {FS=""} {print $1}'` ]; then
+                # relative path. prepend base dir
+                lager_path="$cs_base_dir"/"$lager_path"
+            fi
+
+            lager_file="`echo $lager_path | awk -F/ '{print $NF}'`"
+            lager_dir="`echo $lager_path | awk -F/$lager_file '{print $1}'`"
+            if [ "$cs_log_dir" != "$lager_dir" ]; then
+                if [ -n "`find "${lager_dir}" -maxdepth 1 -name "${lager_file}*" -print -quit`" ]; then
+                    mkdir_or_die "${start_dir}"/"${debug_dir}"/logs/lager_"${lager_num}"
+                    cp "${lager_path}"* "${start_dir}"/"${debug_dir}"/logs/lager_"${lager_num}"
+                fi
+            fi
+        lager_num=`expr $lager_num + 1`
+        fi
+    done
+fi
+
+###
+### Gather Riak CS configuration
+###
+
+if [ 1 -eq $get_cfgs ]; then
+    mkdir_or_die "${start_dir}"/"${debug_dir}"/config/.info
+    cd "${start_dir}"/"${debug_dir}"/config
+
+    # Use dump to execute the copy. This will provide a progress dot and
+    # capture any error messages.
+    dump cp_cfg cp -R "$cs_etc_dir"/* .
+
+    # If the copy succeeded, then the output will be empty and it is unneeded.
+    if [ 0 -eq $? ]; then
+        rm -f cp_cfg
+    fi
+fi
+
+###
+### Produce the output file
+###
+
+# One last sanity check before transferring or removing anything
+cd "${start_dir}"
+if [ -z "$debug_dir" ] || [ ! -d "$debug_dir" ]; then
+    echoerr "Couldn't find ${start_dir}/${debug_dir}. Aborting"
+    exit 1
+fi
+
+if [ '-' = "$outfile" ]; then
+    # So we don't get a file literally named -
+    tar zcf - "${debug_dir}"
+else
+    tar zcf "$outfile" "${debug_dir}"
+
+    # provide some indication of the output filename
+    printf " $outfile" 1>&2
+fi
+rm -rf "${debug_dir}"
+
+# keep things looking pretty
+echoerr ""
+

--- a/rel/files/riak-cs-gc
+++ b/rel/files/riak-cs-gc
@@ -1,25 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    batch|status|pause|resume|cancel|set-interval|set-leeway)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_gc_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { batch [<leeway_seconds>]|status|pause|resume|cancel|" \
-            "set-interval <interval_seconds>|set-leeway <leeway_seconds> }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin gc "$@"

--- a/rel/files/riak-cs-stanchion
+++ b/rel/files/riak-cs-stanchion
@@ -1,24 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    switch|show)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_stanchion_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { switch HOST PORT | show }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin stanchion "$@"

--- a/rel/files/riak-cs-storage
+++ b/rel/files/riak-cs-storage
@@ -1,24 +1,3 @@
 #!/bin/sh
 
-# Pull environment for this install
-. "{{runner_base_dir}}/lib/env.sh"
-
-# Make sure the user running this script is the owner and/or su to that user
-check_user $@
-
-# Make sure CWD is set to runner run dir
-cd $RUNNER_BASE_DIR
-
-# Check the first argument for instructions
-case "$1" in
-    batch|status|pause|resume|cancel)
-        # Make sure the local node IS running
-        node_up_check
-
-        $NODETOOL rpc riak_cs_storage_console $@
-        ;;
-    *)
-        echo "Usage: $SCRIPT { batch|status|pause|resume|cancel }"
-        exit 1
-        ;;
-esac
+{{runner_script_dir}}/riak-cs-admin storage "$@"

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -58,6 +58,8 @@
                   "bin/riak-cs"},
            {template, "../deps/node_package/priv/base/env.sh",
                   "lib/env.sh"},
+           {template, "../deps/node_package/priv/base/app_epath.sh",
+                  "lib/app_epath.sh"},
 
            %% Copy config files
            {template, "files/app.config", "etc/app.config"},
@@ -73,5 +75,6 @@
            {template, "files/riak-cs-gc", "bin/riak-cs-gc"},
            {template, "files/riak-cs-stanchion", "bin/riak-cs-stanchion"},
            {template, "files/riak-cs-admin", "bin/riak-cs-admin"},
+           {template, "files/riak-cs-debug", "bin/riak-cs-debug"},
            {mkdir, "lib/basho-patches"}
           ]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -18,6 +18,7 @@
          lager_syslog,
          poolboy,
          folsom,
+         cluster_info,
          riak_cs
         ]},
        {rel, "start_clean", "",
@@ -71,5 +72,6 @@
            {template, "files/riak-cs-storage", "bin/riak-cs-storage"},
            {template, "files/riak-cs-gc", "bin/riak-cs-gc"},
            {template, "files/riak-cs-stanchion", "bin/riak-cs-stanchion"},
+           {template, "files/riak-cs-admin", "bin/riak-cs-admin"},
            {mkdir, "lib/basho-patches"}
           ]}.

--- a/src/riak_cs.app.src
+++ b/src/riak_cs.app.src
@@ -14,6 +14,7 @@
                   webmachine,
                   poolboy,
                   lager,
+                  cluster_info,
                   folsom
                  ]},
   {mod, { riak_cs_app, []}},

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -1,0 +1,51 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_console).
+
+-export([
+         cluster_info/1
+        ]).
+
+%%%===================================================================
+%%% Public API
+%%%===================================================================
+
+%% in progress.
+cluster_info([OutFile]) ->
+    try
+        cluster_info:dump_local_node(OutFile)
+    catch
+        error:{badmatch, {error, eacces}} ->
+            io:format("Cluster_info failed, permission denied writing to ~p~n", [OutFile]);
+        error:{badmatch, {error, enoent}} ->
+            io:format("Cluster_info failed, no such directory ~p~n", [filename:dirname(OutFile)]);
+        error:{badmatch, {error, enotdir}} ->
+            io:format("Cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
+        Exception:Reason ->
+            lager:error("Cluster_info failed ~p:~p",
+                [Exception, Reason]),
+            io:format("Cluster_info failed, see log for details~n"),
+            error
+    end.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -31,7 +31,7 @@
 
 status([]) ->
     try
-        Stats = riak_cs_stats:get_stats_v2(),
+        Stats = riak_cs_stats:get_console_stats(),
         StatString = format_stats(Stats,
             ["-------------------------------------------\n",
                 io_lib:format("1-minute stats for ~p~n",[node()])]),

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -21,12 +21,29 @@
 -module(riak_cs_console).
 
 -export([
+         status/1,
          cluster_info/1
         ]).
 
 %%%===================================================================
 %%% Public API
 %%%===================================================================
+
+status([]) ->
+    try
+        Stats = riak_cs_stats:get_stats_v2(),
+        StatString = format_stats(Stats,
+            ["-------------------------------------------\n",
+                io_lib:format("1-minute stats for ~p~n",[node()])]),
+        io:format("~s\n", [StatString])
+    catch
+        Exception:Reason ->
+            lager:error("Status failed ~p:~p",
+                [Exception, Reason]),
+            io:format("Status failed, see log for details~n"),
+            error
+    end.
+
 
 %% in progress.
 cluster_info([OutFile]) ->
@@ -49,3 +66,8 @@ cluster_info([OutFile]) ->
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+format_stats([], Acc) ->
+    lists:reverse(Acc);
+format_stats([{Stat, V}|T], Acc) ->
+    format_stats(T, [io_lib:format("~p : ~p~n", [Stat, V])|Acc]).

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -30,7 +30,8 @@
          report_json/0,
          report_pretty_json/0,
          report_str/0,
-         get_stats/0]).
+         get_stats/0,
+         get_stats_v2/0]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -101,6 +102,24 @@ get_stats() ->
     [{legend, [workers, overflow, size]}]
     ++
     [raw_report_pool(P) || P <- [ request_pool, bucket_list_pool ]].
+
+get_stats_v2() ->
+    lists:flatten(
+        [console_report_item(raw_report_item(I)) || I <- ?IDS]
+        ++
+        [console_report_pool(raw_report_pool(P)) || P <- [ request_pool, bucket_list_pool ]]
+        ++
+        cpu_stats()
+        ++
+        mem_stats()
+        ++
+        disk_stats()
+        ++
+        system_stats()
+        ++
+        app_stats()
+        ++
+        memory_stats()).
 
 %% ====================================================================
 %% gen_server callbacks
@@ -186,9 +205,77 @@ raw_report_item(BaseId) ->
             {BaseId, [MeterCount, MeterRate, LatencyMean, LatencyMedian,
              Latency95, Latency99]};
         undefined ->
-            {BaseId, -1, -1, -1, -1, -1, -1}
+            {BaseId, [-1, -1, -1, -1, -1, -1]}
     end.
 
 raw_report_pool(Pool) ->
     {_PoolState, PoolWorkers, PoolOverflow, PoolSize} = poolboy:status(Pool),
     {Pool, [PoolWorkers, PoolOverflow, PoolSize]}.
+
+console_report_item({BaseId, [MeterCount, MeterRate, LatencyMean, LatencyMedian, Latency95, Latency99]}) ->
+    [{list_to_atom(atom_to_list(BaseId) ++ K), V} || {K, V} <-
+        [{"_count", MeterCount},
+         {"_rate", MeterRate},
+         {"_time_mean", LatencyMean},
+         {"_time_median", LatencyMedian},
+         {"_time_95", Latency95},
+         {"_time_99", Latency99}]].
+
+console_report_pool({Pool, [PoolWorkers, PoolOverflow, PoolSize]}) ->
+    [{list_to_atom(atom_to_list(Pool) ++ K), V} || {K, V} <-
+        [{"_workers", PoolWorkers},
+         {"_overflow", PoolOverflow},
+         {"_size", PoolSize}]].
+
+memory_stats() ->
+    [{list_to_atom("memory_" ++ atom_to_list(K)), V} || {K,V} <- erlang:memory()].
+
+app_stats() ->
+    [{list_to_atom(atom_to_list(A) ++ "_version"), list_to_binary(V)}
+     || {A,_,V} <- application:which_applications()].
+
+%% @spec cpu_stats() -> proplist()
+%% @doc Get stats on the cpu, as given by the cpu_sup module
+%%      of the os_mon application.
+cpu_stats() ->
+    [{cpu_nprocs, cpu_sup:nprocs()},
+     {cpu_avg1, cpu_sup:avg1()},
+     {cpu_avg5, cpu_sup:avg5()},
+     {cpu_avg15, cpu_sup:avg15()}].
+
+%% @spec mem_stats() -> proplist()
+%% @doc Get stats on the memory, as given by the memsup module
+%%      of the os_mon application.
+mem_stats() ->
+    {Total, Alloc, _} = memsup:get_memory_data(),
+    [{mem_total, Total},
+     {mem_allocated, Alloc}].
+
+%% @spec disk_stats() -> proplist()
+%% @doc Get stats on the disk, as given by the disksup module
+%%      of the os_mon application.
+disk_stats() ->
+    [{disk, disksup:get_disk_data()}].
+
+system_stats() ->
+    [{nodename, node()},
+     {sys_driver_version, list_to_binary(erlang:system_info(driver_version))},
+     {sys_global_heaps_size, safe_global_heap_size()},
+     {sys_heap_type, erlang:system_info(heap_type)},
+     {sys_logical_processors, erlang:system_info(logical_processors)},
+     {sys_otp_release, list_to_binary(erlang:system_info(otp_release))},
+     {sys_process_count, erlang:system_info(process_count)},
+     {sys_smp_support, erlang:system_info(smp_support)},
+     {sys_system_version, list_to_binary(string:strip(erlang:system_info(system_version), right, $\n))},
+     {sys_system_architecture, list_to_binary(erlang:system_info(system_architecture))},
+     {sys_threads_enabled, erlang:system_info(threads)},
+     {sys_thread_pool_size, erlang:system_info(thread_pool_size)},
+     {sys_wordsize, erlang:system_info(wordsize)}].
+
+safe_global_heap_size() ->
+    try erlang:system_info(global_heaps_size) of
+        N -> N
+    catch
+        error:badarg ->
+            deprecated
+    end.


### PR DESCRIPTION
RiakCS has various CLI tools and they are expected to increase number of them gradually in future. To avoid increasing the number of them I suggest introducing riak-cs-admin into RiakCS as administration CLI like riak-admin for Riak. Changes on this PR include follows:
- riak-cs-admin
  - move the implementation of existing tools into riak-cs-admin
  - leave existing tools as adopter to riak-cs-admin for a while, just in case.
  - add cluster-info to riak-cs-admin
- new stats format
  - add new stats to riak-cs-admin with the same format of `riak-admin status` and also `/stats`. 
  - add config `stats_format` to switch a stats format and keep backward compatibility.
- riak-cs-debug
  - add riak-cs-debug

TODO
- [x] how to deal with current `/stats` API's format ?
  - option1: switch it by config `{cs_stats_version, v2}`
  - option2: switch it by url param `/stats?v2` or `/stats/v2
- [x] how to add riak-cs-debug, this subcommand or not ? It looks like too large code base to add riak-cs-admin as its subcommand.
- [ ] regression test.
#### riak-cs-admin

```
% ./riak-cs-admin
Usage: riak-cs-admin { status | cluster-info | gc | access | storage | stanchion }
```
##### sub commands

```
% ./riak-cs-admin status | head
1-minute stats for 'riak-cs@127.0.0.1'
-------------------------------------------
block_get_total : 0
block_get_rate : 0.0
block_get_time_mean : 0.0
block_get_time_median : 0.0
block_get_time_95 : 0.0
block_get_time_99 : 0.0
block_get_retry_total : 0
block_get_retry_rate : 0.0
```

```
% ./riak-cs-admin cluster-info
Usage: riak-cs-admin cluster-info <output_file>
```

```
% ./riak-cs-admin gc
Usage: riak-cs-admin gc { batch [<leeway_seconds>] | status | pause | resume | cancel |
                          set-interval <interval_seconds> | set-leeway <leeway_seconds> }
```

```
% ./riak-cs-admin access
Usage: riak-cs-admin access  { flush }
```

```
% ./riak-cs-admin storage
Usage: riak-cs-admin storage  { batch | status | pause | resume | cancel }
```

```
% ./riak-cs-admin stanchion
Usage: riak-cs-admin stanchion  { switch HOST PORT | show }
```
#### stats format
#### v0

```
% ./riak-cs-admin status
           block_get:   0       0.0     0.0     0.0     0.0     0.0
     block_get_retry:   0       0.0     0.0     0.0     0.0     0.0
           block_put:   0       0.0     0.0     0.0     0.0     0.0
        block_delete:   0       0.0     0.0     0.0     0.0     0.0
 service_get_buckets:   0       0.0     0.0     0.0     0.0     0.0
    bucket_list_keys:   0       0.0     0.0     0.0     0.0     0.0
       bucket_create:   0       0.0     0.0     0.0     0.0     0.0
       bucket_delete:   0       0.0     0.0     0.0     0.0     0.0
      bucket_get_acl:   0       0.0     0.0     0.0     0.0     0.0
      bucket_put_acl:   0       0.0     0.0     0.0     0.0     0.0
          object_get:   0       0.0     0.0     0.0     0.0     0.0
          object_put:   0       0.0     0.0     0.0     0.0     0.0
         object_head:   0       0.0     0.0     0.0     0.0     0.0
       object_delete:   0       0.0     0.0     0.0     0.0     0.0
      object_get_acl:   0       0.0     0.0     0.0     0.0     0.0
      object_put_acl:   0       0.0     0.0     0.0     0.0     0.0
```

```
% s3cmd -c user.cfg get s3://riak-cs/stats - | jsonpp | head -15
{
  "legend": [
    "meter_count",
    "meter_rate",
    "latency_mean",
    "latency_median",
    "latency_95",
    "latency_99"
  ],
  "block_get": [
    0,
    0.0,
    0.0,
    0.0,
    0.0,
```
##### v1

```
% ./riak-cs-admin status | head
1-minute stats for 'riak-cs@127.0.0.1'
-------------------------------------------
block_get_total : 0
block_get_rate : 0.0
block_get_time_mean : 0.0
block_get_time_median : 0.0
block_get_time_95 : 0.0
block_get_time_99 : 0.0
block_get_retry_total : 0
block_get_retry_rate : 0.0
```

```
% s3cmd -c user.cfg get s3://riak-cs/stats - | jsonpp | head -15
{
  "block_get_total": 0,
  "block_get_rate": 0.0,
  "block_get_time_mean": 0.0,
  "block_get_time_median": 0.0,
  "block_get_time_95": 0.0,
  "block_get_time_99": 0.0,
  "block_get_retry_total": 0,
  "block_get_retry_rate": 0.0,
  "block_get_retry_time_mean": 0.0,
  "block_get_retry_time_median": 0.0,
  "block_get_retry_time_95": 0.0,
  "block_get_retry_time_99": 0.0,
  "block_put_total": 0,
  "block_put_rate": 0.0,
```
