### PR TITLE
Fix {error, disconnected} repainted with {error, notfound}

### DIFF
--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -314,11 +314,7 @@ handle_local_notfound(RcPid, FullBucket, FullKey, GetOptions2,
                 {ok, _} = Success ->
                     ProceedFun(Success);
                 {error, _} ->
-                    if UseProxyGet ->
-                            RetryFun(NumRetries + 1);
-                       true ->
-                            RetryFun(failure)
-                    end
+                    RetryFun(NumRetries + 1)
             end;
         {error, notfound} when UseProxyGet ->
             RetryFun(NumRetries + 1);


### PR DESCRIPTION
In my environment, copying large object (say, 5GB) often caused 500 error to client, while some `{error, notfound}` left in log. This patch handles `disconnected` and `timeout` as simple retry, not asking for proxy-gets.
