### PR TITLE
Update ceph/s3-tests to latest, modified to 1.5.0

### DIFF
--- a/client_tests/python/ceph_tests/Makefile
+++ b/client_tests/python/ceph_tests/Makefile
@@ -7,7 +7,7 @@ BIN = env/bin
 all: test
 
 s3-tests:
-	@git clone --quiet https://github.com/basho/s3-tests
+	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-1.5
 
 env:
 	@cd s3-tests && virtualenv env


### PR DESCRIPTION
Addresses #880. But depends on #904 and #903 .
Changes from current tests is described [here](https://github.com/basho/s3-tests/compare/basho:master...riakcs-1.5).
