### PR TITLE
Add warning logs for manifests, siblings, bytes and history

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -464,6 +464,9 @@
 -define(DEFAULT_AUTH_MODULE, riak_cs_s3_auth).
 -define(DEFAULT_LIST_OBJECTS_MAX_KEYS, 1000).
 -define(DEFAULT_MD5_CHUNK_SIZE, 1048576). %% 1 MB
+-define(DEFAULT_MANIFEST_WARN_SIBLINGS, 20).
+-define(DEFAULT_MANIFEST_WARN_BYTES, 5*1024*1024). %% 5MB
+-define(DEFAULT_MANIFEST_WARN_HISTORY, 30).
 
 %% General system info
 -define(WORD_SIZE, erlang:system_info(wordsize)).

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -207,7 +207,7 @@ fold_delete_uploads(Bucket, RcPid, [D|Ds], Timestamp, Count)->
     Key = D?MULTIPART_DESCR.key,
 
     %% cannot fail here
-    {ok, Obj, Manifests} = riak_cs_utils:get_manifests(RcPid, Bucket, Key),
+    {ok, Obj, Manifests} = riak_cs_manifest:get_manifests(RcPid, Bucket, Key),
 
     UploadId = D?MULTIPART_DESCR.upload_id,
 

--- a/src/riak_cs_diags.erl
+++ b/src/riak_cs_diags.erl
@@ -110,7 +110,7 @@ init([]) ->
 handle_call({get_manifests, Bucket, Key}, _From, State) ->
     {ok, Pid} = riak_cs_utils:riak_connection(),
     try
-        {ok, _, Manifests} = riak_cs_utils:get_manifests(Pid, Bucket, Key),
+        {ok, _, Manifests} = riak_cs_manifest:get_manifests(Pid, Bucket, Key),
         {reply, Manifests, State}
     catch _:_=E ->
         {reply, {error, E}, State}

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -89,7 +89,7 @@ gc_active_manifests(Bucket, Key, RcPid, UUIDs) ->
 -spec get_active_manifests(binary(), binary(), riak_client()) ->
     {ok, riakc_obj:riakc_obj(), [lfs_manifest()]} | {error, term()}.
 get_active_manifests(Bucket, Key, RcPid) ->
-    active_manifests(riak_cs_utils:get_manifests(RcPid, Bucket, Key)).
+    active_manifests(riak_cs_manifest:get_manifests(RcPid, Bucket, Key)).
 
 -spec active_manifests({ok, riakc_obj:riakc_obj(), [lfs_manifest()]}) ->
                           {ok, riakc_obj:riakc_obj(), [lfs_manifest()]};
@@ -179,7 +179,7 @@ gc_specific_manifests(UUIDsToMark, RiakObject, Bucket, Key, RcPid) ->
     ({error, term()}, binary(), binary(), [binary()], riak_client()) ->
     {error, term()} | {ok, riakc_obj:riakc_obj()}.
 handle_mark_as_pending_delete({ok, RiakObject}, Bucket, Key, UUIDsToMark, RcPid) ->
-    Manifests = riak_cs_utils:manifests_from_riak_object(RiakObject),
+    Manifests = riak_cs_manifest:manifests_from_riak_object(RiakObject),
     PDManifests = riak_cs_manifest_utils:manifests_to_gc(UUIDsToMark, Manifests),
     MoveResult = move_manifests_to_gc_bucket(PDManifests, RcPid),
     PDUUIDs = [UUID || {UUID, _} <- PDManifests],
@@ -342,7 +342,7 @@ mark_as_scheduled_delete(UUIDsToMark, RiakObject, Bucket, Key, RcPid) ->
 -spec mark_manifests(riakc_obj:riakc_obj(), binary(), binary(), [binary()], fun(), riak_client()) ->
                     {ok, riakc_obj:riakc_obj()} | {error, term()}.
 mark_manifests(RiakObject, Bucket, Key, UUIDsToMark, ManiFunction, RcPid) ->
-    Manifests = riak_cs_utils:manifests_from_riak_object(RiakObject),
+    Manifests = riak_cs_manifest:manifests_from_riak_object(RiakObject),
     Marked = ManiFunction(Manifests, UUIDsToMark),
     UpdObj0 = riak_cs_utils:update_obj_value(RiakObject,
                                              riak_cs_utils:encode_term(Marked)),

--- a/src/riak_cs_list_objects_fsm_v2.erl
+++ b/src/riak_cs_list_objects_fsm_v2.erl
@@ -209,7 +209,7 @@ handle_done(State=#state{object_buffer=ObjectBuffer,
     update_profiling_and_last_request(State, ObjectBuffer, ObjectBufferLength),
 
     FilteredObjects = exclude_key_from_state(State, ObjectBuffer),
-    Manifests = [riak_cs_utils:manifests_from_riak_object(O) ||
+    Manifests = [riak_cs_manifest:manifests_from_riak_object(O) ||
                  O <- FilteredObjects],
     Active = map_active_manifests(Manifests),
     NewObjects = PrevObjects ++ Active,

--- a/src/riak_cs_manifest.erl
+++ b/src/riak_cs_manifest.erl
@@ -21,6 +21,8 @@
 -module(riak_cs_manifest).
 
 -export([fetch/3,
+         get_manifests/3,
+         manifests_from_riak_object/1,
          etag/1,
          etag_no_quotes/1,
          object_acl/1]).
@@ -29,12 +31,53 @@
 
 -spec fetch(pid(), binary(), binary()) -> {ok, lfs_manifest()} | {error, term()}.
 fetch(RcPid, Bucket, Key) ->
-    case riak_cs_utils:get_manifests(RcPid, Bucket, Key) of
+    case riak_cs_manifest:get_manifests(RcPid, Bucket, Key) of
         {ok, _, Manifests} ->
             riak_cs_manifest_utils:active_manifest(orddict:from_list(Manifests));
         Error ->
             Error
     end.
+
+-spec get_manifests(riak_client(), binary(), binary()) ->
+    {ok, term(), term()} | {error, term()}.
+get_manifests(RcPid, Bucket, Key) ->
+    case get_manifests_raw(RcPid, Bucket, Key) of
+        {ok, Object} ->
+            Manifests = manifests_from_riak_object(Object),
+            maybe_warn_bloated_manifests(Bucket, Key, Object, Manifests),
+            _  = gc_deleted_while_writing_manifests(Object, Manifests, Bucket, Key, RcPid),
+            {ok, Object, Manifests};
+        {error, _Reason}=Error ->
+            Error
+    end.
+
+-spec manifests_from_riak_object(riakc_obj:riakc_obj()) -> orddict:orddict().
+manifests_from_riak_object(RiakObject) ->
+    %% For example, riak_cs_manifest_fsm:get_and_update/4 may wish to
+    %% update the #riakc_obj without a roundtrip to Riak first.  So we
+    %% need to see what the latest
+    Contents = try
+                   %% get_update_value will return the updatevalue or
+                   %% a single old original value.
+                   [{riakc_obj:get_update_metadata(RiakObject),
+                     riakc_obj:get_update_value(RiakObject)}]
+               catch throw:_ ->
+                       %% Original value had many contents
+                       riakc_obj:get_contents(RiakObject)
+               end,
+    DecodedSiblings = [binary_to_term(V) ||
+                          {_, V}=Content <- Contents,
+                          not riak_cs_utils:has_tombstone(Content)],
+
+    %% Upgrade the manifests to be the latest erlang
+    %% record version
+    Upgraded = riak_cs_manifest_utils:upgrade_wrapped_manifests(DecodedSiblings),
+
+    %% resolve the siblings
+    Resolved = riak_cs_manifest_resolution:resolve(Upgraded),
+
+    %% prune old scheduled_delete manifests
+    riak_cs_manifest_utils:prune(Resolved).
 
 -spec etag(lfs_manifest()) -> string().
 etag(?MANIFEST{content_md5={MD5, Suffix}}) ->
@@ -52,3 +95,53 @@ object_acl(notfound) ->
 object_acl(?MANIFEST{acl=Acl}) ->
     Acl.
 
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% Retrieve the riak object at a bucket/key
+-spec get_manifests_raw(riak_client(), binary(), binary()) ->
+    {ok, riakc_obj:riakc_obj()} | {error, term()}.
+get_manifests_raw(RcPid, Bucket, Key) ->
+    ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    ok = riak_cs_riak_client:set_bucket_name(RcPid, Bucket),
+    {ok, ManifestPbc} = riak_cs_riak_client:manifest_pbc(RcPid),
+    riakc_pb_socket:get(ManifestPbc, ManifestBucket, Key).
+
+gc_deleted_while_writing_manifests(Object, Manifests, Bucket, Key, RcPid) ->
+    UUIDs = riak_cs_manifest_utils:deleted_while_writing(Manifests),
+    riak_cs_gc:gc_specific_manifests(UUIDs, Object, Bucket, Key, RcPid).
+
+-spec maybe_warn_bloated_manifests(binary(), binary(), riakc_obj:riakc_obj(), [term()]) -> ok.
+maybe_warn_bloated_manifests(Bucket, Key, Object, Manifests) ->
+    maybe_warn_bloated_manifests(
+      Bucket, Key,
+      riakc_obj:value_count(Object),
+      riak_cs_config:get_env(riak_cs, manifest_warn_siblings,
+                             ?DEFAULT_MANIFEST_WARN_SIBLINGS),
+      "Many manifest siblings", "siblings"),
+    maybe_warn_bloated_manifests(
+      Bucket, Key,
+      %% Approximate object size by the sum of only values, ignoring metadata
+      lists:sum([byte_size(V) || V <- riakc_obj:get_values(Object)]),
+      riak_cs_config:get_env(riak_cs, manifest_warn_bytes,
+                             ?DEFAULT_MANIFEST_WARN_BYTES),
+      "Large manifest size", "bytes"),
+    maybe_warn_bloated_manifests(
+      Bucket, Key,
+      length(Manifests),
+      riak_cs_config:get_env(riak_cs, manifest_warn_history,
+                             ?DEFAULT_MANIFEST_WARN_HISTORY),
+      "Long manifest history", "manifests"),
+    ok.
+
+-spec maybe_warn_bloated_manifests(binary(), binary(), disabled | non_neg_integer(),
+                        non_neg_integer(), string(), string()) -> ok.
+maybe_warn_bloated_manifests(Bucket, Key, Actual, Threshold, Message, Unit) ->
+    case Threshold of
+        disabled -> ok;
+        _ when Actual < Threshold -> ok;
+        _ -> _ = lager:warning("~s (~p ~s) for bucket=~p key=~p",
+                               [Message, Actual, Unit, Bucket, Key])
+    end.

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -263,7 +263,7 @@ code_change(_OldVsn, StateName, State, _Extra) ->
 handle_get_manifests(State=#state{riak_client=RcPid,
                            bucket=Bucket,
                            key=Key}) ->
-    case riak_cs_utils:get_manifests(RcPid, Bucket, Key) of
+    case riak_cs_manifest:get_manifests(RcPid, Bucket, Key) of
         {ok, RiakObject, Resolved} ->
             Reply = {ok, Resolved},
             NewState = State#state{riak_object=RiakObject, manifests=Resolved},
@@ -279,7 +279,7 @@ handle_get_manifests(State=#state{riak_client=RcPid,
 -spec get_and_delete(riak_client(), binary(), binary(), binary()) -> ok |
                                                              {error, term()}.
 get_and_delete(RcPid, UUID, Bucket, Key) ->
-    case riak_cs_utils:get_manifests(RcPid, Bucket, Key) of
+    case riak_cs_manifest:get_manifests(RcPid, Bucket, Key) of
         {ok, RiakObject, Manifests} ->
             ResolvedManifests = riak_cs_manifest_resolution:resolve([Manifests]),
             UpdatedManifests = orddict:erase(UUID, ResolvedManifests),
@@ -305,7 +305,7 @@ get_and_update(RcPid, WrappedManifests, Bucket, Key) ->
     %% NOTE: it would also be nice to assert that the
     %% UUID being added doesn't already exist in the
     %% dict
-    case riak_cs_utils:get_manifests(RcPid, Bucket, Key) of
+    case riak_cs_manifest:get_manifests(RcPid, Bucket, Key) of
         {ok, RiakObject, Manifests} ->
             NewManiAdded = riak_cs_manifest_resolution:resolve([WrappedManifests, Manifests]),
             %% Update the object here so that if there are any
@@ -326,7 +326,7 @@ get_and_update(RcPid, WrappedManifests, Bucket, Key) ->
                                                      Bucket, Key,
                                                      RcPid)
             end,
-            UpdatedManifests = riak_cs_utils:manifests_from_riak_object(NewRiakObject),
+            UpdatedManifests = riak_cs_manifest:manifests_from_riak_object(NewRiakObject),
             {Result, NewRiakObject, UpdatedManifests};
         {error, notfound} ->
             ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -340,7 +340,7 @@ do_part_common(Op, Bucket, Key, UploadId, {_,_,CallerKeyId} = _Caller, Props, Rc
     case wrap_riak_client(RcPidUnW) of
         {ok, RcPid} ->
             try
-                case riak_cs_utils:get_manifests(?PID(RcPid), Bucket, Key) of
+                case riak_cs_manifest:get_manifests(?PID(RcPid), Bucket, Key) of
                     {ok, Obj, Manifests} ->
                         case find_manifest_with_uploadid(UploadId, Manifests) of
                             false ->
@@ -606,7 +606,7 @@ update_keys_and_prefixes({Keys, Prefixes}, _, Prefix, PrefixLen, Group) ->
 multipart_manifests_for_key(Bucket, Key, Opts, Acc, RcPid) ->
     ParameterFilter = build_parameter_filter(Opts),
     Manifests = handle_get_manifests_result(
-                  riak_cs_utils:get_manifests(RcPid, Bucket, Key)),
+                  riak_cs_manifest:get_manifests(RcPid, Bucket, Key)),
     lists:foldl(ParameterFilter, Acc, Manifests).
 
 build_parameter_filter(Opts) ->


### PR DESCRIPTION
Add three kinks of warning logs for potentially bloated manifests.
Original issue is #882.
- many siblings
- large size
- long history ({UUID, M} pairs)

Each has default value and enabled, but has kill switch `disabled`.
