### PR TITLE
Bugfix/copy from multipart

### DIFF
--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -702,7 +702,7 @@ class SimpleCopyTest(S3ApiVerificationTestBase):
         self.assertIn(target_key_name,
                       [k.key for k in target_bucket.get_all_keys()])
 
-    def maybe_test_upload_part_copy(self):
+    def test_upload_part_from_non_mp(self):
         k = self.create_test_object()
 
         target_bucket_name = str(uuid.uuid4())
@@ -711,7 +711,7 @@ class SimpleCopyTest(S3ApiVerificationTestBase):
         start_offset=0
         end_offset=9
         target_bucket = self.conn.create_bucket(target_bucket_name)
-        upload = bucket.initiate_multipart_upload(target_key_name)
+        upload = target_bucket.initiate_multipart_upload(target_key_name)
         upload.copy_part_from_key(self.bucket_name, self.key_name, part_num=1,
                                   start=start_offset, end=end_offset)
         upload.complete_upload()

--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -756,6 +756,19 @@ class SimpleCopyTest(S3ApiVerificationTestBase):
         self.assertEqual(self.data[start_offset:(end_offset+1)],
                          target_key.get_contents_as_string())
 
+    def test_put_copy_from_non_existing_key_404(self):
+        bucket = self.conn.create_bucket(self.bucket_name)
+
+        target_bucket_name = str(uuid.uuid4())
+        target_key_name = str(uuid.uuid4())
+        target_bucket = self.conn.create_bucket(target_bucket_name)
+        try:
+            target_bucket.copy_key(target_key_name, self.bucket_name, 'not_existing')
+            self.fail()
+        except S3ResponseError as e:
+            print e
+            self.assertEqual(e.status, 404)
+            self.assertEqual(e.reason, 'Object Not Found')
 
 if __name__ == "__main__":
     unittest.main()

--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -702,6 +702,22 @@ class SimpleCopyTest(S3ApiVerificationTestBase):
         self.assertIn(target_key_name,
                       [k.key for k in target_bucket.get_all_keys()])
 
+    def test_put_copy_object_from_mp(self):
+        bucket = self.conn.create_bucket(self.bucket_name)
+        (upload, result) = upload_multipart(bucket, self.key_name, [StringIO(self.data)])
+
+        target_bucket_name = str(uuid.uuid4())
+        target_key_name = str(uuid.uuid4())
+        target_bucket = self.conn.create_bucket(target_bucket_name)
+
+        target_bucket.copy_key(target_key_name, self.bucket_name, self.key_name)
+
+        target_key = Key(target_bucket)
+        target_key.key = target_key_name
+        self.assertEqual(target_key.get_contents_as_string(), self.data)
+        self.assertIn(target_key_name,
+                      [k.key for k in target_bucket.get_all_keys()])
+
     def test_upload_part_from_non_mp(self):
         k = self.create_test_object()
 

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -41,11 +41,11 @@
                                            {boolean()|{halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.
 test_condition_and_permission(RcPid, SrcManifest, RD, Ctx) ->
 
-    ContentMD5 = base64:encode_to_string(SrcManifest?MANIFEST.content_md5),
+    ETag = riak_cs_manifest:etag(SrcManifest),
     LastUpdate = SrcManifest?MANIFEST.created,
 
     %% TODO: write tests around these conditions, any kind of test is okay
-    case condition_check(RD, ContentMD5, LastUpdate) of
+    case condition_check(RD, ETag, LastUpdate) of
         ok ->
             _ = authorize_on_src(RcPid, SrcManifest, RD, Ctx);
         Other ->

--- a/src/riak_cs_manifest.erl
+++ b/src/riak_cs_manifest.erl
@@ -20,7 +20,8 @@
 
 -module(riak_cs_manifest).
 
--export([fetch/3]).
+-export([fetch/3,
+         etag/1]).
 
 -include("riak_cs.hrl").
 
@@ -33,4 +34,8 @@ fetch(RcPid, Bucket, Key) ->
             Error
     end.
 
-
+-spec etag(lfs_manifest()) -> string().
+etag(?MANIFEST{content_md5={MD5, Suffix}}) ->
+    riak_cs_utils:etag_from_binary(MD5, Suffix);
+etag(?MANIFEST{content_md5=MD5}) ->
+    riak_cs_utils:etag_from_binary(MD5).

--- a/src/riak_cs_manifest.erl
+++ b/src/riak_cs_manifest.erl
@@ -21,7 +21,8 @@
 -module(riak_cs_manifest).
 
 -export([fetch/3,
-         etag/1]).
+         etag/1,
+         etag_no_quotes/1]).
 
 -include("riak_cs.hrl").
 
@@ -39,3 +40,6 @@ etag(?MANIFEST{content_md5={MD5, Suffix}}) ->
     riak_cs_utils:etag_from_binary(MD5, Suffix);
 etag(?MANIFEST{content_md5=MD5}) ->
     riak_cs_utils:etag_from_binary(MD5).
+
+etag_no_quotes(?MANIFEST{content_md5=ContentMD5}) ->
+    riak_cs_utils:etag_from_binary_no_quotes(ContentMD5).

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -232,7 +232,7 @@ copy_part_response(Manifest, RD, Ctx) ->
 
 copy_response(Manifest, TagName, RD, Ctx) ->
     LastModified = riak_cs_wm_utils:to_iso_8601(Manifest?MANIFEST.created),
-    ETag = riak_cs_utils:etag_from_binary(Manifest?MANIFEST.content_md5),
+    ETag = riak_cs_manifest:etag(Manifest),
     XmlDoc = [{TagName,
                [{'LastModified', [LastModified]},
                 {'ETag', [ETag]}]}],

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -132,7 +132,7 @@ content_types_provided(RD, Ctx=#context{local_context=LocalCtx,
 -spec generate_etag(#wm_reqdata{}, #context{}) -> {string(), #wm_reqdata{}, #context{}}.
 generate_etag(RD, Ctx=#context{local_context=LocalCtx}) ->
     Mfst = LocalCtx#key_context.manifest,
-    ETag = riak_cs_manifest:etag(Mfst),
+    ETag = riak_cs_manifest:etag_no_quotes(Mfst),
     {ETag, RD, Ctx}.
 
 -spec last_modified(#wm_reqdata{}, #context{}) -> {calendar:datetime(), #wm_reqdata{}, #context{}}.

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -396,6 +396,8 @@ handle_copy_put(RD, Ctx, SrcBucket, SrcKey) ->
                         Error
 
                 end;
+            {error, notfound} ->
+                ResponseMod:api_error(no_such_key, RD, Ctx);
             {error, Err} ->
                 ResponseMod:api_error(Err, RD, Ctx)
         end

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -132,7 +132,7 @@ content_types_provided(RD, Ctx=#context{local_context=LocalCtx,
 -spec generate_etag(#wm_reqdata{}, #context{}) -> {string(), #wm_reqdata{}, #context{}}.
 generate_etag(RD, Ctx=#context{local_context=LocalCtx}) ->
     Mfst = LocalCtx#key_context.manifest,
-    ETag = riak_cs_utils:etag_from_binary_no_quotes(Mfst?MANIFEST.content_md5),
+    ETag = riak_cs_manifest:etag(Mfst),
     {ETag, RD, Ctx}.
 
 -spec last_modified(#wm_reqdata{}, #context{}) -> {calendar:datetime(), #wm_reqdata{}, #context{}}.
@@ -176,9 +176,8 @@ produce_body(RD, Ctx=#context{rc_pool=RcPool,
                _ -> <<"object_get">>
            end,
     riak_cs_dtrace:dt_object_entry(?MODULE, Func, [], [UserName, BFile_str]),
-    ContentMd5 = Mfst?MANIFEST.content_md5,
     LastModified = riak_cs_wm_utils:to_rfc_1123(Mfst?MANIFEST.created),
-    ETag = format_etag(ContentMd5),
+    ETag = riak_cs_manifest:etag(Mfst),
     NewRQ1 = lists:foldl(fun({K, V}, Rq) -> wrq:set_resp_header(K, V, Rq) end,
                          RD,
                          [{"ETag",  ETag},
@@ -298,7 +297,7 @@ accept_body(RD, Ctx=#context{riak_client=RcPid,
                                       Mfst?MANIFEST{metadata=Metadata}, NewAcl,
                                       RcPid) of
         ok ->
-            ETag = riak_cs_utils:etag_from_binary(Mfst?MANIFEST.content_md5),
+            ETag = riak_cs_manifest:etag(Mfst),
             RD2 = wrq:set_resp_header("ETag", ETag, RD),
             ResponseMod:copy_object_response(Mfst, RD2, Ctx);
         {error, Err} ->
@@ -382,7 +381,7 @@ handle_copy_put(RD, Ctx, SrcBucket, SrcKey) ->
                         %% This ain't fail because all permission and 404
                         %% possibility has been already checked.
                         {ok, DstManifest} = riak_cs_copy_object:copy(PutFsmPid, SrcManifest, ReadRcPid),
-                        ETag = riak_cs_utils:etag_from_binary(DstManifest?MANIFEST.content_md5),
+                        ETag = riak_cs_manifest:etag(DstManifest),
                         RD2 = wrq:set_resp_header("ETag", ETag, RD),
                         ResponseMod:copy_object_response(DstManifest, RD2,
                                                          Ctx#context{local_context=LocalCtx});
@@ -448,7 +447,7 @@ finalize_request(RD,
     Response =
         case riak_cs_put_fsm:finalize(Pid, ContentMD5) of
             {ok, Manifest} ->
-                ETag = riak_cs_utils:etag_from_binary(Manifest?MANIFEST.content_md5),
+                ETag = riak_cs_manifest:etag(Manifest),
                 %% TODO: probably want something that counts actual bytes uploaded
                 %% instead, to record partial/aborted uploads
                 AccessRD = riak_cs_access_log_handler:set_bytes_in(S, RD),
@@ -491,9 +490,3 @@ zero_length_metadata_update_p(0, RD) ->
     end;
 zero_length_metadata_update_p(_, _) ->
     false.
-
--spec format_etag(binary() | {binary(), string()}) -> string().
-format_etag({ContentMd5, Suffix}) ->
-    riak_cs_utils:etag_from_binary(ContentMd5, Suffix);
-format_etag(ContentMd5) ->
-    riak_cs_utils:etag_from_binary(ContentMd5).


### PR DESCRIPTION
- Fix bug that PUT copy from MP uploaded source results in 500 error
  (expected : successfully copied)
- Fix bug that PUT copy from absent key results in 503
  (expected : 404 error) 

Includes tests by boto for both fixes and some refactoring.

Addresses #900 
