### PR TITLE
Single user mode

### DIFF
--- a/dialyzer.ignore-warnings.ee
+++ b/dialyzer.ignore-warnings.ee
@@ -1,6 +1,6 @@
 # Errors
 Function get_block_remote/5 has no local return
-riak_cs_config.erl:212: Function will never be called
+riak_cs_config.erl:240: Function will never be called
 # Warnings
 Unknown functions:
   app_helper:get_prop_or_env/3

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -423,6 +423,7 @@ fetch_bucket_object(BucketName, RcPid) ->
             end;
         true ->
             {ok, {Key, _Secret}} = riak_cs_config:admin_creds(),
+            %% This object is just dummy; can't mimic true Riak object.
             Obj = riakc_obj:new(?BUCKETS_BUCKET, BucketName, list_to_binary(Key)),
             {ok, Obj}
     end.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -145,7 +145,7 @@ auth_module() ->
 %%  single user mode, Stanchion is not required.
 -spec is_single_user_mode() -> boolean().
 is_single_user_mode() ->
-    get_env(riak_cs, single_mode, false).
+    get_env(riak_cs, single_user_mode, false).
 
 %% @doc In single user mode, there are no buckets by default. Buckets
 %% should by created by specifying their name at all Riak CS's

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -26,6 +26,8 @@
          api/0,
          auth_bypass/0,
          admin_auth_enabled/0,
+         is_single_user_mode/0,
+         single_users_buckets/0,
          auth_module/0,
          cluster_id/1,
          cs_version/0,
@@ -134,6 +136,23 @@ admin_auth_enabled() ->
 -spec auth_module() -> atom().
 auth_module() ->
     get_env(riak_cs, auth_module, ?DEFAULT_AUTH_MODULE).
+
+%% @doc Single user mode is a special mode, where small-object access
+%%  is dominant and querying to moss.users or moss.buckets could be
+%%  bottleneck. In single user mode, no user creation,
+%%  enabling/disabling and bucket creation, deletion, modification is
+%%  permitted. Even ACL cannot be set. Just authorization. Thus in
+%%  single user mode, Stanchion is not required.
+-spec is_single_user_mode() -> boolean().
+is_single_user_mode() ->
+    get_env(riak_cs, single_mode, false).
+
+%% @doc In single user mode, there are no buckets by default. Buckets
+%% should by created by specifying their name at all Riak CS's
+%% `app.config'.
+-spec single_users_buckets() -> [string()].
+single_users_buckets() ->
+    get_env(riak_cs, single_users_buckets, []).
 
 -spec disable_local_bucket_check() -> boolean().
 disable_local_bucket_check() ->

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -26,8 +26,9 @@
          api/0,
          auth_bypass/0,
          admin_auth_enabled/0,
-         is_single_user_mode/0,
+         single_user_mode/0,
          single_users_buckets/0,
+         single_users_canonical_id/0,
          auth_module/0,
          cluster_id/1,
          cs_version/0,
@@ -143,16 +144,24 @@ auth_module() ->
 %%  enabling/disabling and bucket creation, deletion, modification is
 %%  permitted. Even ACL cannot be set. Just authorization. Thus in
 %%  single user mode, Stanchion is not required.
--spec is_single_user_mode() -> boolean().
-is_single_user_mode() ->
-    get_env(riak_cs, single_user_mode, false).
+-spec single_user_mode() -> boolean().
+single_user_mode() ->
+    case get_env(riak_cs, single_user_mode, undefined) of
+        enabled -> true;
+        _ -> false
+    end.
 
 %% @doc In single user mode, there are no buckets by default. Buckets
 %% should by created by specifying their name at all Riak CS's
 %% `app.config'.
--spec single_users_buckets() -> [string()].
+-spec single_users_buckets() -> [string()|{string(), proplists:proplist()}].
 single_users_buckets() ->
     get_env(riak_cs, single_users_buckets, []).
+
+%% @doc
+-spec single_users_canonical_id() -> [string()].
+single_users_canonical_id() ->
+    get_env(riak_cs, single_users_canonical_id, "").
 
 -spec disable_local_bucket_check() -> boolean().
 disable_local_bucket_check() ->

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -76,7 +76,7 @@ authorize(RD, Ctx, _BucketObj, 'GET', notfound = _Manifest) ->
 authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
     riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
-    case riak_cs_config:is_single_user_mode() of
+    case riak_cs_config:single_user_mode() of
         false ->
             riak_cs_wm_utils:object_access_authorize_helper(object, true, RD, Ctx);
         true ->

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -76,7 +76,12 @@ authorize(RD, Ctx, _BucketObj, 'GET', notfound = _Manifest) ->
 authorize(RD, Ctx, _BucketObj, 'HEAD', notfound = _Manifest) ->
     riak_cs_wm_utils:respond_api_error(RD, Ctx, no_such_key);
 authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
-    riak_cs_wm_utils:object_access_authorize_helper(object, true, RD, Ctx).
+    case riak_cs_config:is_single_user_mode() of
+        false ->
+            riak_cs_wm_utils:object_access_authorize_helper(object, true, RD, Ctx);
+        true ->
+            {false, RD, Ctx}
+    end.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -438,6 +438,7 @@ maybe_update_context_with_acl_from_headers(RD,
                 {ok, {ok, Acl=?ACL{}}} ->
                     {ok, Ctx#context{acl=Acl}};
                 error ->
+                    lager:debug("user: ~p", [User]),
                     DefaultAcl = riak_cs_acl_utils:default_acl(User?RCS_USER.display_name,
                                                                User?RCS_USER.canonical_id,
                                                                User?RCS_USER.key_id),


### PR DESCRIPTION
When all the access goes to single bucket (and single user) then getting user record and bucket object from Riak might be bottleneck, because every single operation is serialized there. This patch makes a new separate mode that does not use `moss.buckets` nor `moss.users`, but takes them from `app.config`. Also,  if single user mode is enabled there is no need for stanchion.

Limitations are: no ACLs, policies can be modified at runtime. No users and no buckets can be created on runtime. Enabled APIs are: PUT,GET,DELETE Object, GET Bucket. And pre-defined canned ACLs. This mode cannot be mixed with existing Riak CS setup (or, if very carefully configured, maybe).

To enable this mode, add lines like this to `app.config`:

``` erlang
              {single_user_mode, enabled},
              {single_users_buckets,
               [
                "su-flat-bucket",
                {"su-acl-public-read", [{canned_acl, "public-read"}]},
                {"su-acl-public-rw", [{canned_acl, "public-read-write"}]}
               ]
              },
```

The only accessible user is admin, defined via `admin_key` and `admin_secret`.
