### PR TITLE
update deps to the latest

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,15 +36,16 @@
 
 {deps, [
         {node_package, "1.3.8", {git, "git://github.com/basho/node_package", {tag, "1.3.8"}}},
+        {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.1"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.2"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.3"}}},
-        {eper, ".*", {git, "git://github.com/basho/eper.git", "7f94808f958e810b477e096a4960ee90ea9c0f4b"}},
+        {eper, ".*", {git, "git://github.com/basho/eper.git", "0.78"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "4bb0fd664ff065c4082ca8dd2e0683e920537d15"}},
-        {poolboy, "0.8.1", {git, "git://github.com/basho/poolboy", "0e15b5dcbff89b3d1d4021591f90375d4d2ee9a1"}},
-        {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.7.4"}}},
+        {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p2"}},
+        {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.1"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "1.2.4"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}}
@@ -52,5 +53,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "develop"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.0beta1"}}}
           ]}.


### PR DESCRIPTION
- eper to 0.78, same as riak develop
- riak-erlang-client to 1.4.2, which includes [cs bucket list fix](https://github.com/basho/riak-erlang-client/commit/01cdc125c1c8f14a40309f8fdb45587a3b28e37f)
- ~~webmachine to 1.10.6~~
- poolboy to 0.8.1p1
- folsom to 0.8.1
