### PR TITLE
Ensure no mp uploads remaining in bucket creation and deletion

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -488,3 +488,6 @@
 -define(USERMETA_BUCKET, "RCS-bucket").
 -define(USERMETA_KEY,    "RCS-key").
 -define(USERMETA_BCSUM,  "RCS-bcsum").
+
+-define(OBJECT_BUCKET_PREFIX, <<"0o:">>).       % Version # = 0
+-define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0

--- a/riak_test/src/riakc_helper.erl
+++ b/riak_test/src/riakc_helper.erl
@@ -1,0 +1,54 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+-module(riakc_helper).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+to_bucket_name(CSBucket) ->
+    %%  or make version switch here.
+    <<"0o:", (stanchion_utils:md5(CSBucket))/binary>>.
+
+get_riakc_obj(Node, B, K) ->
+    Riakc = rt:pbc(Node),
+    Result = riakc_pb_socket:get(Riakc, B, K),
+    riakc_pb_socket:stop(Riakc),
+    Result.
+
+update_riakc_obj(Node, B, K, NewObj) ->
+    NewMD = riakc_obj:get_metadata(NewObj),
+    NewValue = riakc_obj:get_value(NewObj),
+    Riakc = rt:pbc(Node),
+    Result = case riakc_pb_socket:get(Riakc, B, K, [deletedvclock]) of
+                 {ok, OldObj} ->
+                     Updated = riakc_obj:update_value(riakc_obj:update_metadata(OldObj, NewMD), NewValue),
+                     riakc_pb_socket:put(Riakc, Updated);
+                 {error, notfound} ->
+                     Obj = riakc_obj:new(B, K, NewValue),
+                     Updated = riakc_obj:update_metadata(Obj, NewMD),
+                     riakc_pb_socket:put(Riakc, Updated)
+             end,
+    riakc_pb_socket:stop(Riakc),
+    Result.
+
+list_keys(Node, B) ->
+    Riakc = rt:pbc(Node),
+    {ok, Keys} = riakc_pb_socket:list_keys(Riakc, B),
+    riakc_pb_socket:stop(Riakc),
+    {ok, Keys}.

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -1,0 +1,153 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(buckets_test).
+
+%% @doc `riak_test' module for testing object get behavior.
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+%% keys for non-multipart objects
+-define(TEST_BUCKET,        "riak-test-bucket").
+-define(KEY_SINGLE_BLOCK,   "riak_test_key1").
+
+%% keys for multipart uploaded objects
+-define(KEY_MP,        "riak_test_mp").  % single part, single block
+
+
+confirm() ->
+    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
+
+
+    %% User 1, Cluster 1 config
+    {AccessKeyId, SecretAccessKey} = rtcs:create_user(hd(RiakNodes), 1),
+    UserConfig1 = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(hd(RiakNodes))),
+
+    ok = verify_create_delete(UserConfig),
+
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    ok = verify_bucket_delete_fails(UserConfig),
+
+    ok = verify_bucket_mpcleanup(UserConfig),
+
+    ok = verify_bucket_mpcleanup_racecond_andfix(UserConfig, UserConfig1,
+                                                 hd(RiakNodes), hd(CSNodes)),
+
+    pass.
+
+
+verify_create_delete(UserConfig) ->
+    lager:info("User is valid on the cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    lager:info("deleting bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+    lager:info("User is valid on the cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+    ok.
+
+verify_bucket_delete_fails(UserConfig) ->
+    %% setup objects
+    SingleBlock = crypto:rand_bytes(400),
+    erlcloud_s3:put_object(?TEST_BUCKET, ?KEY_SINGLE_BLOCK, SingleBlock, UserConfig),
+
+    %% verify bucket deletion fails if any objects exist
+    lager:info("deleting bucket ~p (to fail)", [?TEST_BUCKET]),
+    ?assertError({aws_error, {http_error, _, _, _}},
+                 erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+
+    %% cleanup object
+    erlcloud_s3:delete_object(?TEST_BUCKET, ?KEY_SINGLE_BLOCK, UserConfig),
+    ok.
+
+
+verify_bucket_mpcleanup(UserConfig) ->
+    Bucket = ?TEST_BUCKET,
+    Key = ?KEY_SINGLE_BLOCK,
+    InitUploadRes = erlcloud_s3_multipart:initiate_upload(Bucket, Key, [], [], UserConfig),
+    lager:info("InitUploadRes = ~p", [InitUploadRes]),
+    UploadId = erlcloud_s3_multipart:upload_id(InitUploadRes),
+    lager:info("UploadId = ~p", [UploadId]),
+
+    %% make sure that mp uploads created
+    UploadsList1 = erlcloud_s3_multipart:list_uploads(Bucket, [], UserConfig),
+    Uploads1 = proplists:get_value(uploads, UploadsList1, []),
+    ?assertEqual(Bucket, proplists:get_value(bucket, UploadsList1)),
+    ?assert(mp_upload_test:upload_id_present(UploadId, Uploads1)),
+
+    lager:info("deleting bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+
+    %% check that writing mp uploads never resurrect
+    %% after bucket delete
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+    UploadsList2 = erlcloud_s3_multipart:list_uploads(Bucket, [], UserConfig),
+    Uploads2 = proplists:get_value(uploads, UploadsList2, []),
+    ?assertEqual([], Uploads2),
+    ?assertEqual(Bucket, proplists:get_value(bucket, UploadsList2)),
+    ?assertNot(mp_upload_test:upload_id_present(UploadId, Uploads2)),
+    ok.
+
+%% @doc in race condition: on delete_bucket
+verify_bucket_mpcleanup_racecond_andfix(UserConfig, UserConfig1,
+                                        RiakNode, CSNode) ->
+    Key = ?KEY_MP,
+    Bucket = ?TEST_BUCKET,
+    ?assertEqual(ok, erlcloud_s3:create_bucket(Bucket, UserConfig)),
+    InitUploadRes = erlcloud_s3_multipart:initiate_upload(Bucket, Key, [], [], UserConfig),
+    lager:info("InitUploadRes = ~p", [InitUploadRes]),
+
+    %% Reserve riak object to emulate prior 1.4.5 behavior afterwards
+    RiakBucket = riakc_helper:to_bucket_name(Bucket),
+    {ok, ManiObj} = riakc_helper:get_riakc_obj(RiakNode, RiakBucket, Key),
+
+    ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
+
+    %% emulate a race condition, during the deletion MP initiate happened
+    ok = riakc_helper:update_riakc_obj(RiakNode, RiakBucket, Key, ManiObj),
+
+    %% then fail on creation
+    %%TODO: check fail fail fail => 500
+    ?assertError({aws_error, {http_error, 500, [], _}},
+                 erlcloud_s3:create_bucket(Bucket, UserConfig)),
+
+    ?assertError({aws_error, {http_error, 500, [], _}},
+                 erlcloud_s3:create_bucket(Bucket, UserConfig1)),
+
+    %% but we have a cleanup script, for existing system with 1.4.x or earlier
+    %% DO cleanup here
+    _Res = rpc:call(CSNode, riak_cs_console, cleanup_orphan_multipart, []),
+
+    %% list_keys here? wait for GC?
+
+    %% and Okay, it's clear, another user creates same bucket
+    ?assertEqual(ok, erlcloud_s3:create_bucket(Bucket, UserConfig1)),
+
+    %% Nothing found
+    UploadsList2 = erlcloud_s3_multipart:list_uploads(Bucket, [], UserConfig1),
+    Uploads2 = proplists:get_value(uploads, UploadsList2, []),
+    ?assertEqual([], Uploads2),
+    ?assertEqual(Bucket, proplists:get_value(bucket, UploadsList2)),
+    ok.

--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -22,7 +22,7 @@
 
 %% @doc `riak_test' module for testing multipart upload behavior.
 
--export([confirm/0]).
+-export([confirm/0, upload_id_present/2]).
 -include_lib("eunit/include/eunit.hrl").
 
 -define(TEST_BUCKET, "riak-test-bucket").

--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -169,35 +169,11 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 %%%===================================================================
 
 riak_connection() ->
-    {Host, Port} = riak_host_port(),
-    Timeout = case application:get_env(riak_cs, riakc_connect_timeout) of
-                  {ok, ConfigValue} ->
-                      ConfigValue;
-                  undefined ->
-                      10000
-              end,
-    StartOptions = [{connect_timeout, Timeout},
+    {Host, Port} = riak_cs_config:riak_host_port(),
+    StartOptions = [{connect_timeout, riak_cs_config:connect_timeout()},
                     {auto_reconnect, true}],
     riakc_pb_socket:start_link(Host, Port, StartOptions).
 
-%% @TODO This is duplicated code from
-%% `riak_cs_riakc_pool_worker'. Move this to `riak_cs_config' once
-%% that has been merged.
--spec riak_host_port() -> {string(), pos_integer()}.
-riak_host_port() ->
-    case application:get_env(riak_cs, riak_ip) of
-        {ok, Host} ->
-            ok;
-        undefined ->
-            Host = "127.0.0.1"
-    end,
-    case application:get_env(riak_cs, riak_pb_port) of
-        {ok, Port} ->
-            ok;
-        undefined ->
-            Port = 8087
-    end,
-    {Host, Port}.
 
 cleanup(Table, Pid, Mon) ->
     cleanup_table(Table),

--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -177,7 +177,7 @@ bucket_access(_, RequestedAccess, CanonicalId, RiakPid, Acl) ->
 -type bucket_acl_riak_error() :: {error, 'notfound' | term()}.
 -spec fetch_bucket_acl(binary(), pid()) -> bucket_acl_result() | bucket_acl_riak_error().
 fetch_bucket_acl(Bucket, RiakPid) ->
-    case riak_cs_utils:fetch_bucket_object(Bucket, RiakPid) of
+    case riak_cs_bucket:fetch_bucket_object(Bucket, RiakPid) of
         {ok, Obj} ->
             bucket_acl(Obj);
         {error, Reason} ->
@@ -210,7 +210,7 @@ bucket_acl_from_contents(Bucket, Contents) ->
     {Metas, Vals} = lists:unzip(Contents),
     UniqueVals = lists:usort(Vals),
     UserMetas = [dict:fetch(?MD_USERMETA, MD) || MD <- Metas],
-    riak_cs_utils:maybe_log_bucket_owner_error(Bucket, UniqueVals),
+    riak_cs_bucket:maybe_log_bucket_owner_error(Bucket, UniqueVals),
     resolve_bucket_metadata(UserMetas, UniqueVals).
 
 -spec resolve_bucket_metadata(list(riakc_obj:metadata()),

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -1,0 +1,734 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc riak_cs bucket utility functions, but I dare not use a module
+%% name with '_utils'.
+
+-module(riak_cs_bucket).
+
+%% Public API
+-export([
+         fetch_bucket_object/2,
+         create_bucket/5,
+         delete_bucket/4,
+         get_buckets/1,
+         set_bucket_acl/5,
+         set_bucket_policy/5,
+         delete_bucket_policy/4,
+         get_bucket_acl_policy/3,
+         maybe_log_bucket_owner_error/2,
+         resolve_buckets/3,
+         update_bucket_record/1,
+         delete_all_uploads/2,
+         delete_old_uploads/3,
+         fold_all_buckets/3
+        ]).
+
+-include("riak_cs.hrl").
+-include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
+-include_lib("riakc/include/riakc.hrl").
+
+-ifdef(TEST).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+%% @doc Create a bucket in the global namespace or return
+%% an error if it already exists.
+-spec create_bucket(rcs_user(), term(), binary(), acl(), pid()) ->
+                           ok |
+                           {error, term()}.
+create_bucket(User, UserObj, Bucket, ACL, RiakPid) ->
+    CurrentBuckets = get_buckets(User),
+
+    %% Do not attempt to create bucket if the user already owns it
+    AttemptCreate = riak_cs_config:disable_local_bucket_check() orelse
+        not bucket_exists(CurrentBuckets, binary_to_list(Bucket)),
+    case AttemptCreate of
+        true ->
+            case valid_bucket_name(Bucket) of
+                true ->
+                    serialized_bucket_op(Bucket,
+                                         ACL,
+                                         User,
+                                         UserObj,
+                                         create,
+                                         bucket_create,
+                                         RiakPid);
+                false ->
+                    {error, invalid_bucket_name}
+            end;
+        false ->
+            ok
+    end.
+
+-spec valid_bucket_name(binary()) -> boolean().
+valid_bucket_name(Bucket) when byte_size(Bucket) < 3 orelse
+                               byte_size(Bucket) > 63 ->
+    false;
+valid_bucket_name(Bucket) ->
+    lists:all(fun(X) -> X end, [valid_bucket_label(Label) ||
+                                   Label <- binary:split(Bucket,
+                                                         <<".">>,
+                                                         [global])])
+        andalso not is_bucket_ip_addr(binary_to_list(Bucket)).
+
+-spec valid_bucket_label(binary()) -> boolean().
+valid_bucket_label(<<>>) ->
+    %% this clause gets called when we either have a `.' as the first or
+    %% last byte. Or if it appears twice in a row. Examples are:
+    %% `<<".myawsbucket">>'
+    %% `<<"myawsbucket.">>'
+    %% `<<"my..examplebucket">>'
+    false;
+valid_bucket_label(Label) ->
+    valid_bookend_char(binary:first(Label)) andalso
+        valid_bookend_char(binary:last(Label)) andalso
+        lists:all(fun(X) -> X end,
+                  [valid_bucket_char(C) || C <- middle_chars(Label)]).
+
+-spec middle_chars(binary()) -> list().
+middle_chars(B) when byte_size(B) < 3 ->
+    [];
+middle_chars(B) ->
+    %% `binary:at/2' is zero based
+    ByteSize = byte_size(B),
+    [binary:at(B, Position) || Position <- lists:seq(1, ByteSize - 2)].
+
+-spec is_bucket_ip_addr(string()) -> boolean().
+is_bucket_ip_addr(Bucket) ->
+    case inet_parse:ipv4strict_address(Bucket) of
+        {ok, _} ->
+            true;
+        {error, _} ->
+            false
+    end.
+
+-spec valid_bookend_char(integer()) -> boolean().
+valid_bookend_char(Char) ->
+    numeric_char(Char) orelse lower_case_char(Char).
+
+-spec valid_bucket_char(integer()) -> boolean().
+valid_bucket_char(Char) ->
+    numeric_char(Char) orelse
+        lower_case_char(Char) orelse
+        dash_char(Char).
+
+-spec numeric_char(integer()) -> boolean().
+numeric_char(Char) ->
+    Char >= $0 andalso Char =< $9.
+
+-spec lower_case_char(integer()) -> boolean().
+lower_case_char(Char) ->
+    Char >= $a andalso Char =< $z.
+
+-spec dash_char(integer()) -> boolean().
+dash_char(Char) ->
+    Char =:= $-.
+
+%% @doc Delete a bucket
+-spec delete_bucket(rcs_user(), riakc_obj:riakc_obj(), binary(), pid()) ->
+                           ok |
+                           {error, remaining_multipart_upload}.
+delete_bucket(User, UserObj, Bucket, RiakPid) ->
+    CurrentBuckets = get_buckets(User),
+
+    %% Buckets can only be deleted if they exist
+    {AttemptDelete, LocalError} =
+        case bucket_exists(CurrentBuckets, binary_to_list(Bucket)) of
+            true ->
+                case bucket_empty(Bucket, RiakPid) of
+                    true -> {true, ok};
+                    false -> {false, {error, bucket_not_empty}}
+                end;
+            false -> {true, ok}
+        end,
+    case AttemptDelete of
+        true ->
+            %% TODO: output log if failed in cleaning up existing uploads.
+            %% The number of retry is hardcoded.
+            {ok, Count} = delete_all_uploads(Bucket, RiakPid),
+            _ = lager:debug("deleted ~p multiparts before bucket deletion.", [Count]),
+            %% This call still may return {error, remaining_multipart_upload}
+            %% even if all uploads cleaned up above, because concurrent
+            %% multiple deletion may happen. Then Riak CS returns 409 confliction
+            %% which is not in S3 specification....
+            serialized_bucket_op(Bucket,
+                                 ?ACL{},
+                                 User,
+                                 UserObj,
+                                 delete,
+                                 bucket_delete,
+                                 RiakPid);
+        false ->
+            LocalError
+    end.
+
+%% @doc TODO: this function is to be moved to riak_cs_multipart_utils or else?
+-spec delete_all_uploads(binary(), pid()) -> {ok, non_neg_integer()} | {error, term()}.
+delete_all_uploads(Bucket, RiakPid) ->
+    delete_old_uploads(Bucket, RiakPid, <<255>>).
+
+%% @doc deletes all multipart uploads older than Timestamp.
+%% input binary format of iso8068
+-spec delete_old_uploads(binary(), pid(), binary()) ->
+                                {ok, non_neg_integer()} | {error, term()}.
+delete_old_uploads(Bucket, RiakPid, Timestamp) when is_binary(Timestamp) ->
+    Opts = [{delimiter, undefined}, {max_uploads, undefined},
+            {prefix, undefined}, {key_marker, <<>>},
+            {upload_id_marker, <<>>}],
+    {ok, {Ds, _Commons}} = riak_cs_mp_utils:list_all_multipart_uploads(Bucket, Opts, RiakPid),
+    fold_delete_uploads(Bucket, RiakPid, Ds, Timestamp, 0).
+
+fold_delete_uploads(_Bucket, _RiakPid, [], _Timestamp, Count) -> {ok, Count};
+fold_delete_uploads(Bucket, RiakPid, [D|Ds], Timestamp, Count)->
+    Key = D?MULTIPART_DESCR.key,
+
+    %% cannot fail here
+    {ok, Obj, Manifests} = riak_cs_utils:get_manifests(RiakPid, Bucket, Key),
+
+    UploadId = D?MULTIPART_DESCR.upload_id,
+
+    %% find_manifest_with_uploadid
+    case lists:keyfind(UploadId, 1, Manifests) of
+
+        {UploadId, M} when M?MANIFEST.state == writing
+                           %% comparing timestamp here, like
+                           %% <<"2012-02-17T18:22:50.000Z">> < <<"2014-05-11-....">> => true
+                           andalso M?MANIFEST.created < Timestamp ->
+            case riak_cs_gc:gc_specific_manifests(
+                   [M?MANIFEST.uuid], Obj, Bucket, Key, RiakPid) of
+                {ok, _NewObj} ->
+                    fold_delete_uploads(Bucket, RiakPid, Ds, Timestamp, Count+1);
+                E ->
+                    lager:debug("cannot delete multipart manifest: ~p ~p (~p)",
+                                [{Bucket, Key}, M?MANIFEST.uuid, E]),
+                    E
+            end;
+        _E ->
+            lager:debug("skipping multipart manifest: ~p ~p (~p)",
+                        [{Bucket, Key}, UploadId, _E]),
+            fold_delete_uploads(Bucket, RiakPid, Ds, Timestamp, Count)
+    end.
+
+-spec fold_all_buckets(fun(), term(), pid()) -> {ok, term()} | {error, any()}.
+fold_all_buckets(Fun, Acc0, Pid) when is_function(Fun) ->
+    iterate_csbuckets(Pid, Acc0, Fun, undefined).
+
+-spec iterate_csbuckets(pid(), term(), fun(), binary()|undefined) ->
+                               {ok, term()} | {error, any()}.
+iterate_csbuckets(Pid, Acc0, Fun, Cont0) ->
+
+    Options = case Cont0 of
+                  undefined -> [];
+                  _ ->         [{continuation, Cont0}]
+              end ++ [{max_results, 1024}],
+
+    case riakc_pb_socket:get_index_range(Pid, ?BUCKETS_BUCKET,
+                                         <<"$key">>, <<0>>, <<255>>,
+                                         Options) of
+
+        {ok, ?INDEX_RESULTS{keys=Keys0, continuation=Cont}} ->
+
+            Foldfun = fun(Key, Acc1) ->
+                              Res = riakc_pb_socket:get(Pid, ?BUCKETS_BUCKET, Key),
+                              Fun(Key, Res, Acc1)
+                      end,
+            Acc2 = lists:foldl(Foldfun, Acc0, Keys0),
+            case Cont of
+                undefined ->
+                    {ok, Acc2};
+                _ ->
+                    iterate_csbuckets(Pid, Acc2, Fun, Cont)
+            end;
+
+        Error ->
+            _ = lager:error("iterating CS buckets: ~p", [Error]),
+            {error, {Error, Acc0}}
+    end.
+
+
+%% @doc Return a user's buckets.
+-spec get_buckets(rcs_user()) -> [cs_bucket()].
+get_buckets(?RCS_USER{buckets=Buckets}) ->
+    [Bucket || Bucket <- Buckets, Bucket?RCS_BUCKET.last_action /= deleted].
+
+%% @doc Set the ACL for a bucket. Existing ACLs are only
+%% replaced, they cannot be updated.
+-spec set_bucket_acl(rcs_user(), riakc_obj:riakc_obj(), binary(), acl(), pid()) -> ok | {error, term()}.
+set_bucket_acl(User, UserObj, Bucket, ACL, RiakPid) ->
+    serialized_bucket_op(Bucket,
+                         ACL,
+                         User,
+                         UserObj,
+                         update_acl,
+                         bucket_put_acl,
+                         RiakPid).
+
+%% @doc Set the policy for a bucket. Existing policy is only overwritten.
+-spec set_bucket_policy(rcs_user(), riakc_obj:riakc_obj(), binary(), []|policy()|acl(), pid()) -> ok | {error, term()}.
+set_bucket_policy(User, UserObj, Bucket, PolicyJson, RiakPid) ->
+    serialized_bucket_op(Bucket,
+                         PolicyJson,
+                         User,
+                         UserObj,
+                         update_policy,
+                         bucket_put_policy,
+                         RiakPid).
+
+%% @doc Set the policy for a bucket. Existing policy is only overwritten.
+-spec delete_bucket_policy(rcs_user(), riakc_obj:riakc_obj(), binary(), pid()) -> ok | {error, term()}.
+delete_bucket_policy(User, UserObj, Bucket, RiakPid) ->
+    serialized_bucket_op(Bucket,
+                         [],
+                         User,
+                         UserObj,
+                         delete_policy,
+                         bucket_put_policy,
+                         RiakPid).
+
+% @doc fetch moss.bucket and return acl and policy
+-spec get_bucket_acl_policy(binary(), atom(), pid()) -> {acl(), policy()} | {error, term()}.
+get_bucket_acl_policy(Bucket, PolicyMod, RiakPid) ->
+    case fetch_bucket_object(Bucket, RiakPid) of
+        {ok, Obj} ->
+            %% For buckets there should not be siblings, but in rare
+            %% cases it may happen so check for them and attempt to
+            %% resolve if possible.
+            Contents = riakc_obj:get_contents(Obj),
+            Acl = riak_cs_acl:bucket_acl_from_contents(Bucket, Contents),
+            Policy = PolicyMod:bucket_policy_from_contents(Bucket, Contents),
+            format_acl_policy_response(Acl, Policy);
+        {error, _}=Error ->
+            Error
+    end.
+
+-type policy_from_meta_result() :: {'ok', policy()} | {'error', 'policy_undefined'}.
+-type bucket_policy_result() :: policy_from_meta_result() | {'error', 'multiple_bucket_owners'}.
+-type acl_from_meta_result() :: {'ok', acl()} | {'error', 'acl_undefined'}.
+-type bucket_acl_result() :: acl_from_meta_result() | {'error', 'multiple_bucket_owners'}.
+-spec format_acl_policy_response(bucket_acl_result(), bucket_policy_result()) ->
+                                        {error, atom()} | {acl(), 'undefined' | policy()}.
+format_acl_policy_response({error, _}=Error, _) ->
+    Error;
+format_acl_policy_response(_, {error, multiple_bucket_owners}=Error) ->
+    Error;
+format_acl_policy_response({ok, Acl}, {error, policy_undefined}) ->
+    {Acl, undefined};
+format_acl_policy_response({ok, Acl}, {ok, Policy}) ->
+    {Acl, Policy}.
+
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @doc Generate a JSON document to use for a bucket
+%% ACL request.
+-spec bucket_acl_json(acl(), string()) -> string().
+bucket_acl_json(ACL, KeyId)  ->
+    binary_to_list(
+      iolist_to_binary(
+        mochijson2:encode({struct, [{<<"requester">>, list_to_binary(KeyId)},
+                                    stanchion_acl_utils:acl_to_json_term(ACL)]}))).
+
+%% @doc Generate a JSON document to use for a bucket
+-spec bucket_policy_json(binary(), string()) -> string().
+bucket_policy_json(PolicyJson, KeyId)  ->
+    binary_to_list(
+      iolist_to_binary(
+        mochijson2:encode({struct, [{<<"requester">>, list_to_binary(KeyId)},
+                                    {<<"policy">>, PolicyJson}]
+                          }))).
+
+%% @doc Check if a bucket is empty
+-spec bucket_empty(binary(), pid()) -> boolean().
+bucket_empty(Bucket, RiakcPid) ->
+    ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    %% @TODO Use `stream_list_keys' instead and
+    ListKeysResult = riak_cs_utils:list_keys(ManifestBucket, RiakcPid),
+    bucket_empty_handle_list_keys(RiakcPid,
+                                  Bucket,
+                                  ListKeysResult).
+
+-spec bucket_empty_handle_list_keys(pid(), binary(),
+                                    {ok, list()} |
+                                    {error, term()}) ->
+    boolean().
+bucket_empty_handle_list_keys(RiakcPid, Bucket, {ok, Keys}) ->
+    AnyPred = bucket_empty_any_pred(RiakcPid, Bucket),
+    %% `lists:any/2' will break out early as soon
+    %% as something returns `true'
+    not lists:any(AnyPred, Keys);
+bucket_empty_handle_list_keys(_RiakcPid, _Bucket, _Error) ->
+    false.
+
+-spec bucket_empty_any_pred(RiakcPid :: pid(), Bucket :: binary()) ->
+    fun((Key :: binary()) -> boolean()).
+bucket_empty_any_pred(RiakcPid, Bucket) ->
+    fun (Key) ->
+            riak_cs_utils:key_exists(RiakcPid, Bucket, Key)
+    end.
+
+%% @doc Fetches the bucket object and verify its status.
+-spec fetch_bucket_object(binary(), pid()) ->
+                                 {ok, riakc_obj:riakc_obj()} | {error, term()}.
+fetch_bucket_object(Bucket, RiakPid) ->
+    case riak_cs_utils:get_object(?BUCKETS_BUCKET, Bucket, RiakPid) of
+        {ok, Obj} ->
+            [Value | _] = Values = riakc_obj:get_values(Obj),
+            maybe_log_sibling_warning(Bucket, Values),
+            case Value of
+                ?FREE_BUCKET_MARKER ->
+                    {error, no_such_bucket};
+                _ ->
+                    {ok, Obj}
+            end;
+        {error, _}=Error ->
+            Error
+    end.
+
+-spec maybe_log_sibling_warning(binary(), list(riakc_obj:value())) -> ok.
+maybe_log_sibling_warning(Bucket, Values) when length(Values) > 1 ->
+    _ = lager:warning("The bucket ~s has ~b siblings that may need resolution.",
+                  [binary_to_list(Bucket), length(Values)]),
+    ok;
+maybe_log_sibling_warning(_, _) ->
+    ok.
+
+-spec maybe_log_bucket_owner_error(binary(), list(riakc_obj:value())) -> ok.
+maybe_log_bucket_owner_error(Bucket, Values) when length(Values) > 1 ->
+    _ = lager:error("The bucket ~s has ~b owners."
+                      " This situation requires administrator intervention.",
+                      [binary_to_list(Bucket), length(Values)]),
+    ok;
+maybe_log_bucket_owner_error(_, _) ->
+    ok.
+
+%% @doc Check if a bucket exists in a list of the user's buckets.
+%% @TODO This will need to change once globally unique buckets
+%% are enforced.
+-spec bucket_exists([cs_bucket()], string()) -> boolean().
+bucket_exists(Buckets, CheckBucket) ->
+    SearchResults = [Bucket || Bucket <- Buckets,
+                               Bucket?RCS_BUCKET.name =:= CheckBucket andalso
+                                   Bucket?RCS_BUCKET.last_action =:= created],
+    case SearchResults of
+        [] ->
+            false;
+        _ ->
+            true
+    end.
+
+%% @doc Return a closure over a specific function
+%% call to the stanchion client module for either
+%% bucket creation or deletion.
+-spec bucket_fun(bucket_operation(),
+                 binary(),
+                 acl(),
+                 string(),
+                 {string(), string()},
+                 {string(), pos_integer(), boolean()}) -> function().
+bucket_fun(create, Bucket, ACL, KeyId, AdminCreds, StanchionData) ->
+    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
+    %% Generate the bucket JSON document
+    BucketDoc = bucket_json(Bucket, ACL, KeyId),
+    fun() ->
+            velvet:create_bucket(StanchionIp,
+                                 StanchionPort,
+                                 "application/json",
+                                 BucketDoc,
+                                 [{ssl, StanchionSSL},
+                                  {auth_creds, AdminCreds}])
+    end;
+bucket_fun(update_acl, Bucket, ACL, KeyId, AdminCreds, StanchionData) ->
+    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
+    %% Generate the bucket JSON document for the ACL request
+    AclDoc = bucket_acl_json(ACL, KeyId),
+    fun() ->
+            velvet:set_bucket_acl(StanchionIp,
+                                  StanchionPort,
+                                  Bucket,
+                                  "application/json",
+                                  AclDoc,
+                                  [{ssl, StanchionSSL},
+                                   {auth_creds, AdminCreds}])
+    end;
+bucket_fun(update_policy, Bucket, PolicyJson, KeyId, AdminCreds, StanchionData) ->
+    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
+    %% Generate the bucket JSON document for the ACL request
+    PolicyDoc = bucket_policy_json(PolicyJson, KeyId),
+    fun() ->
+            velvet:set_bucket_policy(StanchionIp,
+                                     StanchionPort,
+                                     Bucket,
+                                     "application/json",
+                                     PolicyDoc,
+                                     [{ssl, StanchionSSL},
+                                      {auth_creds, AdminCreds}])
+    end;
+bucket_fun(delete_policy, Bucket, _, KeyId, AdminCreds, StanchionData) ->
+    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
+    %% Generate the bucket JSON document for the ACL request
+    fun() ->
+            velvet:delete_bucket_policy(StanchionIp,
+                                        StanchionPort,
+                                        Bucket,
+                                        KeyId,
+                                        [{ssl, StanchionSSL},
+                                         {auth_creds, AdminCreds}])
+    end;
+bucket_fun(delete, Bucket, _ACL, KeyId, AdminCreds, StanchionData) ->
+    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
+    fun() ->
+            velvet:delete_bucket(StanchionIp,
+                                 StanchionPort,
+                                 Bucket,
+                                 KeyId,
+                                 [{ssl, StanchionSSL},
+                                  {auth_creds, AdminCreds}])
+    end.
+
+%% @doc Generate a JSON document to use for a bucket
+%% creation request.
+-spec bucket_json(binary(), acl(), string()) -> string().
+bucket_json(Bucket, ACL, KeyId)  ->
+    binary_to_list(
+      iolist_to_binary(
+        mochijson2:encode({struct, [{<<"bucket">>, Bucket},
+                                    {<<"requester">>, list_to_binary(KeyId)},
+                                    stanchion_acl_utils:acl_to_json_term(ACL)]}))).
+
+%% @doc Return a bucket record for the specified bucket name.
+-spec bucket_record(binary(), bucket_operation()) -> cs_bucket().
+bucket_record(Name, Operation) ->
+    case Operation of
+        create ->
+            Action = created;
+        delete ->
+            Action = deleted;
+        _ ->
+            Action = undefined
+    end,
+    ?RCS_BUCKET{name=binary_to_list(Name),
+                 last_action=Action,
+                 creation_date=riak_cs_wm_utils:iso_8601_datetime(),
+                 modification_time=os:timestamp()}.
+
+%% @doc Check for and resolve any conflict between
+%% a bucket record from a user record sibling and
+%% a list of resolved bucket records.
+-spec bucket_resolver(cs_bucket(), [cs_bucket()]) -> [cs_bucket()].
+bucket_resolver(Bucket, ResolvedBuckets) ->
+    case lists:member(Bucket, ResolvedBuckets) of
+        true ->
+            ResolvedBuckets;
+        false ->
+            case [RB || RB <- ResolvedBuckets,
+                        RB?RCS_BUCKET.name =:=
+                            Bucket?RCS_BUCKET.name] of
+                [] ->
+                    [Bucket | ResolvedBuckets];
+                [ExistingBucket] ->
+                    case keep_existing_bucket(ExistingBucket,
+                                              Bucket) of
+                        true ->
+                            ResolvedBuckets;
+                        false ->
+                            [Bucket | lists:delete(ExistingBucket,
+                                                   ResolvedBuckets)]
+                    end
+            end
+    end.
+
+%% @doc Ordering function for sorting a list of bucket records
+%% according to bucket name.
+-spec bucket_sorter(cs_bucket(), cs_bucket()) -> boolean().
+bucket_sorter(?RCS_BUCKET{name=Bucket1},
+              ?RCS_BUCKET{name=Bucket2}) ->
+    Bucket1 =< Bucket2.
+
+%% @doc Return true if the last action for the bucket
+%% is deleted and the action occurred over the configurable
+%% maximum prune-time.
+-spec cleanup_bucket(cs_bucket()) -> boolean().
+cleanup_bucket(?RCS_BUCKET{last_action=created}) ->
+    false;
+cleanup_bucket(?RCS_BUCKET{last_action=deleted,
+                            modification_time=ModTime}) ->
+    %% the prune-time is specified in seconds, so we must
+    %% convert Erlang timestamps to seconds first
+    NowSeconds = riak_cs_utils:second_resolution_timestamp(os:timestamp()),
+    ModTimeSeconds = riak_cs_utils:second_resolution_timestamp(ModTime),
+    (NowSeconds - ModTimeSeconds) >
+    riak_cs_config:user_buckets_prune_time().
+
+%% @doc Determine if an existing bucket from the resolution list
+%% should be kept or replaced when a conflict occurs.
+-spec keep_existing_bucket(cs_bucket(), cs_bucket()) -> boolean().
+keep_existing_bucket(?RCS_BUCKET{last_action=LastAction1,
+                                  modification_time=ModTime1},
+                     ?RCS_BUCKET{last_action=LastAction2,
+                                  modification_time=ModTime2}) ->
+    if
+        LastAction1 == LastAction2
+        andalso
+        ModTime1 =< ModTime2 ->
+            true;
+        LastAction1 == LastAction2 ->
+            false;
+        ModTime1 > ModTime2 ->
+            true;
+        true ->
+            false
+    end.
+
+%% @doc Resolve the set of buckets for a user when
+%% siblings are encountered on a read of a user record.
+-spec resolve_buckets([rcs_user()], [cs_bucket()], boolean()) ->
+                             [cs_bucket()].
+resolve_buckets([], Buckets, true) ->
+    lists:sort(fun bucket_sorter/2, Buckets);
+resolve_buckets([], Buckets, false) ->
+    lists:sort(fun bucket_sorter/2, [Bucket || Bucket <- Buckets, not cleanup_bucket(Bucket)]);
+resolve_buckets([HeadUserRec | RestUserRecs], Buckets, _KeepDeleted) ->
+    HeadBuckets = HeadUserRec?RCS_USER.buckets,
+    UpdBuckets = lists:foldl(fun bucket_resolver/2, Buckets, HeadBuckets),
+    resolve_buckets(RestUserRecs, UpdBuckets, _KeepDeleted).
+
+%% @doc Shared code used when doing a bucket creation or deletion.
+-spec serialized_bucket_op(binary(),
+                           [] | acl() | policy(),
+                           rcs_user(),
+                           riakc_obj:riakc_obj(),
+                           bucket_operation(),
+                           atom(),
+                           pid()) ->
+                                  ok |
+                                  {error, term()}.
+serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatName, RiakPid) ->
+    StartTime = os:timestamp(),
+    case riak_cs_config:admin_creds() of
+        {ok, AdminCreds} ->
+            BucketFun = bucket_fun(BucketOp,
+                                   Bucket,
+                                   ACL,
+                                   User?RCS_USER.key_id,
+                                   AdminCreds,
+                                   riak_cs_utils:stanchion_data()),
+            %% Make a call to the bucket request
+            %% serialization service.
+            OpResult = BucketFun(),
+            case OpResult of
+                ok ->
+                    BucketRecord = bucket_record(Bucket, BucketOp),
+                    case update_user_buckets(User, BucketRecord) of
+                        {ok, ignore} when BucketOp == update_acl ->
+                            ok = riak_cs_stats:update_with_start(StatName,
+                                                                 StartTime),
+                            OpResult;
+                        {ok, ignore} ->
+                            OpResult;
+                        {ok, UpdUser} ->
+                            X = riak_cs_utils:save_user(UpdUser, UserObj, RiakPid),
+                            ok = riak_cs_stats:update_with_start(StatName,
+                                                                 StartTime),
+                            X
+                    end;
+
+                {error, {error_status, Status, _, ErrorDoc}} ->
+                    handle_stanchion_response(Status, ErrorDoc, BucketOp, Bucket);
+
+                {error, _} ->
+                    OpResult
+            end;
+        {error, Reason1} ->
+            {error, Reason1}
+    end.
+
+%% @doc needs retry for delete op.  409 assumes
+%% MultipartUploadRemaining for now if a new feature that needs retry
+%% could come up, add branch here. See tests in
+%% tests/riak_cs_bucket_test.erl
+-spec handle_stanchion_response(200..503, string(), delete|create, binary()) ->
+                                    {error, remaining_multipart_upload} |
+                                    {error, atom()}.
+handle_stanchion_response(409, ErrorDoc, Op, Bucket)
+  when Op =:= delete orelse Op =:= create ->
+
+    Value = riak_cs_s3_response:xml_error_code(ErrorDoc),
+    case {lists:flatten(Value), Op} of
+        {"MultipartUploadRemaining", delete} ->
+            _ = lager:error("Concurrent multipart upload might have"
+                            " happened on deleting bucket '~s'.", [Bucket]),
+            {error, remaining_multipart_upload};
+        {"MultipartUploadRemaining", create} ->
+            %% might be security issue
+            _ = lager:critical("Multipart upload remains in deleted bucket (~s)"
+                               " Clean up the deleted buckets now.", [Bucket]),
+            %% Broken, returns 500
+            throw({remaining_multipart_upload_on_deleted_bucket, Bucket});
+        Other ->
+            _ = lager:debug("errordoc: ~p => ~s", [Other, ErrorDoc]),
+            riak_cs_s3_response:error_response(ErrorDoc)
+    end;
+handle_stanchion_response(_C, ErrorDoc, _M, _) ->
+    %% _ = lager:error("unexpected errordoc: (~p, ~p) ~s", [_C, _M, ErrorDoc]),
+    riak_cs_s3_response:error_response(ErrorDoc).
+
+%% @doc Update a bucket record to convert the name from binary
+%% to string if necessary.
+-spec update_bucket_record(term()) -> cs_bucket().
+update_bucket_record(Bucket=?RCS_BUCKET{name=Name}) when is_binary(Name) ->
+    Bucket?RCS_BUCKET{name=binary_to_list(Name)};
+update_bucket_record(Bucket) ->
+    Bucket.
+
+%% @doc Check if a user already has an ownership of
+%% a bucket and update the bucket list if needed.
+-spec update_user_buckets(rcs_user(), cs_bucket()) ->
+                                 {ok, ignore} | {ok, rcs_user()}.
+update_user_buckets(User, Bucket) ->
+    Buckets = User?RCS_USER.buckets,
+    %% At this point any siblings from the read of the
+    %% user record have been resolved so the user bucket
+    %% list should have 0 or 1 buckets that share a name
+    %% with `Bucket'.
+    case [B || B <- Buckets, B?RCS_BUCKET.name =:= Bucket?RCS_BUCKET.name] of
+        [] ->
+            {ok, User?RCS_USER{buckets=[Bucket | Buckets]}};
+        [ExistingBucket] ->
+            case
+                (Bucket?RCS_BUCKET.last_action == deleted andalso
+                 ExistingBucket?RCS_BUCKET.last_action == created)
+                orelse
+                (Bucket?RCS_BUCKET.last_action == created andalso
+                 ExistingBucket?RCS_BUCKET.last_action == deleted) of
+                true ->
+                    UpdBuckets = [Bucket | lists:delete(ExistingBucket, Buckets)],
+                    {ok, User?RCS_USER{buckets=UpdBuckets}};
+                false ->
+                    {ok, ignore}
+            end
+    end.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -48,7 +48,9 @@
          gc_key_suffix_max/0,
          set_gc_key_suffix_max/1,
          user_buckets_prune_time/0,
-         set_user_buckets_prune_time/1
+         set_user_buckets_prune_time/1,
+         riak_host_port/0,
+         connect_timeout/0
         ]).
 
 %% OpenStack config
@@ -275,6 +277,28 @@ set_user_buckets_prune_time(PruneTime) when is_integer(PruneTime) andalso PruneT
     application:set_env(riak_cs, user_buckets_prune_time, PruneTime);
 set_user_buckets_prune_time(_PruneTime) ->
     {error, invalid_value}.
+
+%% @doc copied from `riak_cs_access_archiver'
+-spec riak_host_port() -> {inet:hostname(), inet:port_number()}.
+riak_host_port() ->
+    Host = case application:get_env(riak_cs, riak_ip) of
+               {ok, Host0} -> Host0;
+               undefined -> "127.0.0.1"
+           end,
+    Port = case application:get_env(riak_cs, riak_pb_port) of
+               {ok, Port0 } -> Port0;
+               undefined -> 8087
+           end,
+    {Host, Port}.
+
+-spec connect_timeout() -> pos_integer().
+connect_timeout() ->
+    case application:get_env(riak_cs, riakc_connect_timeout) of
+        {ok, ConfigValue} ->
+            ConfigValue;
+        undefined ->
+            10000
+    end.
 
 %% ===================================================================
 %% S3 config options

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -21,8 +21,13 @@
 -module(riak_cs_console).
 
 -export([
-         cluster_info/1
+         cluster_info/1,
+         cleanup_orphan_multipart/0,
+         cleanup_orphan_multipart/1
         ]).
+
+-include("riak_cs.hrl").
+-include_lib("riakc/include/riakc.hrl").
 
 %%%===================================================================
 %%% Public API
@@ -46,6 +51,73 @@ cluster_info([OutFile]) ->
             error
     end.
 
+%% @doc This function is for operation, esp cleaning up multipart
+%% uploads which not completed nor aborted, and after that - bucket
+%% deleted. Due to riak_cs/#475, this had been possible and Riak CS
+%% which has been running earlier versions before 1.4.x may need this
+%% cleanup.  This functions takes rather long time, because it
+%% 1. iterates all existing and deleted buckets in moss.buckets
+%% 2. if the bucket is deleted then search for all uncompleted
+%%    multipart uploads.
+%% usage:
+%% $ riak-cs attach
+%% 1> riak_cs_console:cleanup_orphan_multipart().
+%% cleaning up with timestamp 2014-05-11-....
+-spec cleanup_orphan_multipart() -> no_return().
+cleanup_orphan_multipart() ->
+    cleanup_orphan_multipart(riak_cs_wm_utils:iso_8601_datetime()).
+
+-spec cleanup_orphan_multipart(string()|binary()) -> no_return().
+cleanup_orphan_multipart(Timestamp) when is_list(Timestamp) ->
+    cleanup_orphan_multipart(list_to_binary(Timestamp));
+cleanup_orphan_multipart(Timestamp) when is_binary(Timestamp) ->
+
+    {ok, Pid} = riak_cs_riakc_pool_worker:start_link([]),
+    _ = lager:info("cleaning up with timestamp ~s", [Timestamp]),
+    _ = io:format("cleaning up with timestamp ~s", [Timestamp]),
+    Fun = fun(BucketName, GetResult, Acc0) ->
+                  _ = maybe_cleanup_csbucket(Pid, BucketName, GetResult, Timestamp),
+                  Acc0
+          end,
+    _ = riak_cs_bucket:fold_all_buckets(Fun, [], Pid),
+
+    ok = riak_cs_riakc_pool_worker:stop(Pid),
+    _ = lager:info("~nAll old unaborted orphan multipart uploads has deleted.~n", []),
+    _ = io:format("~nAll old unaborted orphan multipart uploads has deleted.~n", []).
+
+
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================
+
+
+-spec maybe_cleanup_csbucket(pid(), binary(),
+                             {ok, riakc_obj()}|{error, term()},
+                             binary()) -> ok.
+maybe_cleanup_csbucket(Pid, BucketName, {ok, RiakObj}, Timestamp) ->
+    case riakc_obj:get_values(RiakObj) of
+        [?FREE_BUCKET_MARKER] ->
+            %% deleted bucket, ensure if no uploads exists
+            io:format("\rchecking bucket ~s:", [BucketName]),
+            case riak_cs_bucket:delete_old_uploads(BucketName, Pid,
+                                                   Timestamp) of
+                {ok, 0} -> ok;
+                {ok, Count} ->  io:format(" aborted ~p uploads.~n",
+                                          [Count]);
+                Error -> io:format("Error: ~p <<< ~n", [Error])
+            end;
+
+        [<<>>] -> %% tombstone, can't happen
+            io:format("tombstone found on bucket ~s~n", [BucketName]),
+            ok;
+        [_] -> %% active bucket, do nothing
+            ok;
+        L when is_list(L) andalso length(L) > 1 -> %% siblings!! whoa!!
+            io:format("siblings found on bucket ~s~n", [BucketName]),
+            ok
+    end;
+maybe_cleanup_csbucket(_, _, {error, notfound}, _) ->
+    ok;
+maybe_cleanup_csbucket(_, BucketName, {error, _} = Error, _) ->
+    io:format("Error: ~p on processing ~s", [Error, BucketName]),
+    Error.

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -255,7 +255,7 @@ log_supported_actions()->
                                 {'error', 'multiple_bucket_owners'}.
 -spec fetch_bucket_policy(binary(), pid()) -> bucket_policy_result().
 fetch_bucket_policy(Bucket, RiakPid) ->
-    case riak_cs_utils:fetch_bucket_object(Bucket, RiakPid) of
+    case riak_cs_bucket:fetch_bucket_object(Bucket, RiakPid) of
         {ok, Obj} ->
             %% For buckets there should not be siblings, but in rare
             %% cases it may happen so check for them and attempt to
@@ -292,7 +292,7 @@ bucket_policy_from_contents(Bucket, Contents) ->
     {Metas, Vals} = lists:unzip(Contents),
     UniqueVals = lists:usort(Vals),
     UserMetas = [dict:fetch(?MD_USERMETA, MD) || MD <- Metas],
-    riak_cs_utils:maybe_log_bucket_owner_error(Bucket, UniqueVals),
+    riak_cs_bucket:maybe_log_bucket_owner_error(Bucket, UniqueVals),
     resolve_bucket_metadata(UserMetas, UniqueVals).
 
 -spec resolve_bucket_metadata(list(riakc_obj:metadata()),

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -26,18 +26,13 @@
 -export([etag_from_binary/1,
          etag_from_binary/2,
          etag_from_binary_no_quotes/1,
-         fetch_bucket_object/2,
          close_riak_connection/1,
          close_riak_connection/2,
-         create_bucket/5,
          create_user/2,
          create_user/4,
-         delete_bucket/4,
          delete_object/3,
          display_name/1,
          encode_term/1,
-         from_bucket_name/1,
-         get_buckets/1,
          get_keys_and_manifests/3,
          has_tombstone/1,
          is_admin/1,
@@ -60,7 +55,7 @@
          binary_to_hexlist/1,
          json_pp_print/1,
          list_keys/2,
-         maybe_log_bucket_owner_error/2,
+         key_exists/3,
          n_val_1_get_requests/0,
          pow/2,
          pow/3,
@@ -76,19 +71,16 @@
          safe_base64url_decode/1,
          safe_list_to_integer/1,
          save_user/3,
-         set_bucket_acl/5,
          set_object_acl/5,
-         set_bucket_policy/5,
-         delete_bucket_policy/4,
-         get_bucket_acl_policy/3,
          second_resolution_timestamp/1,
          timestamp_to_seconds/1,
          timestamp_to_milliseconds/1,
-         to_bucket_name/2,
          update_key_secret/1,
          update_obj_value/2,
          pid_to_binary/1,
          update_user/3,
+         from_bucket_name/1,
+         to_bucket_name/2,
          stanchion_data/0
         ]).
 
@@ -99,9 +91,6 @@
 -ifdef(TEST).
 -compile(export_all).
 -endif.
-
--define(OBJECT_BUCKET_PREFIX, <<"0o:">>).       % Version # = 0
--define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0
 
 %% Definitions for json_pp_print, from riak_core's json_pp.erl
 -define(SPACE, 32).
@@ -178,99 +167,6 @@ close_riak_connection(Pid) ->
 -spec close_riak_connection(atom(), pid()) -> ok.
 close_riak_connection(Pool, Pid) ->
     poolboy:checkin(Pool, Pid).
-
-%% @doc Create a bucket in the global namespace or return
-%% an error if it already exists.
--spec create_bucket(rcs_user(), term(), binary(), acl(), pid()) ->
-                           ok |
-                           {error, term()}.
-create_bucket(User, UserObj, Bucket, ACL, RiakPid) ->
-    CurrentBuckets = get_buckets(User),
-
-    %% Do not attempt to create bucket if the user already owns it
-    AttemptCreate = riak_cs_config:disable_local_bucket_check() orelse
-        not bucket_exists(CurrentBuckets, binary_to_list(Bucket)),
-    case AttemptCreate of
-        true ->
-            case valid_bucket_name(Bucket) of
-                true ->
-                    serialized_bucket_op(Bucket,
-                                         ACL,
-                                         User,
-                                         UserObj,
-                                         create,
-                                         bucket_create,
-                                         RiakPid);
-                false ->
-                    {error, invalid_bucket_name}
-            end;
-        false ->
-            ok
-    end.
-
--spec valid_bucket_name(binary()) -> boolean().
-valid_bucket_name(Bucket) when byte_size(Bucket) < 3 orelse
-                               byte_size(Bucket) > 63 ->
-    false;
-valid_bucket_name(Bucket) ->
-    lists:all(fun(X) -> X end, [valid_bucket_label(Label) ||
-                                   Label <- binary:split(Bucket,
-                                                         <<".">>,
-                                                         [global])])
-        andalso not is_bucket_ip_addr(binary_to_list(Bucket)).
-
--spec valid_bucket_label(binary()) -> boolean().
-valid_bucket_label(<<>>) ->
-    %% this clause gets called when we either have a `.' as the first or
-    %% last byte. Or if it appears twice in a row. Examples are:
-    %% `<<".myawsbucket">>'
-    %% `<<"myawsbucket.">>'
-    %% `<<"my..examplebucket">>'
-    false;
-valid_bucket_label(Label) ->
-    valid_bookend_char(binary:first(Label)) andalso
-        valid_bookend_char(binary:last(Label)) andalso
-        lists:all(fun(X) -> X end,
-                  [valid_bucket_char(C) || C <- middle_chars(Label)]).
-
--spec middle_chars(binary()) -> list().
-middle_chars(B) when byte_size(B) < 3 ->
-    [];
-middle_chars(B) ->
-    %% `binary:at/2' is zero based
-    ByteSize = byte_size(B),
-    [binary:at(B, Position) || Position <- lists:seq(1, ByteSize - 2)].
-
--spec is_bucket_ip_addr(string()) -> boolean().
-is_bucket_ip_addr(Bucket) ->
-    case inet_parse:ipv4strict_address(Bucket) of
-        {ok, _} ->
-            true;
-        {error, _} ->
-            false
-    end.
-
--spec valid_bookend_char(integer()) -> boolean().
-valid_bookend_char(Char) ->
-    numeric_char(Char) orelse lower_case_char(Char).
-
--spec valid_bucket_char(integer()) -> boolean().
-valid_bucket_char(Char) ->
-    numeric_char(Char) orelse
-        lower_case_char(Char) orelse
-        dash_char(Char).
-
--spec numeric_char(integer()) -> boolean().
-numeric_char(Char) ->
-    Char >= $0 andalso Char =< $9.
-
--spec lower_case_char(integer()) -> boolean().
-lower_case_char(Char) ->
-    Char >= $a andalso Char =< $z.
-
--spec dash_char(integer()) -> boolean().
-dash_char(Char) ->
-    Char =:= $-.
 
 %% @doc Create a new Riak CS user
 -spec create_user(string(), string()) -> {ok, rcs_user()} | {error, term()}.
@@ -350,40 +246,6 @@ update_user(User, UserObj, RiakPid) ->
             Error
     end.
 
-%% @doc Delete a bucket
--spec delete_bucket(rcs_user(), riakc_obj:riakc_obj(), binary(), pid()) ->
-                           ok |
-                           {error, term()}.
-delete_bucket(User, UserObj, Bucket, RiakPid) ->
-    CurrentBuckets = get_buckets(User),
-
-    %% Buckets can only be deleted if they exist
-    case bucket_exists(CurrentBuckets, binary_to_list(Bucket)) of
-        true ->
-            case bucket_empty(Bucket, RiakPid) of
-                true ->
-                    AttemptDelete = true,
-                    LocalError = ok;
-                false ->
-                    AttemptDelete = false,
-                    LocalError = {error, bucket_not_empty}
-            end;
-        false ->
-            AttemptDelete = true,
-            LocalError = ok
-    end,
-    case AttemptDelete of
-        true ->
-            serialized_bucket_op(Bucket,
-                                 ?ACL{},
-                                 User,
-                                 UserObj,
-                                 delete,
-                                 bucket_delete,
-                                 RiakPid);
-        false ->
-            LocalError
-    end.
 
 %% @doc Mark all active manifests as pending_delete.
 %% If successful, returns a list of the UUIDs that were marked for
@@ -404,53 +266,6 @@ encode_term(Term) ->
         false ->
             term_to_binary(Term)
     end.
-
-%% Get the root bucket name for either a Riak CS object
-%% bucket or the data block bucket name.
--spec from_bucket_name(binary()) -> {'blocks' | 'objects', binary()}.
-from_bucket_name(BucketNameWithPrefix) ->
-    BlocksName = ?BLOCK_BUCKET_PREFIX,
-    ObjectsName = ?OBJECT_BUCKET_PREFIX,
-    BlockByteSize = byte_size(BlocksName),
-    ObjectsByteSize = byte_size(ObjectsName),
-
-    case BucketNameWithPrefix of
-        <<BlocksName:BlockByteSize/binary, BucketName/binary>> ->
-            {blocks, BucketName};
-        <<ObjectsName:ObjectsByteSize/binary, BucketName/binary>> ->
-            {objects, BucketName}
-    end.
-
-%% @doc Return a user's buckets.
--spec get_buckets(rcs_user()) -> [cs_bucket()].
-get_buckets(?RCS_USER{buckets=Buckets}) ->
-    [Bucket || Bucket <- Buckets, Bucket?RCS_BUCKET.last_action /= deleted].
-
-%% @doc Return `stanchion' configuration data.
--spec stanchion_data() -> {string(), pos_integer(), boolean()}.
-stanchion_data() ->
-    case application:get_env(riak_cs, stanchion_ip) of
-        {ok, IP} ->
-            ok;
-        undefined ->
-            _ = lager:warning("No IP address or host name for stanchion access defined. Using default."),
-            IP = ?DEFAULT_STANCHION_IP
-    end,
-    case application:get_env(riak_cs, stanchion_port) of
-        {ok, Port} ->
-            ok;
-        undefined ->
-            _ = lager:warning("No port for stanchion access defined. Using default."),
-            Port = ?DEFAULT_STANCHION_PORT
-    end,
-    case application:get_env(riak_cs, stanchion_ssl) of
-        {ok, SSL} ->
-            ok;
-        undefined ->
-            _ = lager:warning("No ssl flag for stanchion access defined. Using default."),
-            SSL = ?DEFAULT_STANCHION_SSL
-    end,
-    {IP, Port, SSL}.
 
 %% @doc Return a list of keys for a bucket along
 %% with their associated objects.
@@ -674,7 +489,7 @@ get_user(KeyId, RiakPid) ->
                 1 ->
                     Value = binary_to_term(riakc_obj:get_value(Obj)),
                     User = update_user_record(Value),
-                    Buckets = resolve_buckets([Value], [], KeepDeletedBuckets),
+                    Buckets = riak_cs_bucket:resolve_buckets([Value], [], KeepDeletedBuckets),
                     {ok, {User?RCS_USER{buckets=Buckets}, Obj}};
                 0 ->
                     {error, no_value};
@@ -684,7 +499,7 @@ get_user(KeyId, RiakPid) ->
                                  Value /= <<>>  % tombstone
                              ],
                     User = update_user_record(hd(Values)),
-                    Buckets = resolve_buckets(Values, [], KeepDeletedBuckets),
+                    Buckets = riak_cs_bucket:resolve_buckets(Values, [], KeepDeletedBuckets),
                     {ok, {User?RCS_USER{buckets=Buckets}, Obj}}
             end;
         Error ->
@@ -905,40 +720,6 @@ save_user(User, UserObj, RiakPid) ->
                    MD),
     riakc_pb_socket:put(RiakPid, UpdUserObj).
 
-%% @doc Set the ACL for a bucket. Existing ACLs are only
-%% replaced, they cannot be updated.
--spec set_bucket_acl(rcs_user(), riakc_obj:riakc_obj(), binary(), acl(), pid()) -> ok | {error, term()}.
-set_bucket_acl(User, UserObj, Bucket, ACL, RiakPid) ->
-    serialized_bucket_op(Bucket,
-                         ACL,
-                         User,
-                         UserObj,
-                         update_acl,
-                         bucket_put_acl,
-                         RiakPid).
-
-%% @doc Set the policy for a bucket. Existing policy is only overwritten.
--spec set_bucket_policy(rcs_user(), riakc_obj:riakc_obj(), binary(), []|policy()|acl(), pid()) -> ok | {error, term()}.
-set_bucket_policy(User, UserObj, Bucket, PolicyJson, RiakPid) ->
-    serialized_bucket_op(Bucket,
-                         PolicyJson,
-                         User,
-                         UserObj,
-                         update_policy,
-                         bucket_put_policy,
-                         RiakPid).
-
-%% @doc Set the policy for a bucket. Existing policy is only overwritten.
--spec delete_bucket_policy(rcs_user(), riakc_obj:riakc_obj(), binary(), pid()) -> ok | {error, term()}.
-delete_bucket_policy(User, UserObj, Bucket, RiakPid) ->
-    serialized_bucket_op(Bucket,
-                         [],
-                         User,
-                         UserObj,
-                         delete_policy,
-                         bucket_put_policy,
-                         RiakPid).
-
 %% @doc Set the ACL for an object. Existing ACLs are only
 %% replaced, they cannot be updated.
 -spec set_object_acl(binary(), binary(), lfs_manifest(), acl(), pid()) ->
@@ -956,37 +737,6 @@ set_object_acl(Bucket, Key, Manifest, Acl, RiakPid) ->
             ok
     end,
     Res.
-
-% @doc fetch moss.bucket and return acl and policy
--spec get_bucket_acl_policy(binary(), atom(), pid()) -> {acl(), policy()} | {error, term()}.
-get_bucket_acl_policy(Bucket, PolicyMod, RiakPid) ->
-    case fetch_bucket_object(Bucket, RiakPid) of
-        {ok, Obj} ->
-            %% For buckets there should not be siblings, but in rare
-            %% cases it may happen so check for them and attempt to
-            %% resolve if possible.
-            Contents = riakc_obj:get_contents(Obj),
-            Acl = riak_cs_acl:bucket_acl_from_contents(Bucket, Contents),
-            Policy = PolicyMod:bucket_policy_from_contents(Bucket, Contents),
-            format_acl_policy_response(Acl, Policy);
-        {error, _}=Error ->
-            Error
-    end.
-
--type policy_from_meta_result() :: {'ok', policy()} | {'error', 'policy_undefined'}.
--type bucket_policy_result() :: policy_from_meta_result() | {'error', 'multiple_bucket_owners'}.
--type acl_from_meta_result() :: {'ok', acl()} | {'error', 'acl_undefined'}.
--type bucket_acl_result() :: acl_from_meta_result() | {'error', 'multiple_bucket_owners'}.
--spec format_acl_policy_response(bucket_acl_result(), bucket_policy_result()) ->
-                                        {error, atom()} | {acl(), 'undefined' | policy()}.
-format_acl_policy_response({error, _}=Error, _) ->
-    Error;
-format_acl_policy_response(_, {error, multiple_bucket_owners}=Error) ->
-    Error;
-format_acl_policy_response({ok, Acl}, {error, policy_undefined}) ->
-    {Acl, undefined};
-format_acl_policy_response({ok, Acl}, {ok, Policy}) ->
-    {Acl, Policy}.
 
 -spec second_resolution_timestamp(erlang:timestamp()) -> non_neg_integer().
 %% @doc Return the number of seconds this timestamp represents. Truncated to
@@ -1036,63 +786,60 @@ update_obj_value(Obj, Value) when is_binary(Value) ->
     riakc_obj:update_metadata(riakc_obj:update_value(Obj, Value),
                               MD).
 
-%% ===================================================================
-%% Internal functions
-%% ===================================================================
-
-%% @doc Generate a JSON document to use for a bucket
-%% ACL request.
--spec bucket_acl_json(acl(), string()) -> string().
-bucket_acl_json(ACL, KeyId)  ->
-    binary_to_list(
-      iolist_to_binary(
-        mochijson2:encode({struct, [{<<"requester">>, list_to_binary(KeyId)},
-                                    stanchion_acl_utils:acl_to_json_term(ACL)]}))).
-
-%% @doc Generate a JSON document to use for a bucket
--spec bucket_policy_json(binary(), string()) -> string().
-bucket_policy_json(PolicyJson, KeyId)  ->
-    binary_to_list(
-      iolist_to_binary(
-        mochijson2:encode({struct, [{<<"requester">>, list_to_binary(KeyId)},
-                                    {<<"policy">>, PolicyJson}]
-                          }))).
-
-%% @doc Check if a bucket is empty
--spec bucket_empty(binary(), pid()) -> boolean().
-bucket_empty(Bucket, RiakcPid) ->
-    ManifestBucket = to_bucket_name(objects, Bucket),
-    %% @TODO Use `stream_list_keys' instead and
-    ListKeysResult = list_keys(ManifestBucket, RiakcPid),
-    bucket_empty_handle_list_keys(RiakcPid,
-                                  Bucket,
-                                  ListKeysResult).
-
--spec bucket_empty_handle_list_keys(pid(), binary(),
-                                    {ok, list()} |
-                                    {error, term()}) ->
-    boolean().
-bucket_empty_handle_list_keys(RiakcPid, Bucket, {ok, Keys}) ->
-    AnyPred = bucket_empty_any_pred(RiakcPid, Bucket),
-    %% `lists:any/2' will break out early as soon
-    %% as something returns `true'
-    not lists:any(AnyPred, Keys);
-bucket_empty_handle_list_keys(_RiakcPid, _Bucket, _Error) ->
-    false.
-
--spec bucket_empty_any_pred(RiakcPid :: pid(), Bucket :: binary()) ->
-    fun((Key :: binary()) -> boolean()).
-bucket_empty_any_pred(RiakcPid, Bucket) ->
-    fun (Key) ->
-            key_exists(RiakcPid, Bucket, Key)
-    end.
-
 %% @private
 %% `Bucket' should be the raw bucket name,
 %% we'll take care of calling `to_bucket_name'
 -spec key_exists(pid(), binary(), binary()) -> boolean().
 key_exists(RiakcPid, Bucket, Key) ->
     key_exists_handle_get_manifests(get_manifests(RiakcPid, Bucket, Key)).
+
+%% @doc Return `stanchion' configuration data.
+-spec stanchion_data() -> {string(), pos_integer(), boolean()}.
+stanchion_data() ->
+    case application:get_env(riak_cs, stanchion_ip) of
+        {ok, IP} ->
+            ok;
+        undefined ->
+            _ = lager:warning("No IP address or host name for stanchion access defined. Using default."),
+            IP = ?DEFAULT_STANCHION_IP
+    end,
+    case application:get_env(riak_cs, stanchion_port) of
+        {ok, Port} ->
+            ok;
+        undefined ->
+            _ = lager:warning("No port for stanchion access defined. Using default."),
+            Port = ?DEFAULT_STANCHION_PORT
+    end,
+    case application:get_env(riak_cs, stanchion_ssl) of
+        {ok, SSL} ->
+            ok;
+        undefined ->
+            _ = lager:warning("No ssl flag for stanchion access defined. Using default."),
+            SSL = ?DEFAULT_STANCHION_SSL
+    end,
+    {IP, Port, SSL}.
+
+
+%% Get the root bucket name for either a Riak CS object
+%% bucket or the data block bucket name.
+-spec from_bucket_name(binary()) -> {'blocks' | 'objects', binary()}.
+from_bucket_name(BucketNameWithPrefix) ->
+    BlocksName = ?BLOCK_BUCKET_PREFIX,
+    ObjectsName = ?OBJECT_BUCKET_PREFIX,
+    BlockByteSize = byte_size(BlocksName),
+    ObjectsByteSize = byte_size(ObjectsName),
+
+    case BucketNameWithPrefix of
+        <<BlocksName:BlockByteSize/binary, BucketName/binary>> ->
+            {blocks, BucketName};
+        <<ObjectsName:ObjectsByteSize/binary, BucketName/binary>> ->
+            {objects, BucketName}
+    end.
+
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
 
 %% @private
 -spec key_exists_handle_get_manifests({ok, riakc_obj:riakc_obj(), list()} |
@@ -1109,206 +856,6 @@ active_to_bool({ok, _Active}) ->
     true;
 active_to_bool({error, notfound}) ->
     false.
-
-%% @doc Check if a bucket exists in the `buckets' bucket and verify
-%% that it has an owner assigned. If true return the object;
-%% otherwise, return an error.
-%%
-%% @TODO Rename current `bucket_exists' function to
-%% `bucket_exists_for_user' and rename this function
-%% `bucket_exists'.
--spec fetch_bucket_object(binary(), pid()) ->
-                                 {ok, riakc_obj:riakc_obj()} | {error, term()}.
-fetch_bucket_object(Bucket, RiakPid) ->
-    case riak_cs_utils:get_object(?BUCKETS_BUCKET, Bucket, RiakPid) of
-        {ok, Obj} ->
-            %% Make sure the bucket has an owner
-            [Value | _] = Values = riakc_obj:get_values(Obj),
-            maybe_log_sibling_warning(Bucket, Values),
-            case Value of
-                <<"0">> ->
-                    {error, no_such_bucket};
-                _ ->
-                    {ok, Obj}
-            end;
-        {error, _}=Error ->
-            Error
-    end.
-
--spec maybe_log_sibling_warning(binary(), list(riakc_obj:value())) -> ok.
-maybe_log_sibling_warning(Bucket, Values) when length(Values) > 1 ->
-    _ = lager:warning("The bucket ~s has ~b siblings that may need resolution.",
-                  [binary_to_list(Bucket), length(Values)]),
-    ok;
-maybe_log_sibling_warning(_, _) ->
-    ok.
-
--spec maybe_log_bucket_owner_error(binary(), list(riakc_obj:value())) -> ok.
-maybe_log_bucket_owner_error(Bucket, Values) when length(Values) > 1 ->
-    _ = lager:error("The bucket ~s has ~b owners."
-                      " This situation requires administrator intervention.",
-                      [binary_to_list(Bucket), length(Values)]),
-    ok;
-maybe_log_bucket_owner_error(_, _) ->
-    ok.
-
-%% @doc Check if a bucket exists in a list of the user's buckets.
-%% @TODO This will need to change once globally unique buckets
-%% are enforced.
--spec bucket_exists([cs_bucket()], string()) -> boolean().
-bucket_exists(Buckets, CheckBucket) ->
-    SearchResults = [Bucket || Bucket <- Buckets,
-                               Bucket?RCS_BUCKET.name =:= CheckBucket andalso
-                                   Bucket?RCS_BUCKET.last_action =:= created],
-    case SearchResults of
-        [] ->
-            false;
-        _ ->
-            true
-    end.
-
-%% @doc Return a closure over a specific function
-%% call to the stanchion client module for either
-%% bucket creation or deletion.
--spec bucket_fun(bucket_operation(),
-                 binary(),
-                 acl(),
-                 string(),
-                 {string(), string()},
-                 {string(), pos_integer(), boolean()}) -> function().
-bucket_fun(create, Bucket, ACL, KeyId, AdminCreds, StanchionData) ->
-    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
-    %% Generate the bucket JSON document
-    BucketDoc = bucket_json(Bucket, ACL, KeyId),
-    fun() ->
-            velvet:create_bucket(StanchionIp,
-                                 StanchionPort,
-                                 "application/json",
-                                 BucketDoc,
-                                 [{ssl, StanchionSSL},
-                                  {auth_creds, AdminCreds}])
-    end;
-bucket_fun(update_acl, Bucket, ACL, KeyId, AdminCreds, StanchionData) ->
-    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
-    %% Generate the bucket JSON document for the ACL request
-    AclDoc = bucket_acl_json(ACL, KeyId),
-    fun() ->
-            velvet:set_bucket_acl(StanchionIp,
-                                  StanchionPort,
-                                  Bucket,
-                                  "application/json",
-                                  AclDoc,
-                                  [{ssl, StanchionSSL},
-                                   {auth_creds, AdminCreds}])
-    end;
-bucket_fun(update_policy, Bucket, PolicyJson, KeyId, AdminCreds, StanchionData) ->
-    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
-    %% Generate the bucket JSON document for the ACL request
-    PolicyDoc = bucket_policy_json(PolicyJson, KeyId),
-    fun() ->
-            velvet:set_bucket_policy(StanchionIp,
-                                     StanchionPort,
-                                     Bucket,
-                                     "application/json",
-                                     PolicyDoc,
-                                     [{ssl, StanchionSSL},
-                                      {auth_creds, AdminCreds}])
-    end;
-bucket_fun(delete_policy, Bucket, _, KeyId, AdminCreds, StanchionData) ->
-    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
-    %% Generate the bucket JSON document for the ACL request
-    fun() ->
-            velvet:delete_bucket_policy(StanchionIp,
-                                        StanchionPort,
-                                        Bucket,
-                                        KeyId,
-                                        [{ssl, StanchionSSL},
-                                         {auth_creds, AdminCreds}])
-    end;
-bucket_fun(delete, Bucket, _ACL, KeyId, AdminCreds, StanchionData) ->
-    {StanchionIp, StanchionPort, StanchionSSL} = StanchionData,
-    fun() ->
-            velvet:delete_bucket(StanchionIp,
-                                 StanchionPort,
-                                 Bucket,
-                                 KeyId,
-                                 [{ssl, StanchionSSL},
-                                  {auth_creds, AdminCreds}])
-    end.
-
-%% @doc Generate a JSON document to use for a bucket
-%% creation request.
--spec bucket_json(binary(), acl(), string()) -> string().
-bucket_json(Bucket, ACL, KeyId)  ->
-    binary_to_list(
-      iolist_to_binary(
-        mochijson2:encode({struct, [{<<"bucket">>, Bucket},
-                                    {<<"requester">>, list_to_binary(KeyId)},
-                                    stanchion_acl_utils:acl_to_json_term(ACL)]}))).
-
-%% @doc Return a bucket record for the specified bucket name.
--spec bucket_record(binary(), bucket_operation()) -> cs_bucket().
-bucket_record(Name, Operation) ->
-    case Operation of
-        create ->
-            Action = created;
-        delete ->
-            Action = deleted;
-        _ ->
-            Action = undefined
-    end,
-    ?RCS_BUCKET{name=binary_to_list(Name),
-                 last_action=Action,
-                 creation_date=riak_cs_wm_utils:iso_8601_datetime(),
-                 modification_time=os:timestamp()}.
-
-%% @doc Check for and resolve any conflict between
-%% a bucket record from a user record sibling and
-%% a list of resolved bucket records.
--spec bucket_resolver(cs_bucket(), [cs_bucket()]) -> [cs_bucket()].
-bucket_resolver(Bucket, ResolvedBuckets) ->
-    case lists:member(Bucket, ResolvedBuckets) of
-        true ->
-            ResolvedBuckets;
-        false ->
-            case [RB || RB <- ResolvedBuckets,
-                        RB?RCS_BUCKET.name =:=
-                            Bucket?RCS_BUCKET.name] of
-                [] ->
-                    [Bucket | ResolvedBuckets];
-                [ExistingBucket] ->
-                    case keep_existing_bucket(ExistingBucket,
-                                              Bucket) of
-                        true ->
-                            ResolvedBuckets;
-                        false ->
-                            [Bucket | lists:delete(ExistingBucket,
-                                                   ResolvedBuckets)]
-                    end
-            end
-    end.
-
-%% @doc Ordering function for sorting a list of bucket records
-%% according to bucket name.
--spec bucket_sorter(cs_bucket(), cs_bucket()) -> boolean().
-bucket_sorter(?RCS_BUCKET{name=Bucket1},
-              ?RCS_BUCKET{name=Bucket2}) ->
-    Bucket1 =< Bucket2.
-
-%% @doc Return true if the last action for the bucket
-%% is deleted and the action occurred over the configurable
-%% maximum prune-time.
--spec cleanup_bucket(cs_bucket()) -> boolean().
-cleanup_bucket(?RCS_BUCKET{last_action=created}) ->
-    false;
-cleanup_bucket(?RCS_BUCKET{last_action=deleted,
-                            modification_time=ModTime}) ->
-    %% the prune-time is specified in seconds, so we must
-    %% convert Erlang timestamps to seconds first
-    NowSeconds = second_resolution_timestamp(os:timestamp()),
-    ModTimeSeconds = second_resolution_timestamp(ModTime),
-    (NowSeconds - ModTimeSeconds) >
-    riak_cs_config:user_buckets_prune_time().
 
 %% @doc Strip off the user name portion of an email address
 -spec display_name(string()) -> string().
@@ -1399,87 +946,6 @@ is_admin(?RCS_USER{key_id=KeyId, key_secret=KeySecret},
 is_admin(_, _) ->
     false.
 
-%% @doc Determine if an existing bucket from the resolution list
-%% should be kept or replaced when a conflict occurs.
--spec keep_existing_bucket(cs_bucket(), cs_bucket()) -> boolean().
-keep_existing_bucket(?RCS_BUCKET{last_action=LastAction1,
-                                  modification_time=ModTime1},
-                     ?RCS_BUCKET{last_action=LastAction2,
-                                  modification_time=ModTime2}) ->
-    if
-        LastAction1 == LastAction2
-        andalso
-        ModTime1 =< ModTime2 ->
-            true;
-        LastAction1 == LastAction2 ->
-            false;
-        ModTime1 > ModTime2 ->
-            true;
-        true ->
-            false
-    end.
-
-%% @doc Resolve the set of buckets for a user when
-%% siblings are encountered on a read of a user record.
--spec resolve_buckets([rcs_user()], [cs_bucket()], boolean()) ->
-                             [cs_bucket()].
-resolve_buckets([], Buckets, true) ->
-    lists:sort(fun bucket_sorter/2, Buckets);
-resolve_buckets([], Buckets, false) ->
-    lists:sort(fun bucket_sorter/2, [Bucket || Bucket <- Buckets, not cleanup_bucket(Bucket)]);
-resolve_buckets([HeadUserRec | RestUserRecs], Buckets, _KeepDeleted) ->
-    HeadBuckets = HeadUserRec?RCS_USER.buckets,
-    UpdBuckets = lists:foldl(fun bucket_resolver/2, Buckets, HeadBuckets),
-    resolve_buckets(RestUserRecs, UpdBuckets, _KeepDeleted).
-
-%% @doc Shared code used when doing a bucket creation or deletion.
--spec serialized_bucket_op(binary(),
-                           [] | acl() | policy(),
-                           rcs_user(),
-                           riakc_obj:riakc_obj(),
-                           bucket_operation(),
-                           atom(),
-                           pid()) ->
-                                  ok |
-                                  {error, term()}.
-serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatName, RiakPid) ->
-    StartTime = os:timestamp(),
-    case riak_cs_config:admin_creds() of
-        {ok, AdminCreds} ->
-            BucketFun = bucket_fun(BucketOp,
-                                   Bucket,
-                                   ACL,
-                                   User?RCS_USER.key_id,
-                                   AdminCreds,
-                                   stanchion_data()),
-            %% Make a call to the bucket request
-            %% serialization service.
-            OpResult = BucketFun(),
-            case OpResult of
-                ok ->
-                    BucketRecord = bucket_record(Bucket, BucketOp),
-                    case update_user_buckets(User, BucketRecord) of
-                        {ok, ignore} when BucketOp == update_acl ->
-                            ok = riak_cs_stats:update_with_start(StatName,
-                                                                 StartTime),
-                            OpResult;
-                        {ok, ignore} ->
-                            OpResult;
-                        {ok, UpdUser} ->
-                            X = save_user(UpdUser, UserObj, RiakPid),
-                            ok = riak_cs_stats:update_with_start(StatName,
-                                                                 StartTime),
-                            X
-                    end;
-                {error, {error_status, _, _, ErrorDoc}} ->
-                    riak_cs_s3_response:error_response(ErrorDoc);
-                {error, _} ->
-                    OpResult
-            end;
-        {error, Reason1} ->
-            {error, Reason1}
-    end.
-
 %% @doc Validate an email address.
 -spec validate_email(string()) -> ok | {error, term()}.
 validate_email(EmailAddr) ->
@@ -1489,42 +955,6 @@ validate_email(EmailAddr) ->
             {error, invalid_email_address};
         _ ->
             ok
-    end.
-
-%% @doc Update a bucket record to convert the name from binary
-%% to string if necessary.
--spec update_bucket_record(term()) -> cs_bucket().
-update_bucket_record(Bucket=?RCS_BUCKET{name=Name}) when is_binary(Name) ->
-    Bucket?RCS_BUCKET{name=binary_to_list(Name)};
-update_bucket_record(Bucket) ->
-    Bucket.
-
-%% @doc Check if a user already has an ownership of
-%% a bucket and update the bucket list if needed.
--spec update_user_buckets(rcs_user(), cs_bucket()) ->
-                                 {ok, ignore} | {ok, rcs_user()}.
-update_user_buckets(User, Bucket) ->
-    Buckets = User?RCS_USER.buckets,
-    %% At this point any siblings from the read of the
-    %% user record have been resolved so the user bucket
-    %% list should have 0 or 1 buckets that share a name
-    %% with `Bucket'.
-    case [B || B <- Buckets, B?RCS_BUCKET.name =:= Bucket?RCS_BUCKET.name] of
-        [] ->
-            {ok, User?RCS_USER{buckets=[Bucket | Buckets]}};
-        [ExistingBucket] ->
-            case
-                (Bucket?RCS_BUCKET.last_action == deleted andalso
-                 ExistingBucket?RCS_BUCKET.last_action == created)
-                orelse
-                (Bucket?RCS_BUCKET.last_action == created andalso
-                 ExistingBucket?RCS_BUCKET.last_action == deleted) of
-                true ->
-                    UpdBuckets = [Bucket | lists:delete(ExistingBucket, Buckets)],
-                    {ok, User?RCS_USER{buckets=UpdBuckets}};
-                false ->
-                    {ok, ignore}
-            end
     end.
 
 %% @doc Update a user record from a previous version if necessary.
@@ -1538,7 +968,7 @@ update_user_record(User=#moss_user_v1{}) ->
               key_id=User#moss_user_v1.key_id,
               key_secret=User#moss_user_v1.key_secret,
               canonical_id=User#moss_user_v1.canonical_id,
-              buckets=[update_bucket_record(Bucket) ||
+              buckets=[riak_cs_bucket:update_bucket_record(Bucket) ||
                           Bucket <- User#moss_user_v1.buckets]}.
 
 %% @doc Return a user record for the specified user name and

--- a/src/riak_cs_wm_bucket.erl
+++ b/src/riak_cs_wm_bucket.erl
@@ -100,7 +100,7 @@ handle_read_request(RD, Ctx=#context{user=User,
     %% override the content-type on HEAD
     HeadRD = wrq:set_resp_header("content-type", "text/html", RD),
     StrBucket = binary_to_list(Bucket),
-    case [B || B <- riak_cs_utils:get_buckets(User),
+    case [B || B <- riak_cs_bucket:get_buckets(User),
                B?RCS_BUCKET.name =:= StrBucket] of
         [] ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_head">>,
@@ -122,11 +122,11 @@ accept_body(RD, Ctx=#context{user=User,
                              riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_create">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    case riak_cs_utils:create_bucket(User,
-                                     UserObj,
-                                     Bucket,
-                                     ACL,
-                                     RiakPid) of
+    case riak_cs_bucket:create_bucket(User,
+                                      UserObj,
+                                      Bucket,
+                                      ACL,
+                                      RiakPid) of
         ok ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_create">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
@@ -148,10 +148,10 @@ delete_resource(RD, Ctx=#context{user=User,
                                  riakc_pid=RiakPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_delete">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    case riak_cs_utils:delete_bucket(User,
-                                       UserObj,
-                                       Bucket,
-                                       RiakPid) of
+    case riak_cs_bucket:delete_bucket(User,
+                                      UserObj,
+                                      Bucket,
+                                      RiakPid) of
         ok ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_delete">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),

--- a/src/riak_cs_wm_bucket_acl.erl
+++ b/src/riak_cs_wm_bucket_acl.erl
@@ -116,11 +116,11 @@ accept_body(RD, Ctx=#context{user=User,
         end,
     case AclRes of
         {ok, ACL} ->
-            case riak_cs_utils:set_bucket_acl(User,
-                                              UserObj,
-                                              Bucket,
-                                              ACL,
-                                              RiakPid) of
+            case riak_cs_bucket:set_bucket_acl(User,
+                                               UserObj,
+                                               Bucket,
+                                               ACL,
+                                               RiakPid) of
                 ok ->
                     riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_acl">>,
                                                     [200], [riak_cs_wm_utils:extract_name(User), Bucket]),

--- a/src/riak_cs_wm_bucket_location.erl
+++ b/src/riak_cs_wm_bucket_location.erl
@@ -49,7 +49,7 @@ authorize(RD, Ctx) ->
                     {binary() | {'halt', term()}, #wm_reqdata{}, #context{}}.
 to_xml(RD, Ctx=#context{user=User,bucket=Bucket}) ->
     StrBucket = binary_to_list(Bucket),
-    case [B || B <- riak_cs_utils:get_buckets(User),
+    case [B || B <- riak_cs_bucket:get_buckets(User),
                B?RCS_BUCKET.name =:= StrBucket] of
         [] ->
             riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);

--- a/src/riak_cs_wm_bucket_policy.erl
+++ b/src/riak_cs_wm_bucket_policy.erl
@@ -102,7 +102,7 @@ accept_body(RD, Ctx=#context{user=User,
             Access = PolicyMod:reqdata_to_access(RD, bucket_policy, User#rcs_user_v2.canonical_id),
             case PolicyMod:check_policy(Access, Policy) of
                 ok ->
-                    case riak_cs_utils:set_bucket_policy(User, UserObj, Bucket, PolicyJson, RiakPid) of
+                    case riak_cs_bucket:set_bucket_policy(User, UserObj, Bucket, PolicyJson, RiakPid) of
                         ok ->
                             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_policy">>,
                                                             [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
@@ -130,7 +130,7 @@ delete_resource(RD, Ctx=#context{user=User,
     riak_cs_dtrace:dt_object_entry(?MODULE, <<"bucket_policy_delete">>,
                                    [], [RD, Ctx, RiakPid]),
 
-    case riak_cs_utils:delete_bucket_policy(User, UserObj, Bucket, RiakPid) of
+    case riak_cs_bucket:delete_bucket_policy(User, UserObj, Bucket, RiakPid) of
         ok ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_put_policy">>,
                                             [200], [riak_cs_wm_utils:extract_name(User), Bucket]),

--- a/src/riak_cs_wm_bucket_versioning.erl
+++ b/src/riak_cs_wm_bucket_versioning.erl
@@ -49,7 +49,7 @@ authorize(RD, Ctx) ->
                     {binary() | {halt, term()}, #wm_reqdata{}, #context{}}.
 to_xml(RD, Ctx=#context{user=User,bucket=Bucket}) ->
     StrBucket = binary_to_list(Bucket),
-    case [B || B <- riak_cs_utils:get_buckets(User),
+    case [B || B <- riak_cs_bucket:get_buckets(User),
                B?RCS_BUCKET.name =:= StrBucket] of
         [] ->
             riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);

--- a/src/riak_cs_wm_objects.erl
+++ b/src/riak_cs_wm_objects.erl
@@ -56,7 +56,7 @@ api_request(RD, Ctx=#context{bucket=Bucket,
     UserName = riak_cs_wm_utils:extract_name(User),
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"list_keys">>, [], [UserName, Bucket]),
     Res = riak_cs_api:list_objects(
-            [B || B <- riak_cs_utils:get_buckets(User),
+            [B || B <- riak_cs_bucket:get_buckets(User),
                   B?RCS_BUCKET.name =:= binary_to_list(Bucket)],
             Ctx#context.bucket,
             get_max_keys(RD),

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -241,7 +241,7 @@ validate_auth_header(RD, AuthBypass, RiakPid, Ctx) ->
 -spec ensure_doc(term(), pid()) -> term().
 ensure_doc(KeyCtx=#key_context{bucket_object=undefined,
                                bucket=Bucket}, RiakcPid) ->
-    case riak_cs_utils:fetch_bucket_object(Bucket, RiakcPid) of
+    case riak_cs_bucket:fetch_bucket_object(Bucket, RiakcPid) of
         {ok, Obj} ->
             setup_manifest(KeyCtx#key_context{bucket_object = Obj}, RiakcPid);
         {error, Reason} when Reason =:= notfound orelse Reason =:= no_such_bucket ->
@@ -430,7 +430,7 @@ bucket_obj_from_local_context(#key_context{bucket_object=BucketObject},
                               _BucketName, _Pid) ->
     {ok, BucketObject};
 bucket_obj_from_local_context(undefined, BucketName, RiakcPid) ->
-    case riak_cs_utils:fetch_bucket_object(BucketName, RiakcPid) of
+    case riak_cs_bucket:fetch_bucket_object(BucketName, RiakcPid) of
         {error, notfound} ->
             {ok, undefined};
         {error, no_such_bucket} ->
@@ -620,7 +620,7 @@ bucket_access_authorize_helper(AccessType, Deletable, RD, Ctx) ->
     PermCtx = Ctx#context{bucket=Bucket,
                           requested_perm=RequestedAccess},
     handle_bucket_acl_policy_response(
-      riak_cs_utils:get_bucket_acl_policy(Bucket, PolicyMod, RiakPid),
+      riak_cs_bucket:get_bucket_acl_policy(Bucket, PolicyMod, RiakPid),
       AccessType,
       Deletable,
       RD,
@@ -702,7 +702,7 @@ handle_policy_eval_result(User, _, _, RD, Ctx) ->
     AccessRD = riak_cs_access_log_handler:set_user(User, RD),
     %% Check if the bucket actually exists so we can
     %% make the correct decision to return a 404 or 403
-    case riak_cs_utils:fetch_bucket_object(Bucket, RiakPid) of
+    case riak_cs_bucket:fetch_bucket_object(Bucket, RiakPid) of
         {ok, _} ->
             riak_cs_wm_utils:deny_access(AccessRD, Ctx);
         {error, Reason} ->

--- a/test/riak_cs_bucket_name_test.erl
+++ b/test/riak_cs_bucket_name_test.erl
@@ -55,6 +55,6 @@ invalid_names() ->
 
 make_test_from_name_and_success(Name, Success) ->
     ?_assertEqual(Success,
-                  riak_cs_utils:valid_bucket_name(Name)).
+                  riak_cs_bucket:valid_bucket_name(Name)).
 
 -endif.

--- a/test/riak_cs_bucket_test.erl
+++ b/test/riak_cs_bucket_test.erl
@@ -1,0 +1,109 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_bucket_test).
+
+-compile(export_all).
+
+-ifdef(TEST).
+-include("riak_cs.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+handle_delete_response_test() ->
+    ErrorDoc =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Error>"
+        " <Code>MultipartUploadRemaining</Code> <Message>Multipart uploads still remaining.</Message>"
+        "<Resource>/buckets/riak-test-bucket</Resource><RequestId></RequestId></Error>",
+    %% which is defined at stanchion_response.erl
+    ?assertEqual({error, remaining_multipart_upload},
+                 riak_cs_bucket:handle_stanchion_response(409, ErrorDoc, delete, <<>>)),
+    ?assertThrow({remaining_multipart_upload_on_deleted_bucket, <<>>},
+                 riak_cs_bucket:handle_stanchion_response(409, ErrorDoc, create, <<>>)),
+    ErrorResponse = riak_cs_s3_response:error_response(ErrorDoc),
+    ?assertEqual(ErrorResponse,
+                 riak_cs_bucket:handle_stanchion_response(503, ErrorDoc, delete, <<>>)),
+    ?assertEqual(ErrorResponse,
+                 riak_cs_bucket:handle_stanchion_response(204, ErrorDoc, delete, <<>>)).
+
+
+bucket_resolution_test() ->
+    %% @TODO Replace or augment this with eqc testing.
+    UserRecord = riak_cs_utils:user_record("uncle fester",
+                                           "fester@tester.com",
+                                           "festersquest",
+                                           "wasthebest"),
+    BucketList1 = [riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket2">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket3">>, create)],
+    BucketList2 = [riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, create)],
+    BucketList3 = [riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, delete),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, create)],
+    BucketList4 = [riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, create),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, delete)],
+    BucketList5 = [riak_cs_bucket:bucket_record(<<"bucket1">>, delete),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, delete),
+                   riak_cs_bucket:bucket_record(<<"bucket1">>, delete)],
+    Obj1 = riakc_obj:new_obj(<<"bucket">>,
+                            <<"key">>,
+                            <<"value">>,
+                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
+                                Buckets <- BucketList1]),
+    Obj2 = riakc_obj:new_obj(<<"bucket">>,
+                            <<"key">>,
+                            <<"value">>,
+                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
+                                Buckets <- BucketList2]),
+    Obj3 = riakc_obj:new_obj(<<"bucket">>,
+                            <<"key">>,
+                            <<"value">>,
+                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
+                                Buckets <- BucketList3]),
+    Obj4 = riakc_obj:new_obj(<<"bucket">>,
+                            <<"key">>,
+                            <<"value">>,
+                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
+                                Buckets <- BucketList4]),
+    Obj5 = riakc_obj:new_obj(<<"bucket">>,
+                            <<"key">>,
+                            <<"value">>,
+                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
+                                Buckets <- BucketList5]),
+    Values1 = riakc_obj:get_values(Obj1),
+    Values2 = riakc_obj:get_values(Obj2),
+    Values3 = riakc_obj:get_values(Obj3),
+    Values4 = riakc_obj:get_values(Obj4),
+    Values5 = riakc_obj:get_values(Obj5),
+    ResBuckets1 = riak_cs_bucket:resolve_buckets(Values1, [], true),
+    ResBuckets2 = riak_cs_bucket:resolve_buckets(Values2, [], true),
+    ResBuckets3 = riak_cs_bucket:resolve_buckets(Values3, [], true),
+    ResBuckets4 = riak_cs_bucket:resolve_buckets(Values4, [], true),
+    ResBuckets5 = riak_cs_bucket:resolve_buckets(Values5, [], true),
+    ?assertEqual(BucketList1, ResBuckets1),
+    ?assertEqual([hd(BucketList2)], ResBuckets2),
+    ?assertEqual([hd(lists:reverse(BucketList3))], ResBuckets3),
+    ?assertEqual([hd(lists:reverse(BucketList4))], ResBuckets4),
+    ?assertEqual([hd(BucketList5)], ResBuckets5).
+
+
+-endif.

--- a/test/riak_cs_utils_test.erl
+++ b/test/riak_cs_utils_test.erl
@@ -90,10 +90,10 @@ bucket_appears() ->
     BucketName = "fooser-bucket",
     {ok, User} = riak_cs_utils:create_user(Name, Email),
     KeyID = User?RCS_USER.key_id,
-    riak_cs_utils:create_bucket(KeyID, BucketName),
+    riak_cs_bucket:create_bucket(KeyID, BucketName),
     {ok, UserAfter} = riak_cs_utils:get_user(KeyID),
     AfterBucketNames = [B#moss_bucket.name ||
-                           B <- riak_cs_utils:get_buckets(UserAfter)],
+                           B <- riak_cs_bucket:get_buckets(UserAfter)],
     {"bucket appears test",
      fun() ->
              [
@@ -117,11 +117,11 @@ key_appears() ->
     KeyName = "testkey",
     {ok, User} = riak_cs_utils:create_user(Name, Email),
     KeyID = User?RCS_USER.key_id,
-    ok = riak_cs_utils:create_bucket(KeyID, BucketName),
+    ok = riak_cs_bucket:create_bucket(KeyID, BucketName),
     riak_cs_utils:put_object(BucketName, KeyName,
                                "value", dict:new()),
 
-    {ok, ListKeys} = riak_cs_utils:list_keys(BucketName),
+    {ok, ListKeys} = riak_cs_bucket:list_keys(BucketName),
     {"key appears test",
      fun() ->
              [
@@ -142,7 +142,7 @@ content_type_sticks() ->
     Metadata = dict:from_list([{<<"content-type">>, CType}]),
     {ok, User} = riak_cs_utils:create_user(Name, Email),
     KeyID = User?RCS_USER.key_id,
-    ok = riak_cs_utils:create_bucket(KeyID, BucketName),
+    ok = riak_cs_bucket:create_bucket(KeyID, BucketName),
     riak_cs_utils:put_object(BucketName, KeyName,
                                <<"value">>, Metadata),
     {ok, Object} = riak_cs_utils:get_object(BucketName, KeyName),
@@ -165,13 +165,13 @@ keys_are_sorted() ->
 
     {ok, User} = riak_cs_utils:create_user(Name, Email),
     KeyID = User?RCS_USER.key_id,
-    ok = riak_cs_utils:create_bucket(KeyID, BucketName),
+    ok = riak_cs_bucket:create_bucket(KeyID, BucketName),
 
     [riak_cs_utils:put_object(BucketName, binary_to_list(KeyName),
                                 "value", dict:new()) ||
         KeyName <- Keys],
 
-    {ok, ListKeys} = riak_cs_utils:list_keys(BucketName),
+    {ok, ListKeys} = riak_cs_bucket:list_keys(BucketName),
     {"keys are sorted test",
      fun() ->
              [
@@ -240,68 +240,6 @@ nonexistent_deletes() ->
              ]
      end
     }.
-
-bucket_resolution_test() ->
-    %% @TODO Replace or augment this with eqc testing.
-    UserRecord = riak_cs_utils:user_record("uncle fester",
-                                           "fester@tester.com",
-                                           "festersquest",
-                                           "wasthebest"),
-    BucketList1 = [riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket2">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket3">>, create)],
-    BucketList2 = [riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, create)],
-    BucketList3 = [riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, delete),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, create)],
-    BucketList4 = [riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, create),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, delete)],
-    BucketList5 = [riak_cs_utils:bucket_record(<<"bucket1">>, delete),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, delete),
-                   riak_cs_utils:bucket_record(<<"bucket1">>, delete)],
-    Obj1 = riakc_obj:new_obj(<<"bucket">>,
-                            <<"key">>,
-                            <<"value">>,
-                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
-                                Buckets <- BucketList1]),
-    Obj2 = riakc_obj:new_obj(<<"bucket">>,
-                            <<"key">>,
-                            <<"value">>,
-                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
-                                Buckets <- BucketList2]),
-    Obj3 = riakc_obj:new_obj(<<"bucket">>,
-                            <<"key">>,
-                            <<"value">>,
-                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
-                                Buckets <- BucketList3]),
-    Obj4 = riakc_obj:new_obj(<<"bucket">>,
-                            <<"key">>,
-                            <<"value">>,
-                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
-                                Buckets <- BucketList4]),
-    Obj5 = riakc_obj:new_obj(<<"bucket">>,
-                            <<"key">>,
-                            <<"value">>,
-                            [{[], UserRecord?RCS_USER{buckets=[Buckets]}} ||
-                                Buckets <- BucketList5]),
-    Values1 = riakc_obj:get_values(Obj1),
-    Values2 = riakc_obj:get_values(Obj2),
-    Values3 = riakc_obj:get_values(Obj3),
-    Values4 = riakc_obj:get_values(Obj4),
-    Values5 = riakc_obj:get_values(Obj5),
-    ResBuckets1 = riak_cs_utils:resolve_buckets(Values1, [], true),
-    ResBuckets2 = riak_cs_utils:resolve_buckets(Values2, [], true),
-    ResBuckets3 = riak_cs_utils:resolve_buckets(Values3, [], true),
-    ResBuckets4 = riak_cs_utils:resolve_buckets(Values4, [], true),
-    ResBuckets5 = riak_cs_utils:resolve_buckets(Values5, [], true),
-    ?assertEqual(BucketList1, ResBuckets1),
-    ?assertEqual([hd(BucketList2)], ResBuckets2),
-    ?assertEqual([hd(lists:reverse(BucketList3))], ResBuckets3),
-    ?assertEqual([hd(lists:reverse(BucketList4))], ResBuckets4),
-    ?assertEqual([hd(BucketList5)], ResBuckets5).
 
 hash_test() ->
     %% to prevent undef or else


### PR DESCRIPTION
(squashed version of #842)

There was a security issue that flaws remaining multipart uploads,
where an newly created bucket may include unaborted or uncompleted
multipart uploads which was created in previous epoch of the bucket
with same name. This commit fixes it by:
- on creating buckets;
  - check if live multipart exists
  - if exists, return 500 failure to client
- on deleting buckets;
  - try to clean up all live multipart remains
  - check if live multipart remains (in stanchion)
  - if exists, return 409 failure to client
- after upgrading from 1.4.x (or former) to 1.5.0;
  - run `riak_cs_console:cleanup_orphan_multipart/0` or
    `riak_cs_console:cleanup_orphan_multipart/1` in an
    attached console to cleanup all buckets
  - there might be a time period until above cleanup
    finished, where no client can create bucket if
    unfinished multipart upload remains under deleted
    bucket. You can find [critical] log if such bucket
    creation is attempted.

This commit also inclues:
- cut out bucket related operations from riak_cs_utils to riak_cs_bucket
- riak_test (riak_cs_buckets_test) to check bucket related tests
