### PR TITLE
Re-add rebar_lock_deps_plugin to deps

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,8 @@
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.1"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "1.2.4"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}}
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.4"}}},
+        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "3.1.0"}}}
        ]}.
 
 {deps_ee, [


### PR DESCRIPTION
Once added in #779 . But rebar.config lost it.
