### PR TITLE
Bugfix/kill copy on disconnect

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -107,6 +107,15 @@ running `riak-cs-admin gc set-interval infinity` .
 Multi data center cluster should be upgraded more carefully, as to
 make sure GC is not running while upgrading.
 
+## Known Issues and Limitations
+
+* If a client sends another request in the same connection while
+  waiting for copy finish, the copy also will be aborted.  This is a
+  side effect of client disconnect detection in case of object copy.
+  See [#932](https://github.com/basho/riak_cs/pull/932) for further
+  information.
+
+
 # Riak CS 1.4.5 Release Notes
 
 ## Bugs Fixed

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -200,7 +200,7 @@ get_content_md5(MD5) ->
                  -> {ok, lfs_manifest()} | {error, term()}.
 get_and_put(GetPid, PutPid, MD5, ContFun) ->
     case ContFun() of
-        true -> 
+        true ->
             case riak_cs_get_fsm:get_next_chunk(GetPid) of
                 {done, <<>>} ->
                     riak_cs_get_fsm:stop(GetPid),
@@ -298,6 +298,7 @@ copy_range(RD, ?MANIFEST{content_length=Len}) ->
 
 %% @doc  nasty  hack,  do  not  use this  other  than  for  disconnect
 %% detection in copying objects.
+-spec connection_checker(inet:socket()) -> fun(() -> boolean()).
 connection_checker(Socket) ->
     fun() ->
             case inet:peername(Socket) of

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -28,7 +28,7 @@
 
 -export([test_condition_and_permission/4,
          start_put_fsm/6, get_copy_source/1,
-         copy/3, copy/4,
+         copy/4, copy/5,
          copy_range/2]).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -146,24 +146,28 @@ handle_copy_source(Path0) when is_list(Path0) ->
     end.
 
 %% @doc runs copy
--spec copy(pid(), lfs_manifest(), riak_client()) ->
+-spec copy(pid(), lfs_manifest(), riak_client(), fun(() -> boolean())) ->
                   {ok, DstManifest::lfs_manifest()} | {error, term()}.
-copy(PutFsmPid, SrcManifest, ReadRcPid) ->
-    copy(PutFsmPid, SrcManifest, ReadRcPid, undefined).
+copy(PutFsmPid, SrcManifest, ReadRcPid, ContFun) ->
+    copy(PutFsmPid, SrcManifest, ReadRcPid, ContFun, undefined).
 
 %% @doc runs copy, Target PUT FSM pid and source object manifest are
 %% specified. This function kicks up GET FSM of source object and
-%% streams blocks to specified PUT FSM.
--spec copy(pid(), lfs_manifest(), riak_client(),
+%% streams blocks to specified PUT FSM. ContFun is a function that
+%% returns whether copying should be continued or not; Clients may
+%% disconnect the TCP connection while waiting for copying large
+%% objects. But mochiweb/webmachine cannot notify nor stop copying,
+%% thus some fd watcher is expected here.
+-spec copy(pid(), lfs_manifest(), riak_client(), fun(()->boolean()),
            {non_neg_integer(), non_neg_integer()}|fail|undefined) ->
                   {ok, DstManifest::lfs_manifest()} | {error, term()}.
-copy(_, _, _, fail) ->
+copy(_, _, _, _, fail) ->
     {error, bad_request};
 copy(PutFsmPid, ?MANIFEST{content_length=0} = _SrcManifest,
-     _ReadRcPid, _) ->
+     _ReadRcPid, _, _) ->
     %% Zero-size copy will successfully create zero-size object
     riak_cs_put_fsm:finalize(PutFsmPid, undefined);
-copy(PutFsmPid, SrcManifest, ReadRcPid, Range0) ->
+copy(PutFsmPid, SrcManifest, ReadRcPid, ContFun, Range0) ->
     {ok, GetFsmPid} = start_get_fsm(SrcManifest, ReadRcPid),
     _RetrievedManifest = riak_cs_get_fsm:get_manifest(GetFsmPid),
 
@@ -181,7 +185,7 @@ copy(PutFsmPid, SrcManifest, ReadRcPid, Range0) ->
         end,
 
     riak_cs_get_fsm:continue(GetFsmPid, Range),
-    get_and_put(GetFsmPid, PutFsmPid, MD5).
+    get_and_put(GetFsmPid, PutFsmPid, MD5, ContFun).
 
 -spec get_content_md5(tuple() | binary()) -> string().
 get_content_md5({_MD5, _Str}) ->
@@ -189,15 +193,22 @@ get_content_md5({_MD5, _Str}) ->
 get_content_md5(MD5) ->
     base64:encode_to_string(MD5).
 
--spec get_and_put(pid(), pid(), list()) -> {ok, lfs_manifest()} | {error, term()}.
-get_and_put(GetPid, PutPid, MD5) ->
-    case riak_cs_get_fsm:get_next_chunk(GetPid) of
-        {done, <<>>} ->
+-spec get_and_put(pid(), pid(), list(), fun(() -> boolean()))
+                 -> {ok, lfs_manifest()} | {error, term()}.
+get_and_put(GetPid, PutPid, MD5, ContFun) ->
+    case ContFun() of
+        true -> 
+            case riak_cs_get_fsm:get_next_chunk(GetPid) of
+                {done, <<>>} ->
+                    riak_cs_get_fsm:stop(GetPid),
+                    riak_cs_put_fsm:finalize(PutPid, MD5);
+                {chunk, Block} ->
+                    riak_cs_put_fsm:augment_data(PutPid, Block),
+                    get_and_put(GetPid, PutPid, MD5, ContFun)
+            end;
+        false ->
             riak_cs_get_fsm:stop(GetPid),
-            riak_cs_put_fsm:finalize(PutPid, MD5);
-        {chunk, Block} ->
-            riak_cs_put_fsm:augment_data(PutPid, Block),
-            get_and_put(GetPid, PutPid, MD5)
+            riak_cs_put_fsm:force_stop(PutPid)
     end.
 
 -spec start_get_fsm(lfs_manifest(), riak_client()) -> {ok, pid()}.

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -410,18 +410,12 @@ maybe_copy_part(PutPid,
                             [SrcBucket, SrcKey, DstBucket, DstKey, ReadRcPid]),
 
             Range = riak_cs_copy_object:copy_range(RD, SrcManifest),
+
+            %% Prepare for connection loss or client close
+            FDWatcher = riak_cs_copy_object:connection_checker((RD#wm_reqdata.wm_state)#wm_reqstate.socket),
+
             %% This ain't fail because all permission and 404
             %% possibility has been already checked.
-
-            %%Fd = (RD#wm_reqdata.wm_state)#wm_state.socket,
-            FDWatcher = fun() ->
-                                %%case inet:peername((RD#wm_reqdata.wm_state)#wm_reqstate.socket) of
-                                case inet:getfd((RD#wm_reqdata.wm_state)#wm_reqstate.socket) of
-                                    {ok, _} -> true;
-                                    {error, _} -> false
-                                end
-                        end,
-
             case riak_cs_copy_object:copy(PutPid, SrcManifest, ReadRcPid, FDWatcher, Range) of
 
                 {ok, DstManifest} ->


### PR DESCRIPTION
Copying can't be stopped on client disconnect, because it does not need any socket read/writes once copying started. That makes detecting client disconnect harder - this patch puts a zero-timeout read on socket to find `{error, closed}` and other errors. This is a dirty hack and mochiweb or webmachine should have such interface that handles lower layer connection error handling, but for now we adopt this hack, which should be fixed in the future. 
Copy should be cancelled because orphan copy without clients are likely not required by clients and may cause overloaded cluster.

Important limitation is: if client sends any additional HTTP request to CS during copy being processed, Riak CS reads that request and throws error, and cancels the copy. 
