### PR TITLE
Use standard lager for logs of "make test-client"

### DIFF
--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -7,50 +7,53 @@
 -define(TEST_BUCKET, "external-client-test").
 
 confirm() ->
-    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, [{cs, cs_config()}]),
-    ?assertEqual(ok, erlcloud_s3:create_bucket("external-client-test", UserConfig)),
-
-    CS_http_port = rtcs:cs_port(hd(RiakNodes)),
-
-    CS_src_dir = rt_cs_dev:srcpath(cs_src_root),
-    lager:debug("cs_src_root = ~p", [CS_src_dir]),
     %% NOTE: This 'cs_src_root' path must appear in
     %% ~/.riak_test.config in the 'rt_cs_dev' section, 'src_paths'
     %% subsection.
+    CsSrcDir = rt_cs_dev:srcpath(cs_src_root),
+    lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    StdoutStderr = "/tmp/my_output." ++ os:getpid(),
-    os:cmd("rm -f " ++ StdoutStderr),
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, [{cs, cs_config()}]),
+    ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
+    CsPortStr = integer_to_list(rtcs:cs_port(hd(RiakNodes))),
 
-    Cmd = lists:flatten(
-            io_lib:format("cd ~s; env "
-                          "CS_HTTP_PORT=~B "
-                          "HTTP_PROXY=127.0.0.1:~B "
-                          "AWS_ACCESS_KEY_ID=~s "
-                          "AWS_SECRET_ACCESS_KEY=~s "
-                          "CS_BUCKET=~s "
-                          "make test-client > ~s 2>&1 ; echo Res $?",
-                          [CS_src_dir, CS_http_port, CS_http_port,
-                           UserConfig#aws_config.access_key_id,
-                           UserConfig#aws_config.secret_access_key,
-                           ?TEST_BUCKET,
-                           StdoutStderr])),
-    lager:debug("Cmd = ~s", [Cmd]),
-    Res = os:cmd(Cmd),
-    lager:debug("Res = ~s", [Res]),
-    {ok, DebugOut} = file:read_file(StdoutStderr),
-    %% This io:format will have every line tagged as "debug" output.
-    io:format("Verbose Res = ~s\n", [DebugOut]),
+    Cmd = os:find_executable("make"),
+    Args = ["test-client"],
+    Env = [{"CS_HTTP_PORT",          CsPortStr},
+           {"AWS_ACCESS_KEY_ID",     UserConfig#aws_config.access_key_id},
+           {"AWS_SECRET_ACCESS_KEY", UserConfig#aws_config.secret_access_key},
+           {"CS_BUCKET",             ?TEST_BUCKET}],
+    case execute_cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}]) of
+        ok ->
+            pass;
+        {error, Reason} ->
+            lager:error("Error : ~p", [Reason]),
+            error({external_client_tests, Reason})
+    end.
 
-    try
-        case Res of
-            "Res 0\n" ->
-                pass;
-            _ ->
-                lager:error("Expected 'Res 0', got: ~s", [Res]),
-                error(fail)
-        end
-    after
-        os:cmd("rm -f " ++ StdoutStderr)
+execute_cmd(Cmd, Opts) ->
+    lager:info("Command: ~s", [Cmd]),
+    lager:info("Options: ~p", [Opts]),
+    Port = open_port({spawn_executable, Cmd},
+                     [in, exit_status, binary,
+                      stream, stderr_to_stdout,{line, 200} | Opts]),
+    get_cmd_result(Port).
+
+get_cmd_result(Port) ->
+    WaitTime = rt_config:get(rt_max_wait_time),
+    receive
+        {Port, {data, {Flag, Line}}} when Flag =:= eol orelse Flag =:= noeol ->
+            lager:info(Line),
+            get_cmd_result(Port);
+        {Port, {exit_status, 0}} ->
+            ok;
+        {Port, {exit_status, Status}} ->
+            {error, {exit_status, Status}};
+        {Port, Other} ->
+            lager:warning("Other data from port: ~p", [Other]),
+            get_cmd_result(Port)
+    after WaitTime * 2 ->
+            {error, timeout}
     end.
 
 cs_config() ->


### PR DESCRIPTION
The log of `make test-client` in `external_client_tests` currently
goes `/tmp/*` and is removed after the `make` exits.

When executing riak_test in batch (e.g. `-d riak_test/ebin`), I
sometimes want to read such log files to investigate why the test fails.

This PR makes the log be forwarded to lager and logged to cosole or files.

One subtle point is progress indicator by dots `....` are logged after
line break character comes.
This can be handled but I now leave it future refactoring in the future.
