### PR TITLE
Add exponential back off with randomization to avoid sibling explosion

### DIFF
--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -53,7 +53,8 @@
               object_head,
               object_delete,
               object_get_acl,
-              object_put_acl]).
+              object_put_acl,
+              manifest_update_retry_sleep]).
 
 %% ====================================================================
 %% API


### PR DESCRIPTION
Addresses #882 (together with #915).

When multipart uploads are executed in concurrent, get-modify-put manifest objects
may be interleaved and lead to sibling explosion.
This PR add retries with sleep to releive it.

Three knobs are introduced.
- `manifest_update_max_retries` (default: 4)
  
  Max number of reties for GET manifests before update.
- `manifest_siblings_suppress` (default: 5)
  
  The threshold for the number of manifest object siblings to trigger suppression logic.
  If the number of siblings is equal to or greater than this value,
  retry logic is applied.
- `manifest_siblings_force_update_at_last_retry` (default: 15)
  
  The threshold for the number of manifest object siblings to
  force update at the last retry.
  If the number of siblings is less than this value,
  update without gamble (see below) at the last retry.
### Logic

After getting manifest object, check the number of siblings.
If it is less than `manifest_siblings_suppress`,
modify/put it without sleep or retry.
Otherwise, do a simple gamble.
- First, generate random uniform integer from 0 to 9.
- If it is 0, then win! update modify/put manifests.
- Other than that, sleep and retry from getting manifest object.

This randomness is necessary because there should be a chance to
resolve siblings which needs modify/put.

Also, at the last retry attempt, depending on the #(siblings),
the upload forcedly move to upload without gambling.

Another randomness is in sleep intervals.
Sleep intervals are uniformly distributed in the ranges 0.5 +/- 0.25, 1 +/- 0.5,
2 +/- 1, 4 +/- 2, for 1st retry, 2nd, 3rd,... respectively.
### Misc notes
- No dependency on the number of siblings other than threashold for suppression.
  If the current logic not enough, some penalty for sleep interval for large
  number of siblings might help (or not. I don't know).
- Add `manifest_update_retry_sleep` to riak_cs_stats.
  It collects sleep intervals as latency (a bit of abuse).
