### PR TITLE
Allow multipart orphan cleanup to be run from command line

### DIFF
--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { gc | access | storage | stanchion | cluster-info }"
+    echo "Usage: $SCRIPT { gc | access | storage | stanchion | cluster-info | cleanup-orphan-multipart }"
 }
 
 # Check the first argument for instructions
@@ -92,6 +92,14 @@ case "$1" in
         node_up_check
 
         $NODETOOL rpc_infinity riak_cs_console cluster_info "$@"
+        ;;
+    cleanup[_-]orphan[_-]multipart)
+        shift
+
+        # Make sure the local node IS running
+        node_up_check
+
+        $NODETOOL rpc riak_cs_console cleanup_orphan_multipart "$@"
         ;;
     *)
         usage

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -70,9 +70,11 @@ cluster_info([OutFile]) ->
 %% cleaning up with timestamp 2014-05-11-....
 -spec cleanup_orphan_multipart() -> no_return().
 cleanup_orphan_multipart() ->
-    cleanup_orphan_multipart(riak_cs_wm_utils:iso_8601_datetime()).
+    cleanup_orphan_multipart([]).
 
 -spec cleanup_orphan_multipart(string()|binary()) -> no_return().
+cleanup_orphan_multipart([]) ->
+    cleanup_orphan_multipart(riak_cs_wm_utils:iso_8601_datetime());
 cleanup_orphan_multipart(Timestamp) when is_list(Timestamp) ->
     cleanup_orphan_multipart(list_to_binary(Timestamp));
 cleanup_orphan_multipart(Timestamp) when is_binary(Timestamp) ->
@@ -88,8 +90,8 @@ cleanup_orphan_multipart(Timestamp) when is_binary(Timestamp) ->
     _ = riak_cs_bucket:fold_all_buckets(Fun, [], RcPid),
 
     ok = riak_cs_riak_client:stop(RcPid),
-    _ = lager:info("All old unaborted orphan multipart uploads has deleted.", []),
-    _ = io:format("~nAll old unaborted orphan multipart uploads has deleted.~n", []).
+    _ = lager:info("All old unaborted orphan multipart uploads have been deleted.", []),
+    _ = io:format("~nAll old unaborted orphan multipart uploads have been deleted.~n", []).
 
 
 %%%===================================================================


### PR DESCRIPTION
In the release notes for 1.5.0 in the comments about upgrading we have the instructions that require attaching to the console and calling an erlang function:

> - run riak_cs_console:cleanup_orphan_multipart/0 or riak_cs_console:cleanup_orphan_multipart/1 in an attached console to cleanup all buckets

I think is easy enough to go ahead and add this to the command line tools in order to make it easier for users. This is just a suggestion and it could be done after 1.5.0 is released, but it should be very easy to do and better for users.

cc: @michellep 
