### PR TITLE
Deterministic bag choice by seed and bug fixes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,5 +53,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "release/1.5"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "master"}}}
           ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -53,5 +53,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.0beta1"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "release/1.5"}}}
           ]}.

--- a/riak_test/src/rc_helper.erl
+++ b/riak_test/src/rc_helper.erl
@@ -38,7 +38,7 @@ to_riak_key(_,_) ->
 
 -spec get_riakc_obj([term()], objects | blocks, binary(), term()) -> term().
 get_riakc_obj(RiakNodes, Kind, CsBucket, CsKey) ->
-    Pbc = rtcs:pbc(RiakNodes, Kind, CsBucket, CsKey),
+    Pbc = rtcs:pbc(RiakNodes, Kind, CsBucket),
     RiakBucket = to_riak_bucket(Kind, CsBucket),
     RiakKey = to_riak_key(Kind, CsKey),
     Result = riakc_pb_socket:get(Pbc, RiakBucket, RiakKey),
@@ -49,7 +49,7 @@ get_riakc_obj(RiakNodes, Kind, CsBucket, CsKey) ->
 update_riakc_obj(RiakNodes, ObjectKind, CsBucket, CsKey, NewObj) ->
     NewMD = riakc_obj:get_metadata(NewObj),
     NewValue = riakc_obj:get_value(NewObj),
-    Pbc = rtcs:pbc(RiakNodes, ObjectKind, CsBucket, CsKey),
+    Pbc = rtcs:pbc(RiakNodes, ObjectKind, CsBucket),
     RiakBucket = to_riak_bucket(ObjectKind, CsBucket),
     RiakKey = to_riak_key(ObjectKind, CsKey),
     Result = case riakc_pb_socket:get(Pbc, RiakBucket, RiakKey, [deletedvclock]) of

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -74,15 +74,16 @@ setup2x2(Configs) ->
               end,
     setup_clusters(Configs, JoinFun, 4).
 
-setupNx1x1(N) ->
-    setupNx1x1(N, default_configs()).
+%% 1 cluster with N nodes + M cluster with 1 node
+setupNxMsingles(N, M) ->
+    setupNxMsingles(N, M, default_configs()).
 
-setupNx1x1(N, Configs) ->
+setupNxMsingles(N, M, Configs) ->
     JoinFun = fun(Nodes) ->
                       [Target | Joiners] = lists:sublist(Nodes, N),
                       [join(J, Target) || J <- Joiners]
               end,
-    setup_clusters(Configs, JoinFun, N + 1 + 1).
+    setup_clusters(Configs, JoinFun, N + M).
 
 flavored_setup(NumNodes, basic, Configs) ->
     JoinFun = fun(Nodes) ->
@@ -700,13 +701,13 @@ wait_until(Fun, Condition, Retries, Delay) ->
     end.
 
 %% Kind = objects | blocks | users | buckets ...
-pbc(RiakNodes, ObjectKind, CsBucket, CsKey) ->
-    pbc(rt_config:get(flavor, basic), ObjectKind, RiakNodes, CsBucket, CsKey).
+pbc(RiakNodes, ObjectKind, Opts) ->
+    pbc(rt_config:get(flavor, basic), ObjectKind, RiakNodes, Opts).
 
-pbc(basic, _ObjectKind, RiakNodes, _CsBucket, _CsKey) ->
+pbc(basic, _ObjectKind, RiakNodes, _Opts) ->
     rt:pbc(hd(RiakNodes));
-pbc({multibag, _} = Flavor, ObjectKind, RiakNodes, CsBucket, CsKey) ->
-    rtcs_bag:pbc(Flavor, ObjectKind, RiakNodes, CsBucket, CsKey).
+pbc({multibag, _} = Flavor, ObjectKind, RiakNodes, Opts) ->
+    rtcs_bag:pbc(Flavor, ObjectKind, RiakNodes, Opts).
 
 make_authorization(Method, Resource, ContentType, Config, Date) ->
     StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n, Resource],

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -56,7 +56,7 @@ confirm() ->
             O <- proplists:get_value(contents, ObjList2)]),
 
     Obj = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C1Config),
-    ?assertEqual(Object1, proplists:get_value(content, Obj)),
+    assert_content(Object1, proplists:get_value(content, Obj)),
 
     lager:info("set up replication between clusters"),
 
@@ -98,7 +98,7 @@ confirm() ->
     lager:info("Object written on primary cluster is readable from secondary "
         "cluster"),
     Obj2 = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C2Config),
-    ?assertEqual(Object1, proplists:get_value(content, Obj2)),
+    assert_content(Object1, proplists:get_value(content, Obj2)),
 
     lager:info("write 2 more objects to the primary cluster"),
 
@@ -117,7 +117,7 @@ confirm() ->
     lager:info("check we can still read the fullsynced object"),
 
     Obj3 = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C2Config),
-    ?assertEqual(Object1, proplists:get_value(content,Obj3)),
+    assert_content(Object1, proplists:get_value(content,Obj3)),
 
     lager:info("check all 3 objects are listed on the secondary cluster"),
     ?assertEqual(["object_one", "object_three", "object_two"],
@@ -137,7 +137,7 @@ confirm() ->
 
     lager:info("check we can read object_two via proxy get"),
     Obj6 = erlcloud_s3:get_object(?TEST_BUCKET, "object_two", U1C2Config),
-    ?assertEqual(Object2, proplists:get_value(content, Obj6)),
+    assert_content(Object2, proplists:get_value(content, Obj6)),
 
     lager:info("disconnect the clusters again"),
     repl_helpers:del_site(LeaderB, "site1"),
@@ -149,7 +149,7 @@ confirm() ->
     lager:info("check that proxy getting object_two wrote it locally, so we"
         " can read it"),
     Obj8 = erlcloud_s3:get_object(?TEST_BUCKET, "object_two", U1C2Config),
-    ?assertEqual(Object2, proplists:get_value(content, Obj8)),
+    assert_content(Object2, proplists:get_value(content, Obj8)),
 
     lager:info("delete object_one while clusters are disconnected"),
     erlcloud_s3:delete_object(?TEST_BUCKET, "object_one", U1C1Config),
@@ -162,7 +162,7 @@ confirm() ->
 
     lager:info("object_one is still visible on secondary cluster"),
     Obj9 = erlcloud_s3:get_object(?TEST_BUCKET, "object_one", U1C2Config),
-    ?assertEqual(Object1, proplists:get_value(content, Obj9)),
+    assert_content(Object1, proplists:get_value(content, Obj9)),
 
     lager:info("object_two is deleted"),
     ?assertError({aws_error, _},
@@ -207,26 +207,26 @@ confirm() ->
 
     lager:info("secondary cluster has old version of object three"),
     Obj10 = erlcloud_s3:get_object(?TEST_BUCKET, "object_three", U1C2Config),
-    ?assertEqual(Object3, proplists:get_value(content, Obj10)),
+    assert_content(Object3, proplists:get_value(content, Obj10)),
 
     lager:info("secondary cluster has 'B' version of object four"),
     Obj11 = erlcloud_s3:get_object(?TEST_BUCKET, "object_four", U1C2Config),
-    ?assertEqual(Object4B, proplists:get_value(content, Obj11)),
+    assert_content(Object4B, proplists:get_value(content, Obj11)),
 
     repl_helpers:start_and_wait_until_fullsync_complete(LeaderA),
 
     lager:info("secondary cluster has new version of object three"),
     Obj12 = erlcloud_s3:get_object(?TEST_BUCKET, "object_three", U1C2Config),
-    ?assertEqual(Object3A, proplists:get_value(content, Obj12)),
+    assert_content(Object3A, proplists:get_value(content, Obj12)),
 
     lager:info("secondary cluster has 'B' version of object four"),
     Obj13 = erlcloud_s3:get_object(?TEST_BUCKET, "object_four", U1C2Config),
-    ?assertEqual(Object4B, proplists:get_value(content, Obj13)),
+    assert_content(Object4B, proplists:get_value(content, Obj13)),
 
     lager:info("secondary cluster has 'A' version of object five, because it "
         "was written later"),
     Obj14 = erlcloud_s3:get_object(?TEST_BUCKET, "object_five", U1C2Config),
-    ?assertEqual(Object5A, proplists:get_value(content, Obj14)),
+    assert_content(Object5A, proplists:get_value(content, Obj14)),
 
     lager:info("write 'A' version of object four again on primary cluster"),
 
@@ -235,5 +235,15 @@ confirm() ->
     lager:info("secondary cluster now has 'A' version of object four"),
 
     Obj15 = erlcloud_s3:get_object(?TEST_BUCKET, "object_four", U1C2Config),
-    ?assertEqual(Object4A, proplists:get_value(content,Obj15)),
+    assert_content(Object4A, proplists:get_value(content,Obj15)),
     pass.
+
+assert_content(Expected, Expected) ->
+    ok;
+assert_content(Expected, Actual) ->
+    lager:error("assert_content failed"),
+    lager:error("Expected length: ~p~n", [length(Expected)]),
+    lager:error("Actual length  : ~p~n", [length(Actual)]),
+    Prefix = binary:longest_common_prefix([Expected, Actual]),
+    lager:error("Common prefix length: ~p~n", [length(Prefix)]),
+    error(asset_content_fail).

--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -278,7 +278,7 @@ new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5,
                    cluster_id()) -> lfs_manifest().
 new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5,
              MetaData, BlockSize, Acl, Props, ClusterID) ->
-    BagId = riak_cs_mb_helper:choose_bag_id(block),
+    BagId = riak_cs_mb_helper:choose_bag_id(block, {Bucket, FileName, UUID}),
     new_manifest(Bucket, FileName, UUID, ContentLength, ContentType, ContentMd5,
                  MetaData, BlockSize, Acl, Props, ClusterID, BagId).
 

--- a/src/riak_cs_mb_helper.erl
+++ b/src/riak_cs_mb_helper.erl
@@ -23,7 +23,7 @@
 -module(riak_cs_mb_helper).
 
 -export([process_specs/0, bags/0,
-         choose_bag_id/1,
+         choose_bag_id/2,
          set_bag_id_to_manifest/2,
          bag_id_from_manifest/1]).
 
@@ -44,8 +44,8 @@ bags() ->
     ?MB_ENABLED([{<<"master">>, MasterAddress, MasterPort}],
                 riak_cs_multibag:bags()).
 
-choose_bag_id(PoolType) ->
-    ?MB_ENABLED(undefined, riak_cs_multibag:choose_bag_id(PoolType)).
+choose_bag_id(PoolType, Seed) ->
+    ?MB_ENABLED(undefined, riak_cs_multibag:choose_bag_id(PoolType, Seed)).
 
 set_bag_id_to_manifest(undefined, Manifest) ->
     Manifest;

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -472,11 +472,12 @@ do_part_common2(upload_part, RcPid, M, _Obj, MpM, Props) ->
     {Bucket, Key, _UploadId, _Caller, PartNumber, Size} =
         proplists:get_value(upload_part, Props),
     BlockSize = riak_cs_lfs_utils:block_size(),
+    BagId = riak_cs_mb_helper:bag_id_from_manifest(M),
     {ok, PutPid} = riak_cs_put_fsm:start_link(
                      {Bucket, Key, Size, <<"x-riak/multipart-part">>,
                       orddict:new(), BlockSize, M?MANIFEST.acl,
                       infinity, self(), RcPid},
-                     false),
+                     {false, BagId}),
     try
         ?MANIFEST{content_length = ContentLength,
                   props = MProps} = M,

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -63,7 +63,7 @@
                 reply_pid :: {pid(), reference()},
                 riak_client :: riak_client(),
                 mani_pid :: undefined | pid(),
-                make_new_manifest_p :: boolean(),
+                make_new_manifest_p ::  true | {false, bag_id()},
                 timer_ref :: reference(),
                 bucket :: binary(),
                 key :: binary(),

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -63,7 +63,7 @@
                 reply_pid :: {pid(), reference()},
                 riak_client :: riak_client(),
                 mani_pid :: undefined | pid(),
-                make_new_manifest_p ::  true | {false, bag_id()},
+                make_new_manifest_p :: true | {false, bag_id()},
                 timer_ref :: reference(),
                 bucket :: binary(),
                 key :: binary(),

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -94,7 +94,7 @@ start_link(Tuple) when is_tuple(Tuple) ->
 
 -spec start_link({binary(), binary(), non_neg_integer(), binary(),
                   term(), pos_integer(), acl(), timeout(), pid(), riak_client()},
-                 boolean()) ->
+                 true | {false, bag_id()}) ->
                         {ok, pid()} | {error, term()}.
 start_link({_Bucket,
             _Key,
@@ -141,7 +141,7 @@ block_written(Pid, BlockID) ->
 %% make things more confusing?
 -spec init({{binary(), binary(), non_neg_integer(), binary(),
              term(), pos_integer(), acl(), timeout(), pid(), riak_client()},
-            term()}) ->
+            true | {false, bag_id()}}) ->
                   {ok, prepare, #state{}, timeout()}.
 init({{Bucket, Key, ContentLength, ContentType,
        Metadata, BlockSize, Acl, Timeout, Caller, RcPid},
@@ -399,19 +399,35 @@ prepare(State=#state{bucket=Bucket,
     %% this shouldn't be hardcoded.
     %% for now, always populate cluster_id
     ClusterID = riak_cs_config:cluster_id(RcPid),
-    Manifest =
-        riak_cs_lfs_utils:new_manifest(Bucket,
-                                       Key,
-                                       UUID,
-                                       ContentLength,
-                                       ContentType,
-                                       %% we don't know the md5 yet
-                                       undefined,
-                                       Metadata,
-                                       BlockSize,
-                                       Acl,
-                                       [],
-                                       ClusterID),
+    Manifest = case MakeNewManifestP of
+                true ->
+                       riak_cs_lfs_utils:new_manifest(Bucket,
+                                                      Key,
+                                                      UUID,
+                                                      ContentLength,
+                                                      ContentType,
+                                                      %% we don't know the md5 yet
+                                                      undefined,
+                                                      Metadata,
+                                                      BlockSize,
+                                                      Acl,
+                                                      [],
+                                                      ClusterID);
+                {false, BagId} ->
+                       riak_cs_lfs_utils:new_manifest(Bucket,
+                                                      Key,
+                                                      UUID,
+                                                      ContentLength,
+                                                      ContentType,
+                                                      %% we don't know the md5 yet
+                                                      undefined,
+                                                      Metadata,
+                                                      BlockSize,
+                                                      Acl,
+                                                      [],
+                                                      ClusterID,
+                                                      BagId)
+               end,
     NewManifest = Manifest?MANIFEST{write_start_time=os:timestamp()},
 
     Md5 = riak_cs_utils:md5_init(),
@@ -633,7 +649,7 @@ handle_receiving_last_chunk(NewData, State=#state{buffer_queue=BufferQueue,
     Reply = ok,
     {reply, Reply, all_received, NewStateData}.
 
-maybe_riak_cs_manifest_fsm_start_link(false, _Bucket, _Key, _RcPid) ->
+maybe_riak_cs_manifest_fsm_start_link({false, _BagId}, _Bucket, _Key, _RcPid) ->
     {ok, undefined};
 maybe_riak_cs_manifest_fsm_start_link(true, Bucket, Key, RcPid) ->
     riak_cs_manifest_fsm:start_link(Bucket, Key, RcPid).

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -92,8 +92,8 @@ sum_bucket(BucketName) ->
               [do_prereduce], false},
              {reduce, {modfun, riak_cs_storage, object_size_reduce},
               none, true}],
-    %% Manifests may exists in different bag for each bucket,
-    %% use new one to map/reduce and fetch manifest objects.
+    %% We cannot reuse RcPid because different bucket may use different bag.
+    %% This is why each sum_bucket/1 call retrieves new client on every bucket.
     {ok, RcPid} = riak_cs_riak_client:checkout(),
     try
         ok = riak_cs_riak_client:set_bucket_name(RcPid, BucketName),

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -26,7 +26,7 @@
 
 -export([
          sum_user/2,
-         sum_bucket/2,
+         sum_bucket/1,
          make_object/4,
          get_usage/4,
          archive_period/0
@@ -52,7 +52,7 @@ sum_user(RcPid, User) when is_binary(User) ->
 sum_user(RcPid, User) when is_list(User) ->
     case riak_cs_utils:get_user(User, RcPid) of
         {ok, {?RCS_USER{buckets=Buckets}, _UserObj}} ->
-            BucketUsages = [maybe_sum_bucket(RcPid, User, B) || B <- Buckets],
+            BucketUsages = [maybe_sum_bucket(User, B) || B <- Buckets],
             {ok, BucketUsages};
         {error, Error} ->
             {error, Error}
@@ -62,13 +62,13 @@ sum_user(RcPid, User) when is_list(User) ->
 %%      This log is *very* important because unless this log
 %%      there are no other way for operator to know a calculation
 %%      which riak_cs_storage_d failed.
--spec maybe_sum_bucket(riak_client(), string(), cs_bucket()) ->
+-spec maybe_sum_bucket(string(), cs_bucket()) ->
                               {binary(), [{binary(), integer()}]} |
                               {binary(), binary()}.
-maybe_sum_bucket(RcPid, User, ?RCS_BUCKET{name=Name} = Bucket) when is_list(Name) ->
-    maybe_sum_bucket(RcPid, User, Bucket?RCS_BUCKET{name=list_to_binary(Name)});
-maybe_sum_bucket(RcPid, User, ?RCS_BUCKET{name=Name} = _Bucket) when is_binary(Name) ->
-    case sum_bucket(RcPid, Name) of
+maybe_sum_bucket(User, ?RCS_BUCKET{name=Name} = Bucket) when is_list(Name) ->
+    maybe_sum_bucket(User, Bucket?RCS_BUCKET{name=list_to_binary(Name)});
+maybe_sum_bucket(User, ?RCS_BUCKET{name=Name} = _Bucket) when is_binary(Name) ->
+    case sum_bucket(Name) of
         {struct, _} = BucketUsage -> {Name, BucketUsage};
         {error, _} = E ->
             _ = lager:error("failed to calculate usage of "
@@ -85,23 +85,30 @@ maybe_sum_bucket(RcPid, User, ?RCS_BUCKET{name=Name} = _Bucket) when is_binary(N
 %% The result is a mochijson structure with two fields: `Objects',
 %% which is the number of objects that were counted in the bucket, and
 %% `Bytes', which is the total size of all of those objects.
--spec sum_bucket(riak_client(), binary()) -> {struct, [{binary(), integer()}]}
+-spec sum_bucket(binary()) -> {struct, [{binary(), integer()}]}
                                    | {error, term()}.
-sum_bucket(RcPid, BucketName) ->
+sum_bucket(BucketName) ->
     Query = [{map, {modfun, riak_cs_storage, object_size_map},
               [do_prereduce], false},
              {reduce, {modfun, riak_cs_storage, object_size_reduce},
               none, true}],
-    ok = riak_cs_riak_client:set_bucket_name(RcPid, BucketName),
-    {ok, ManifestPbc} = riak_cs_riak_client:manifest_pbc(RcPid),
-    ManifestBucket = riak_cs_utils:to_bucket_name(objects, BucketName),
-    case riakc_pb_socket:mapred(ManifestPbc, ManifestBucket, Query) of
-        {ok, Results} ->
-            {1, [{Objects, Bytes}]} = lists:keyfind(1, 1, Results),
-            {struct, [{<<"Objects">>, Objects},
-                      {<<"Bytes">>, Bytes}]};
-        {error, Error} ->
-            {error, Error}
+    %% Manifests may exists in different bag for each bucket,
+    %% use new one to map/reduce and fetch manifest objects.
+    {ok, RcPid} = riak_cs_riak_client:checkout(),
+    try
+        ok = riak_cs_riak_client:set_bucket_name(RcPid, BucketName),
+        {ok, ManifestPbc} = riak_cs_riak_client:manifest_pbc(RcPid),
+        ManifestBucket = riak_cs_utils:to_bucket_name(objects, BucketName),
+        case riakc_pb_socket:mapred(ManifestPbc, ManifestBucket, Query) of
+            {ok, Results} ->
+                {1, [{Objects, Bytes}]} = lists:keyfind(1, 1, Results),
+                {struct, [{<<"Objects">>, Objects},
+                          {<<"Bytes">>, Bytes}]};
+            {error, Error} ->
+                {error, Error}
+        end
+    after
+        riak_cs_riak_client:checkin(RcPid)
     end.
 
 object_size_map({error, notfound}, _, _) ->

--- a/src/riak_cs_wm_bucket.erl
+++ b/src/riak_cs_wm_bucket.erl
@@ -122,7 +122,7 @@ accept_body(RD, Ctx=#context{user=User,
                              riak_client=RcPid}) ->
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"bucket_create">>,
                                       [], [riak_cs_wm_utils:extract_name(User), Bucket]),
-    BagId = riak_cs_mb_helper:choose_bag_id(manifest),
+    BagId = riak_cs_mb_helper:choose_bag_id(manifest, Bucket),
     case riak_cs_bucket:create_bucket(User,
                                       UserObj,
                                       Bucket,

--- a/test/riak_cs_gc_single_run_eqc.erl
+++ b/test/riak_cs_gc_single_run_eqc.erl
@@ -68,7 +68,7 @@ eqc_test_() ->
              application:set_env(riak_cs, gc_interval, infinity),
              application:set_env(riak_cs, gc_paginated_indexes, true),
 
-             meck:new(riakc_pb_socket),
+             meck:new(riakc_pb_socket, [passthrough]),
              %% For riak_cs_gc_worker, it starts/stops pool worker directly.
              meck_pool_worker(),
              %% GET/DELETE filesets from riak-cs-gc bucket


### PR DESCRIPTION
This PR contains several commits.
The initial intent of this branch is to make bag choice logic slightly more
deterministic. It is address by:
- 4bdbd46 Add seeds to choose bag for new buckets and manifests

Then it opens possibility to use more nodes/bags in riak_test (of multibag flavor)
and assert which riak objects goes where.
- 75ec381 \* Use more nodes and more bags in riak_test

These extended riak_test cases found two bugs, so fix them:
- c24044d \* origin/refactor/bag-choice-seed refactor/bag-choice-seed Fix wrong reuse of riak_client processes
- 2bc1edd \* Reuse bag ID in original manifest in part uploads

Other misc changes:
- b7b2e83 \* Change reference of riak_cs_multibag to release branch
- f784cc0 \* Change ?assertEqual to custom assertion to verify binary identity

Is it better to break multiple PRs for review? If so, I will do :smile:
