### PR TITLE
Remove erroneous entry from 1.5.0 release notes

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,7 +11,6 @@
 * Syslog support through lager_syslog [riak_cs/#617](https://github.com/basho/riak_cs/pull/617)
 * Add support for Cache-Control header [riak_cs/#821](https://github.com/basho/riak_cs/pull/821)
 * Allow objects to be reaped sooner than leeway interval. [riak_cs/#470](https://github.com/basho/riak_cs/pull/470)
-* Add option to allow a delay for the initial GC collection [riak_cs/#688](https://github.com/basho/riak_cs/pull/688)
 * PUT Copy on both objects and upload parts as technical preview [riak_cs/#548](https://github.com/basho/riak_cs/pull/548)
 * Update to lager 2.0.3
 * Compiles with R16B0x (Releases still by R15B01)


### PR DESCRIPTION
Remove the entry about the initial garbage collection delay from the
1.5.0 section of the release notes. This feature was added in 1.4.2
and is already documented in the release notes of that section.
