### PR TITLE
GC may stall due to  riak_cs_delete_fsm deadlock

### DIFF
--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -167,7 +167,7 @@ block_sort_fun(SafeBlockSize) ->
             PartBlocks = initial_blocks(PartManifest?PART_MANIFEST.content_length,
                                         SafeBlockSize,
                                         PartManifest?PART_MANIFEST.part_id),
-            lists:usort(Parts ++ PartBlocks)
+            lists:usort(PartBlocks ++ Parts)
     end.
 
 block_sequences_for_part_manifests_skip(SafeBlockSize, [PM | Rest],

--- a/src/riak_cs_lfs_utils.erl
+++ b/src/riak_cs_lfs_utils.erl
@@ -109,10 +109,14 @@ initial_blocks(ContentLength, BlockSize) ->
     UpperBound = block_count(ContentLength, BlockSize),
     lists:seq(0, (UpperBound - 1)).
 
+-spec initial_blocks(integer(), integer(), binary()) ->
+                            [{binary(), integer()}].
 initial_blocks(ContentLength, SafeBlockSize, UUID) ->
     Bs = initial_blocks(ContentLength, SafeBlockSize),
     [{UUID, B} || B <- Bs].
 
+-spec range_blocks(integer(), integer(), integer(), binary()) ->
+                            {[{binary(), integer()}], integer(), integer()}.
 range_blocks(Start, End, SafeBlockSize, UUID) ->
     SkipInitial = Start rem SafeBlockSize,
     KeepFinal = (End rem SafeBlockSize) + 1,
@@ -122,6 +126,8 @@ range_blocks(Start, End, SafeBlockSize, UUID) ->
     {[{UUID, B} || B <- lists:seq(Start div SafeBlockSize, End div SafeBlockSize)],
      SkipInitial, KeepFinal}.
 
+-spec block_sequences_for_manifest(lfs_manifest()) ->
+                                          ordsets:ordset({binary(), integer()}).
 block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest) ->
     block_sequences_for_manifest(Manifest?MANIFEST{props=[]});
 block_sequences_for_manifest(?MANIFEST{uuid=UUID,
@@ -129,15 +135,16 @@ block_sequences_for_manifest(?MANIFEST{uuid=UUID,
     SafeBlockSize = safe_block_size_from_manifest(Manifest),
     case riak_cs_mp_utils:get_mp_manifest(Manifest) of
         undefined ->
-            initial_blocks(ContentLength, SafeBlockSize, UUID);
+            ordsets:from_list(
+              initial_blocks(ContentLength, SafeBlockSize, UUID));
         MpM ->
             PartManifests = MpM?MULTIPART_MANIFEST.parts,
-            lists:append([initial_blocks(PM?PART_MANIFEST.content_length,
-                                         SafeBlockSize,
-                                         PM?PART_MANIFEST.part_id) ||
-                             PM <- PartManifests])
+            ordsets:from_list(
+              lists:foldl(block_sort_fun(SafeBlockSize), [], PartManifests))
     end.
 
+-spec block_sequences_for_manifest(lfs_manifest(), {integer(), integer()}) ->
+                                          {[{binary(), integer()}], integer(), integer()}.
 block_sequences_for_manifest(?MANIFEST{props=undefined}=Manifest, {Start, End}) ->
     block_sequences_for_manifest(Manifest?MANIFEST{props=[]}, {Start, End});
 block_sequences_for_manifest(?MANIFEST{uuid=UUID}=Manifest,
@@ -150,6 +157,17 @@ block_sequences_for_manifest(?MANIFEST{uuid=UUID}=Manifest,
             PartManifests = MpM?MULTIPART_MANIFEST.parts,
             block_sequences_for_part_manifests_skip(SafeBlockSize, PartManifests,
                                                     Start, End)
+    end.
+
+
+-type block_sort_fun() :: fun((part_manifest(), list(part_manifest())) -> list(part_manifest())).
+-spec block_sort_fun(pos_integer()) -> block_sort_fun().
+block_sort_fun(SafeBlockSize) ->
+    fun(PartManifest, Parts) ->
+            PartBlocks = initial_blocks(PartManifest?PART_MANIFEST.content_length,
+                                        SafeBlockSize,
+                                        PartManifest?PART_MANIFEST.part_id),
+            lists:usort(Parts ++ PartBlocks)
     end.
 
 block_sequences_for_part_manifests_skip(SafeBlockSize, [PM | Rest],

--- a/test/riak_cs_delete_deadlock.erl
+++ b/test/riak_cs_delete_deadlock.erl
@@ -1,0 +1,129 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+-module(riak_cs_delete_deadlock).
+
+-ifdef(EQC).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("riak_cs.hrl").
+
+-compile(export_all).
+
+%% eqc property
+-export([prop_delete_deadlock/0]).
+
+-define(TEST_ITERATIONS, 500).
+-define(QC_OUT(P),
+    eqc:on_output(fun(Str, Args) ->
+                io:format(user, Str, Args) end, P)).
+-define(CONTENT_LENGTH, 10 * 1048576).
+-define(BLOCK_SIZE, 1024).
+
+%%====================================================================
+%% Eunit tests
+%%====================================================================
+
+eqc_test_() ->
+    {spawn,
+     [{setup,
+       fun setup/0,
+       fun cleanup/1,
+       [%% Run the quickcheck tests
+        {timeout, 300,
+            ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT((prop_delete_deadlock())))))}
+       ]
+      }
+     ]
+    }.
+
+setup() ->
+    ok.
+
+cleanup(_) ->
+    ok.
+
+
+%% ====================================================================
+%% eqc property
+%% ====================================================================
+
+prop_delete_deadlock() ->
+    ?FORALL({UUID, Parts},
+             {g_uuid(),
+              part_manifests()},
+             begin
+                BlockSize = riak_cs_lfs_utils:block_size(),
+                Manifest = riak_cs_lfs_utils:new_manifest(<<"bucket">>,
+                                                          "test_file",
+                                                          UUID,
+                                                          ?CONTENT_LENGTH,
+                                                          <<"ctype">>,
+                                                          "md5",
+                                                          dict:new(),
+                                                          BlockSize,
+                                                          riak_cs_acl_utils:default_acl("tester",
+                                                                                        "tester_id",
+                                                                                        "tester_key_id")),
+                MpM = ?MULTIPART_MANIFEST{parts = Parts},
+                NewManifest = Manifest?MANIFEST{props = 
+                    riak_cs_mp_utils:replace_mp_manifest(MpM, Manifest?MANIFEST.props)},
+
+                OutputList = riak_cs_lfs_utils:block_sequences_for_manifest(NewManifest),
+                TestList = assemble_test_list(?CONTENT_LENGTH, BlockSize, Parts),
+
+                OutputList == TestList
+            end).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+assemble_test_list(ContentLength, BlockSize, Parts) ->
+    Int = ContentLength div BlockSize,
+    lists:usort([ {Part?PART_MANIFEST.part_id, BlockSeg} || BlockSeg <- lists:seq(0, Int - 1),
+                                  Part <- Parts ]).
+
+%%====================================================================
+%% Generators
+%%====================================================================
+part_manifests() ->
+    not_empty(eqc_gen:list(part())).
+
+raw_part() ->    
+    ?PART_MANIFEST{bucket= <<"part_bucket">>, 
+                   key = <<"part_key">>,
+                   start_time = os:timestamp(),
+                   part_id = g_uuid(),
+                   content_length = ?CONTENT_LENGTH,
+                   block_size=?BLOCK_SIZE}.
+part() ->          
+    ?LET(Part, raw_part(), process_part(Part)).
+
+process_part(Part) ->
+    Part?PART_MANIFEST{part_number = choose(1,1000)}.
+
+g_uuid() ->
+    noshrink(eqc_gen:bind(eqc_gen:bool(), fun(_) -> druuid:v4_str() end)).
+
+not_empty(G) ->
+    ?SUCHTHAT(X, G, X /= [] andalso X /= <<>>).
+
+-endif.


### PR DESCRIPTION
GC can stall when a `riak_cs_delete_fsm` worker process encounters a deadlock condition. It is related to the `delete_concurrency` setting, but only has the potential to affect files that were uploaded using multipart upload.

The problem rests on the fact that we treat the `delete_blocks_remaining` field of the object manifest as an ordered set except when that set is initially determined for a manifest that contains metadata indicating it was a multipart upload. The initial assignment for `delete_blocks_remaining` can be seen [here](https://github.com/basho/riak_cs/blob/release/1.5/src/riak_cs_delete_fsm.erl#L247). The code that fails to properly order the list of upload parts is [here](https://github.com/basho/riak_cs/blob/release/1.5/src/riak_cs_lfs_utils.erl#L135).

The reason this is an issue and that `riak_cs_delete_fsm` processes hang around indefinitely is that the `ordsets:del_element` [call is used to remove elements of the `delete_blocks_remaining` set](https://github.com/basho/riak_cs/blob/release/1.5/src/riak_cs_lfs_utils.erl#L333) as the delete workers (whose count is controlled by `delete_concurrency`) respond that their assigned blocks have been deleted. If a call to `ordsets:del_element` is made with an element that does not exist in the set or more imporantly in this case is made on an unordered set where the element for deletion sorts less than any key ahead of it in the the set, the return value is identical to the input set. This can come into play when you have `delete_concurrency` greater than 1 and a block delete worker, call it worker _A_, assigned to delete a block identified by `{UUID, BlockNumber}` return a response to the riak_cs_delete_fsm process before another delete worker, worker _B_, whose assigned `{UUID, BlockNumber}` pair sorts greater than that of worker _A_, but appears before the pair of worker A int the set. More concisely, if the block assigned to worker _A_ sorts less than that assigned to worker _B_, but appears after the block assigned to worker _B_ in the `delete_blocks_remaining` set in the manifest and worker _A_ responds before worker _B_, then the entry for worker _A_ will not be removed from the `delete_blocks_remaining` set . Since the delete fsm relies on `delete_blocks_remaining` being empty as a termination condition, the process will hang forever and GC stalls out.

Here is a snippet of the return value from a call to `riak_cs_lfs_utils:block_sequences_for_manifest` for a multipart-uploaded file:

```
[{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,0},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,1},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,2},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,3},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,4},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,5},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,6},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,7},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,8},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,9},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,10},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,11},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,12},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,13},
{<<65,96,107,167,183,167,76,217,141,81,114,254,144,244,52,133>>,14},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,0},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,1},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,2},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,3},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,4},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,5},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,6},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,7},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,8},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,9},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,10},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,11},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,12},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,13},
{<<59,96,159,218,40,102,71,175,150,203,86,162,121,73,239,151>>,14},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,0},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,1},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,2},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,3},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,4},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,5},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,6},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,7},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,8},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,9},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,10},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,11},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,12},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,13},
{<<65,3,98,125,155,70,68,164,142,30,86,92,118,80,72,124>>,14},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,0},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,1},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,2},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,3},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,4},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,5},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,6},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,7},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,8},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,9},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,10},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,11},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,12},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,13},
{<<55,111,232,89,145,102,68,183,181,224,42,97,177,53,222,22>>,14},
{<<205,40,202,58,57,21,69,232,143,194,10,120,82,3,214,169>>,0},
{<<205,40,202,58,57,21,69,232,143,194,10,120,82,3,214,169>>,1}...
```
