### PR TITLE
Add bucket number limit check in Riak CS process

### DIFF
--- a/dialyzer.ignore-warnings.ee
+++ b/dialyzer.ignore-warnings.ee
@@ -1,6 +1,6 @@
 # Errors
 Function get_block_remote/5 has no local return
-riak_cs_config.erl:211: Function will never be called
+riak_cs_config.erl:212: Function will never be called
 # Warnings
 Unknown functions:
   app_helper:get_prop_or_env/3

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -382,6 +382,7 @@
 -define(BUCKETS_BUCKET, <<"moss.buckets">>).
 -define(GC_BUCKET, <<"riak-cs-gc">>).
 -define(FREE_BUCKET_MARKER, <<"0">>).
+-define(DEFAULT_MAX_BUCKETS_PER_USER, 100).
 -define(DEFAULT_MAX_CONTENT_LENGTH, 5368709120). %% 5 GB
 -define(DEFAULT_LFS_BLOCK_SIZE, 1048576).%% 1 MB
 -define(XML_PROLOG, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>").

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -66,6 +66,7 @@ cs_config() ->
        {riak_pb_port, 10017},
        {stanchion_port, 9095},
        {cs_version, 010300},
-       {enforce_multipart_part_size, false}
+       {enforce_multipart_part_size, false},
+       {max_buckets_per_user, 150}
       ]
      }].

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -64,7 +64,8 @@ create_bucket(User, UserObj, Bucket, BagId, ACL, RcPid) ->
 
     %% Do not attempt to create bucket if the user already owns it
     AttemptCreate = riak_cs_config:disable_local_bucket_check() orelse
-        not bucket_exists(CurrentBuckets, binary_to_list(Bucket)),
+        not (bucket_exists(CurrentBuckets, binary_to_list(Bucket))
+             and length(CurrentBuckets) < riak_cs_config:max_buckets_per_user()),
     case AttemptCreate of
         true ->
             case valid_bucket_name(Bucket) of

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -51,7 +51,8 @@
          set_user_buckets_prune_time/1,
          riak_host_port/0,
          connect_timeout/0,
-         is_multibag_enabled/0
+         is_multibag_enabled/0,
+         max_buckets_per_user/0
         ]).
 
 %% OpenStack config
@@ -309,6 +310,10 @@ connect_timeout() ->
 -spec is_multibag_enabled() -> boolean().
 is_multibag_enabled() ->
     application:get_env(riak_cs_multibag, bags) =/= undefined.
+
+-spec max_buckets_per_user() -> non_neg_integer() | unlimited.
+max_buckets_per_user() ->
+    get_env(riak_cs, max_buckets_per_user, ?DEFAULT_MAX_BUCKETS_PER_USER).
 
 %% ===================================================================
 %% S3 config options


### PR DESCRIPTION
The size of an user record is proportional to bucket number. If too
many buckets were created, then the user's record gets large and
access to anything owned by the user gets slow. This commit adds
bucket number limitation in bucket creation, to prevent user record to
grow too large. As this is not a strict check in a critical section,
there might be a race condition in multiple bucket creations where
they validate total number of owned buckets and then send requests to
Stanchion. But bucket creation is a rare operation, this won't happen
so frequently.

The case where this commit can't prevent growth of an user object is,
when buckets are frequently created and deleted; in that case the user
record may have many deleted bucket records. But that will be pruned.

Addressed by #927 
