### PR TITLE
Bugfix/remove error log of anonymous access

### DIFF
--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -214,6 +214,10 @@ maybe_create_user({error, NE}, KeyId, s3, riak_cs_keystone_auth, {UserData, _}, 
     %% Attempt to create a Riak CS user to represent the OS tenant
     _ = riak_cs_utils:create_user(Name, Email, KeyId, Secret),
     riak_cs_utils:get_user(KeyId, RcPid);
+maybe_create_user({error, no_user_key}=Error, _, _, _, _, _) ->
+    %% Anonymous access may be authorized by ACL or policy afterwards,
+    %% no logging here.
+    Error;
 maybe_create_user({error, Reason}=Error, _, Api, _, _, _) ->
     _ = lager:error("Retrieval of user record for ~p failed. Reason: ~p",
                     [Api, Reason]),

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -22,7 +22,6 @@
 
 -export([service_available/2,
          service_available/3,
-         parse_auth_header/2,
          iso_8601_datetime/0,
          iso_8601_datetime/1,
          to_iso_8601/1,
@@ -96,10 +95,6 @@ service_available(Pool, RD, Ctx) ->
                                                  string() | undefined}.
 parse_auth_header(KeyId, true) when KeyId =/= undefined ->
     {riak_cs_passthru_auth, KeyId, undefined};
-parse_auth_header(_, true) ->
-    {riak_cs_passthru_auth, [], undefined};
-parse_auth_header(undefined, false) ->
-    {riak_cs_blockall_auth, undefined, undefined};
 parse_auth_header("AWS " ++ Key, _) ->
     case string:tokens(Key, ":") of
         [KeyId, KeyData] ->

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -113,8 +113,8 @@ parse_auth_header(_, _) ->
                                                            string() | undefined}.
 parse_auth_params(KeyId, _, true) when KeyId =/= undefined ->
     {riak_cs_passthru_auth, KeyId, undefined};
-parse_auth_params(_, _, true) ->
-    {riak_cs_passthru_auth, [], undefined};
+parse_auth_params(undefined, _, true) ->
+    {riak_cs_passthru_auth, undefined, undefined};
 parse_auth_params(undefined, _, false) ->
     {riak_cs_blockall_auth, undefined, undefined};
 parse_auth_params(_, undefined, _) ->


### PR DESCRIPTION
Original issue #876 
- Removed `no_user_key` error log 152793b
- Changed handling of `undefind` for user key to avoid error messages like
  `Retrieval of user record for [] failed. Reason: <<"Key cannot be zero-length">>' .
  These logs happened when access admin resources`/riak-cs/users`as anonymous
  with configuration`{admin_auth_enabled, false}`.
