### PR TITLE
unintentionally pkg.vars.config was in .gitignore, recovering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ current_counterexample.eqc
 .int_test/
 .client_test/
 priv/riak_cs_drv.so
-pkg.vars.config
 client_tests/python/ceph_tests/s3-tests
 riak-cs.png
 .local_dialyzer_plt

--- a/pkg.vars.config
+++ b/pkg.vars.config
@@ -1,0 +1,24 @@
+%% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+%%
+%% Packaging
+%%
+{package_name, "riak-cs"}.
+{package_install_name, "riak-cs"}.
+{package_install_user, "riakcs"}.
+{package_install_group, "riak"}.
+{package_install_user_desc, "Riak CS user"}.
+{package_commands, {list, [[{name, "riak-cs"}], [{name, "riak-cs-access"}], [{name, "riak-cs-gc"}], [{name, "riak-cs-storage"}], [{name, "riak-cs-stanchion"}]]}}.
+{package_shortdesc, "Riak CS"}.
+{package_patch_dir, "basho-patches"}.
+{package_desc, "Riak CS"}.
+{bin_or_sbin, "sbin"}.
+{license_type, "Apache License, Version 2.0"}.
+{copyright, "2013 Basho Technologies, Inc"}.
+{vendor_name, "Basho Technologies, Inc"}.
+{vendor_url, "http://basho.com"}.
+{vendor_contact_name, "Basho Package Maintainer"}.
+{vendor_contact_email, "packaging@basho.com"}.
+{license_full_text, "This software is provided under license from Basho Technologies."}.
+{solaris_pkgname, "BASHOriak-cs"}.


### PR DESCRIPTION
At b79d88596281513d658f4d pkg.var.config was put into .gitignore, this commit saves it from ignorance. What makes me wonder is why packaging system has been working correctly through several 1.4.x releases - probably `git archive` command let it resurrect in the archive. Whatever, without this file we can't add any commands in #826, #829 .
