### PR TITLE
Reduce execution time of repl test (v2 and v3)

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -241,6 +241,7 @@ cs_config(UserExtra, OtherApps) ->
              {request_pool, {request_pool_size(), 0} },
              {bucket_list_pool, {bucket_list_pool_size(), 0} }
             ]},
+           {block_get_max_retries, 1},
            {proxy_get, enabled},
            {anonymous_user_creation, true},
            {riak_pb_port, 10017},

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -114,8 +114,6 @@ confirm() ->
     LeaderB = rpc:call(hd(BNodes), riak_repl_leader, leader_node, []),
     repl_helpers:del_site(LeaderB, "site1"),
 
-    timer:sleep(5000),
-
     lager:info("check we can still read the fullsynced object"),
 
     Obj3 = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C2Config),

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -131,14 +131,9 @@ confirm() ->
     erlcloud_s3:put_object(?TEST_BUCKET, "object_three", Object3, U1C1Config),
 
     lager:info("disable proxy_get"),
-
     disable_pg(LeaderA, "B", ANodes, BNodes, BPort),
 
-    %% not sure what this is for, but I'm not going to touch it right now
-    timer:sleep(5000),
-
     lager:info("check we can still read the fullsynced object"),
-
     Obj3 = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C2Config),
     ?assertEqual(Object1, proplists:get_value(content,Obj3)),
 
@@ -282,6 +277,5 @@ set_proxy_get(SourceLeader, EnableOrDisable, SinkName, ANodes, BNodes) ->
     end,
     rt:wait_until_ring_converged(ANodes),
     rt:wait_until_ring_converged(BNodes),
-    timer:sleep(10000).
-
+    ok.
 


### PR DESCRIPTION
The most time consuming part is five retries for getting blocks.
After making retry number configurable, use small number `1` for testing.

There are also some misc refinement such as removing sleep or replacing sleep with `wait_until`.

One example of execution times are as follows.

Before
- repl_test  20.78s user 8.88s system 7% cpu 6:26.88 total
- repl_v3_test  21.25s user 9.68s system 6% cpu 7:44.34 total

After
- repl_test  21.09s user 10.34s system 41% cpu 1:15.17 total
- repl_v3_test  20.61s user 9.04s system 23% cpu 2:04.00 total
