### PR TITLE
Clean up edoc generation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,9 @@
 
 {cover_enabled, true}.
 
+%% EDoc options
+{edoc_opts, [preprocess]}.
+
 {lib_dirs, ["deps", "apps"]}.
 
 {erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.

--- a/src/riak_cs_auth.erl
+++ b/src/riak_cs_auth.erl
@@ -25,9 +25,9 @@
 -type wm_reqdata() :: tuple().
 -type wm_context() :: tuple().
 
-%% TODO: arguments of identify/2, and 3rd&4th arguments of
-%%       authenticate/4 are actually #wm_reqdata{} and #context{}
-%%       from webmachine, but can't compile after webmachine.hrl import.
+%% TODO: arguments of `identify/2', and 3rd and 4th arguments of
+%%       authenticate/4 are actually `#wm_reqdata{}' and `#context{}'
+%%       from webmachine, but can't compile after `webmachine.hrl' import.
 -callback identify(RD :: wm_reqdata(), Ctx :: wm_context()) ->
     failed | {string() | undefined, string() | tuple()} |
     {string(), undefined}.

--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -55,17 +55,12 @@
 %%% API
 %%%===================================================================
 
-%%--------------------------------------------------------------------
-%% @doc
-%% Starts the server
-%%
-%% @spec start_link(lfs_manifest()) -> {ok, Pid} | ignore | {error, Error}
-%% @spec start_link(lfs_manifest(), riak_client()) -> {ok, Pid} | ignore | {error, Error}
-%% @end
-%%--------------------------------------------------------------------
+%% @doc Starts the server
+-spec start_link(lfs_manifest()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Manifest) ->
     gen_server:start_link(?MODULE, [Manifest], []).
 
+-spec start_link(lfs_manifest(), riak_client()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Manifest, RcPid) ->
     gen_server:start_link(?MODULE, [Manifest, RcPid], []).
 

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -159,7 +159,7 @@ policy_module() ->
     get_env(riak_cs, policy_module, ?DEFAULT_POLICY_MODULE).
 
 %% @doc paginated 2i is supported after Riak 1.4
-%% When using Riak CS >= 1.5 with Riak =< 1.3 (it rarely happens)
+%% When using Riak CS `>= 1.5' with Riak `=< 1.3' (it rarely happens)
 %% this should be set as false at app.config.
 -spec gc_paginated_indexes() -> atom().
 gc_paginated_indexes() ->

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -612,16 +612,16 @@ current_state() ->
 
 -ifdef(TEST).
 
-%% @doc Start the garbage collection server
+%% Start the garbage collection server
 test_link() ->
     gen_fsm:start_link({local, ?SERVER}, ?MODULE, [testing], []).
 
-%% @doc Start the garbage collection server
+%% Start the garbage collection server
 test_link(Interval) ->
     application:set_env(riak_cs, gc_interval, Interval),
     test_link().
 
-%% @doc Manipulate the current state of the fsm for testing
+%% Manipulate the current state of the fsm for testing
 change_state(State) ->
     gen_fsm:sync_send_all_state_event(?SERVER, {change_state, State}).
 

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -84,7 +84,6 @@
 %% initialize. To ensure a synchronized start-up procedure, this
 %% function does not return until Module:init/1 has returned.
 %%
-%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
 %% @end
 %%--------------------------------------------------------------------
 start_link(Bucket, Key, RcPid) ->

--- a/src/riak_cs_oos_response.erl
+++ b/src/riak_cs_oos_response.erl
@@ -109,10 +109,8 @@ error_code_to_atom(ErrorCode) ->
             unknown
     end.
 
--spec error_message(atom() | {'riak_connect_failed', term()}) -> string().
--spec error_code(atom() | {'riak_connect_failed', term()}) -> string().
--spec status_code(atom() | {'riak_connect_failed', term()}) -> pos_integer().
 
+-spec error_message(atom() | {'riak_connect_failed', term()}) -> string().
 error_message(invalid_access_key_id) ->
     "The AWS Access Key Id you provided does not exist in our records.";
 error_message(invalid_email_address) ->
@@ -160,6 +158,7 @@ error_message(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "Please reduce your request rate.".
 
+-spec error_code(atom() | {'riak_connect_failed', term()}) -> string().
 error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
 error_code(access_denied) -> "AccessDenied";
 error_code(bucket_not_empty) -> "BucketNotEmpty";
@@ -197,6 +196,7 @@ error_code(ErrorName) ->
 %% These should match:
 %% http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 
+-spec status_code(atom() | {'riak_connect_failed', term()}) -> pos_integer().
 status_code(invalid_access_key_id) -> 403;
 status_code(invalid_email_address) -> 400;
 status_code(access_denied) ->  403;

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -690,6 +690,7 @@ parse_principals([{<<"AWS">>,<<"*">>}|TL], Principal) ->
 %% TODO: CanonicalUser as principal is not yet supported,
 %%  Because to use at Riak CS, key_id is better to specify user, because
 %%  getting canonical ID from Riak is not enough efficient
+%% ```
 %% parse_principals([{<<"CanonicalUser">>,CanonicalIds}|TL], Principal) ->
 %%     case CanonicalIds of
 %%         [H|_] when is_binary(H) ->
@@ -703,6 +704,7 @@ parse_principals([{<<"AWS">>,<<"*">>}|TL], Principal) ->
 %%             %% in case of just a string ["CAFEBABE..."]
 %%             parse_principals(TL, [{canonical_id, binary_to_list(CanonicalId)}|Principal])
 %%     end.
+%% '''
 
 print_principal('*') -> <<"*">>;
 print_principal({aws, '*'}) ->
@@ -831,9 +833,11 @@ parse_bool(MaybeBool) when is_binary(MaybeBool) ->
     end;
 parse_bool(_) -> {error, notbool}.
 
-% TODO: IPv6
-% <<"10.1.2.3/24">> -> {{10,1,2,3}, {255,255,255,0}}
-% "10.1.2.3/24 -> {{10,1,2,3}, {255,255,255,0}}
+%% TODO: IPv6
+%% ```
+%% <<"10.1.2.3/24">> -> {{10,1,2,3}, {255,255,255,0}}
+%% "10.1.2.3/24 -> {{10,1,2,3}, {255,255,255,0}}
+%% '''
 %% NOTE: Returns false on a bad ip
 -spec parse_ip(binary() | string()) -> {inet:ip_address(), inet:ip_address()} | {error, term()}.
 parse_ip(Bin) when is_binary(Bin) ->

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -44,7 +44,7 @@
 
 %% @doc Sum the number of bytes stored in active files in all of the
 %% given user's directories.  The result is a list of pairs of
-%% `{BucketName, Bytes}`.
+%% `{BucketName, Bytes}'.
 -spec sum_user(riak_client(), string()) -> {ok, [{string(), integer()}]}
                                  | {error, term()}.
 sum_user(RcPid, User) when is_binary(User) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -354,15 +354,19 @@ maybe_process_resolved(Object, ResolvedManifestsHandler, ErrorReturn) ->
 reduce_keys_and_manifests(Acc, _) ->
     Acc.
 
--spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
--spec sha(binary()) -> binary().
 
 -ifdef(new_hash).
+-spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
 sha_mac(Key,STS) -> crypto:hmac(sha, Key,STS).
+
+-spec sha(binary()) -> binary().
 sha(Bin) -> crypto:hash(sha, Bin).
 
 -else.
+-spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
 sha_mac(Key,STS) -> crypto:sha_mac(Key,STS).
+
+-spec sha(binary()) -> binary().
 sha(Bin) -> crypto:sha(Bin).
 
 -endif.
@@ -377,29 +381,28 @@ md5(List) when is_list(List) ->
 
 -ifdef(new_hash).
 -spec md5_init() -> crypto_context().
--spec md5_update(crypto_context(), binary()) -> crypto_context().
--spec md5_final(crypto_context()) -> digest().
-
 md5_init() -> crypto:hash_init(md5).
 
+-spec md5_update(crypto_context(), binary()) -> crypto_context().
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
     crypto:hash_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
     md5_update(crypto:hash_update(Ctx, Part), Rest).
+
+-spec md5_final(crypto_context()) -> digest().
 md5_final(Ctx) -> crypto:hash_final(Ctx).
 
 -else.
 -spec md5_init() -> binary().
--spec md5_update(binary(), binary()) -> binary().
--spec md5_final(binary()) -> digest().
-
 md5_init() -> crypto:md5_init().
 
+-spec md5_update(binary(), binary()) -> binary().
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
     crypto:md5_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
     md5_update(crypto:md5_update(Ctx, Part), Rest).
 
+-spec md5_final(binary()) -> digest().
 md5_final(Ctx) -> crypto:md5_final(Ctx).
 -endif.
 

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -567,7 +567,7 @@ default_produce_body(RD, Ctx=#context{submodule=Mod,
             ResponseMod:api_error(Reason, RD, Ctx)
     end.
 
-%% @doc this function will be called by `post_authenticate/2` if the user successfully
+%% @doc this function will be called by `post_authenticate/2' if the user successfully
 %% authenticates and the submodule does not provide an implementation
 %% of authorize/2. The default implementation does not perform any authorization
 %% and simply returns false to signify the request is not fobidden

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -63,7 +63,7 @@
 %% @doc parse XML and produce xmlElement (other comments and else are bad)
 %% in R15B03 (and maybe later version), xmerl_scan:string/2 may return any
 %% xml nodes, such as defined as xmlNode() above. It it unsafe because
-%% `String` is the Body sent from client, which can be anything.
+%% `String' is the Body sent from client, which can be anything.
 -spec scan(string()) -> {ok, xmlElement()} | {error, malformed_xml}.
 scan(String) ->
     case catch xmerl_scan:string(String, [{space, normalize}]) of


### PR DESCRIPTION
Run `make docs` on the previous commit to see all of the individual
error messages. There are several basic types of changes:
- Fix `foo` syntax to `foo'
- Put specs on top of their functions. Otherwise edoc complains that
- there are multiple spec definitions for a function
- Properly escape code that edoc was interpreting  as XML
- Make sure module documentation comes before `-module(..).`

`rm -rf doc && make docs; echo $?` should now exit with 0, and have no
warnings or errors printed.
