### PR TITLE
Fix spelling error

### DIFF
--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -43,7 +43,7 @@ confirm() ->
 
     lists:foreach(fun(RiakNode) ->
                           N = rt_cs_dev:node_id(RiakNode),
-                          ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9095\n",
+                          ?assertEqual("Current Stanchion Address: http://127.0.0.1:9095\n",
                                        rtcs:show_stanchion_cs(N))
                   end, RiakNodes),
 
@@ -72,7 +72,7 @@ confirm() ->
     lists:foreach(fun(RiakNode) ->
                           N = rt_cs_dev:node_id(RiakNode),
                           rtcs:switch_stanchion_cs(N, "127.0.0.1", ?BACKUP_PORT),
-                          ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9096\n",
+                          ?assertEqual("Current Stanchion Address: http://127.0.0.1:9096\n",
                                        rtcs:show_stanchion_cs(N))
                   end, RiakNodes),
 

--- a/src/riak_cs_stanchion_console.erl
+++ b/src/riak_cs_stanchion_console.erl
@@ -73,6 +73,6 @@ show([]) ->
                              true -> "https://";
                              false -> "http://"
                          end,
-                io:format("Current Stanchion Adderss: ~s~s:~s~n",
+                io:format("Current Stanchion Address: ~s~s:~s~n",
                           [Scheme, Host, integer_to_list(Port)])
             end, "Retrieving Stanchion info").


### PR DESCRIPTION
In three places, "Address" was mistakenly input as "Adderss"
