### PR TITLE
Add sleep after update manifests to avoid sibling explosion

### DIFF
--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -326,7 +326,7 @@ maybe_backpressure_sleep(Siblings, BackpressureThreshold)
   when Siblings < BackpressureThreshold ->
     ok;
 maybe_backpressure_sleep(Siblings, _BackpressureThreshold) ->
-    MaxSleep = riak_cs_config:get_env(riak_cs, manifest_siblings_bp_max_sleep, 10*1000),
+    MaxSleep = riak_cs_config:get_env(riak_cs, manifest_siblings_bp_max_sleep, 30*1000),
     Coefficient = riak_cs_config:get_env(riak_cs, manifest_siblings_bp_coefficient, 200),
     MeanSleepMS = min(Coefficient * Siblings, MaxSleep),
     Delta = MeanSleepMS div 2,

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -53,7 +53,8 @@
               object_head,
               object_delete,
               object_get_acl,
-              object_put_acl]).
+              object_put_acl,
+              manifest_siblings_bp_sleep]).
 
 %% ====================================================================
 %% API


### PR DESCRIPTION
Another candidate solution #882 of based on the @kuenishi 's idea (see also #905).

Idea is simple:
sleep some interval after get-modify-update manifests depending on #(siblings)

knobs
- `manifest_siblings_bp_threashold` (default 5)
  
  threshold to trigger backpressure by sleep
- `manifest_siblings_bp_coefficient` (default 200 [msec])
  
  Coefficient of sleep interval, which is `manifest_siblings_bp_coefficient * #(siblings)`
- `manifest_siblings_bp_max_sleep` (default 30*1000 [msec] = 30sec)
  
  Max sleep interval. Mean sleep interval is determined by minimum of this value and the above.

Actual sleep interval is uniformly randomized between
(0.5 \* mean sleep interval, 1.5 \* mean sleep interval).
