### PR TITLE
Use new UUID for seed of canonical ID instead of secret

### DIFF
--- a/test/riak_cs_bucket_test.erl
+++ b/test/riak_cs_bucket_test.erl
@@ -46,9 +46,10 @@ handle_delete_response_test() ->
 bucket_resolution_test() ->
     %% @TODO Replace or augment this with eqc testing.
     UserRecord = riak_cs_user:user_record("uncle fester",
-                                           "fester@tester.com",
-                                           "festersquest",
-                                           "wasthebest"),
+                                          "fester@tester.com",
+                                          "festersquest",
+                                          "wasthebest",
+                                          "cid"),
     BucketList1 = [riak_cs_bucket:bucket_record(<<"bucket1">>, create),
                    riak_cs_bucket:bucket_record(<<"bucket2">>, create),
                    riak_cs_bucket:bucket_record(<<"bucket3">>, create)],


### PR DESCRIPTION
Canonical IDs are not hidden information.
Worry about nothing, but better not to use secret (hidden information) to generate it if unnecessary.

This is NOT an security issue because secret is hased by md5 even before this PR.
