### PR TITLE
First step of Riak 2.0 adoption

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,6 +4,9 @@
 
 {cover_enabled, true}.
 
+%% EDoc options
+{edoc_opts, [preprocess]}.
+
 {lib_dirs, ["deps", "apps"]}.
 
 {erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,7 @@
         {node_package, "1.3.8", {git, "git://github.com/basho/node_package", {tag, "1.3.8"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.3"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "1.4.2"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.3"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "0.78"}},
@@ -56,6 +56,6 @@
        ]}.
 
 {deps_ee, [
-           {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
+           {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.0.0rc1"}}},
            {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.0"}}}
           ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -54,5 +54,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "master"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.0"}}}
           ]}.

--- a/riak_test/src/list_objects_test_helper.erl
+++ b/riak_test/src/list_objects_test_helper.erl
@@ -117,7 +117,7 @@ test(UserConfig) ->
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
 
     ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(?TEST_BUCKET, UserConfig)),
-    pass.
+    rtcs:pass().
 
 load_objects(Bucket, Count, Config) ->
     load_objects(Bucket, Count, [], Config).

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -118,6 +118,15 @@ setup_clusters(Configs, JoinFun, NumNodes) ->
     {AdminConfig, Nodes}.
 
 
+pass() ->
+    teardown(),
+    pass.
+
+teardown() ->
+    %% catch application:stop(sasl),
+    catch application:stop(erlcloud),
+    catch application:stop(ibrowse).
+
 configs(CustomConfigs) ->
     [{riak, proplists:get_value(riak, CustomConfigs, riak_config())},
      {cs, proplists:get_value(cs, CustomConfigs, cs_config())},

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -40,7 +40,8 @@ confirm() ->
     flush_access_stats(),
     assert_access_stats(json, UserConfig, {Begin, End}),
     assert_access_stats(xml, UserConfig, {Begin, End}),
-    pass.
+
+    rtcs:pass().
 
 generate_some_accesses(UserConfig) ->
     Begin = rtcs:datetime(),

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -52,7 +52,7 @@ confirm() ->
     End = rtcs:datetime(),
 
     assert_storage_stats(UserConfig, Begin, End),
-    pass.
+    rtcs:pass().
 
 assert_storage_stats(UserConfig, Begin, End) ->
     KeyId = UserConfig#aws_config.access_key_id,

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -25,7 +25,7 @@ confirm() ->
            {"CS_BUCKET",             ?TEST_BUCKET}],
     case execute_cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}]) of
         ok ->
-            pass;
+            rtcs:pass();
         {error, Reason} ->
             lager:error("Error : ~p", [Reason]),
             error({external_client_tests, Reason})

--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -130,7 +130,7 @@ confirm() ->
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
 
     ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(?TEST_BUCKET, UserConfig)),
-    pass.
+    rtcs:pass().
 
 upload_and_assert_parts(Bucket, Key, UploadId, PartCount, Size, Config) ->
     [{X, rtcs_multipart:upload_and_assert_part(Bucket,

--- a/riak_test/tests/object_get_conditional_test.erl
+++ b/riak_test/tests/object_get_conditional_test.erl
@@ -51,7 +51,7 @@ confirm() ->
                                        Content, ThreeDates, UserConfig),
     match_condition_test_cases(?TEST_BUCKET, ?TEST_KEY,
                                Content, Etag, UserConfig),
-    pass.
+    rtcs:pass().
 
 setup_object(Bucket, Key, UserConfig) ->
     Content = crypto:rand_bytes(400),

--- a/riak_test/tests/object_get_test.erl
+++ b/riak_test/tests/object_get_test.erl
@@ -50,7 +50,8 @@ confirm() ->
 
     non_mp_get_cases(UserConfig),
     mp_get_cases(UserConfig),
-    pass.
+
+    rtcs:pass().
 
 non_mp_get_cases(UserConfig) ->
     %% setup objects

--- a/riak_test/tests/put_copy_test.erl
+++ b/riak_test/tests/put_copy_test.erl
@@ -55,10 +55,10 @@ confirm() ->
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET2, UserConfig)),
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET3, UserConfig2)),
 
-    pass = verify_simple_copy(UserConfig),
-    pass = verify_others_copy(UserConfig, UserConfig2),
-    pass = verify_multipart_copy(UserConfig),
-    pass = verify_security(UserConfig, UserConfig2, UserConfig3),
+    ok = verify_simple_copy(UserConfig),
+    ok = verify_others_copy(UserConfig, UserConfig2),
+    ok = verify_multipart_copy(UserConfig),
+    ok = verify_security(UserConfig, UserConfig2, UserConfig3),
 
     ?assertEqual([{delete_marker, false}, {version_id, "null"}],
                  erlcloud_s3:delete_object(?BUCKET, ?KEY, UserConfig)),
@@ -68,7 +68,7 @@ confirm() ->
                  erlcloud_s3:delete_object(?BUCKET2, ?KEY2, UserConfig)),
     ?assertEqual([{delete_marker, false}, {version_id, "null"}],
                  erlcloud_s3:delete_object(?BUCKET3, ?KEY, UserConfig2)),
-    pass.
+    rtcs:pass().
 
 
 verify_simple_copy(UserConfig) ->
@@ -80,7 +80,7 @@ verify_simple_copy(UserConfig) ->
     lager:debug("copied object: ~p", [Props]),
     ?assertEqual(?DATA0, proplists:get_value(content, Props)),
 
-    pass.
+    ok.
 
 
 verify_others_copy(UserConfig, OtherUserConfig) ->
@@ -104,7 +104,7 @@ verify_others_copy(UserConfig, OtherUserConfig) ->
     Props2 = erlcloud_s3:get_object(?BUCKET3, ?KEY, OtherUserConfig),
     lager:debug("copied object: ~p", [Props2]),
     ?assertEqual(?DATA0, proplists:get_value(content, Props2)),
-    pass.
+    ok.
 
 verify_multipart_copy(UserConfig) ->
     %% ~6MB iolist
@@ -148,7 +148,7 @@ verify_multipart_copy(UserConfig) ->
     Props = erlcloud_s3:get_object(?BUCKET2, ?KEY3, UserConfig),
     %% lager:debug("~p> Props => ~p", [?LINE, Props]),
     ?assertEqual(MillionPocketBurgers, proplists:get_value(content, Props)),
-    pass.
+    ok.
 
 verify_security(Alice, Bob, Charlie) ->
     AlicesBucket = "alice",
@@ -236,4 +236,4 @@ verify_security(Alice, Bob, Charlie) ->
     lager:debug("request ~p ~p => ~p ~p", [URL, Headers, Status, Hdr]),
     ?assertEqual("403", Status),
 
-    pass.
+    ok.

--- a/riak_test/tests/regression_tests.erl
+++ b/riak_test/tests/regression_tests.erl
@@ -34,14 +34,14 @@
 confirm() ->
     {UserConfig, _} = SetupInfo = rtcs:setup(1),
 
-    pass = verify_cs296(SetupInfo, "test-bucket-cs296"),
-    pass = verify_cs347(SetupInfo, "test-bucket-cs347"),
-    pass = verify_cs436(SetupInfo, "test-bucket-cs436"),
-    pass = verify_cs512(UserConfig, "test-bucket-cs512"),
+    ok = verify_cs296(SetupInfo, "test-bucket-cs296"),
+    ok = verify_cs347(SetupInfo, "test-bucket-cs347"),
+    ok = verify_cs436(SetupInfo, "test-bucket-cs436"),
+    ok = verify_cs512(UserConfig, "test-bucket-cs512"),
 
     %% Append your next regression tests here
 
-    pass.
+    rtcs:pass().
 
 %% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/296">
 %% issue 296</a>. The issue description is: 403 instead of 404 returned when
@@ -62,7 +62,7 @@ verify_cs296(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
     ?assertEqual(ok, erlcloud_s3:delete_bucket(BucketName, UserConfig)),
 
     ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(BucketName, UserConfig)),
-    pass.
+    ok.
 
 %% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/347">
 %% issue 347</a>. The issue description is: No response body in 404 to the
@@ -98,7 +98,7 @@ verify_cs347(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
                 Result2
         end,
     ?assert(rtcs:check_no_such_bucket(ListObjectRes2, "/"++?TEST_BUCKET_CS347)),
-    pass.
+    ok.
 
 
 %% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/436">
@@ -132,7 +132,7 @@ verify_cs436(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
                                         "somekey",
                                         crypto:rand_bytes(100),
                                         UserConfig)),
-    pass.
+    ok.
 
 -define(KEY, "cs512-key").
 
@@ -143,7 +143,7 @@ verify_cs512(UserConfig, BucketName) ->
     put_and_get(UserConfig, BucketName, <<"NEW">>),
     delete(UserConfig, BucketName),
     assert_notfound(UserConfig,BucketName),
-    pass.
+    ok.
 
 put_and_get(UserConfig, BucketName, Data) ->
     erlcloud_s3:put_object(BucketName, ?KEY, Data, UserConfig),

--- a/riak_test/tests/regression_tests_2.erl
+++ b/riak_test/tests/regression_tests_2.erl
@@ -34,13 +34,13 @@ confirm() ->
               {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, Config),
 
-    pass = verify_cs631(UserConfig, "cs-631-test-bukcet"),
-    pass = verify_cs654(UserConfig),
-    pass = verify_cs781(UserConfig, "cs-781-test-bucket"),
+    ok = verify_cs631(UserConfig, "cs-631-test-bukcet"),
+    ok = verify_cs654(UserConfig),
+    ok = verify_cs781(UserConfig, "cs-781-test-bucket"),
 
     %% Append your next regression tests here
 
-    pass.
+    rtcs:pass().
 
 
 %% @doc Integration test for [https://github.com/basho/riak_cs/issues/631]
@@ -48,7 +48,7 @@ verify_cs631(UserConfig, BucketName) ->
     ?assertEqual(ok, erlcloud_s3:create_bucket(BucketName, UserConfig)),
     test_unknown_canonical_id_grant_returns_400(UserConfig, BucketName),
     test_canned_acl_and_grants_returns_400(UserConfig, BucketName),
-    pass.
+    ok.
 
 -define(KEY_1, "key-1").
 -define(KEY_2, "key-2").
@@ -99,7 +99,7 @@ run_test_empty_common_prefixes(UserConfig) ->
                                      erlcloud_s3:list_objects(?TEST_BUCKET_1,
                                                               ListObjectsOptions,
                                                               UserConfig))),
-    pass.
+    ok.
 
 %% Test for issue in comment
 %% [https://github.com/basho/riak_cs/pull/655#issuecomment-23309088]
@@ -150,7 +150,7 @@ run_test_no_duplicate_key(UserConfig) ->
                                         UserConfig),
     [SingleResult] = proplists:get_value(contents, Response),
     ?assertEqual("1.txt", proplists:get_value(key, SingleResult)),
-    pass.
+    ok.
 
 %% Test for issue in comment
 %% [https://github.com/basho/riak_cs/pull/655#issuecomment-23390742]
@@ -179,7 +179,7 @@ run_test_no_infinite_loop(UserConfig) ->
                                         UserConfig),
     [SingleResult] = proplists:get_value(common_prefixes, Response),
     ?assertEqual("0/", proplists:get_value(prefix, SingleResult)),
-    pass.
+    ok.
 
 
 
@@ -201,5 +201,5 @@ verify_cs781(UserConfig, BucketName) ->
                                      erlcloud_s3:list_objects(BucketName,
                                                               [],
                                                               UserConfig))),
-    pass.
+    ok.
 

--- a/riak_test/tests/repl_test.erl
+++ b/riak_test/tests/repl_test.erl
@@ -236,7 +236,7 @@ confirm() ->
 
     Obj15 = erlcloud_s3:get_object(?TEST_BUCKET, "object_four", U1C2Config),
     assert_equal_binary(Object4A, proplists:get_value(content,Obj15)),
-    pass.
+    rtcs:pass().
 
 assert_equal_binary(Expected, Expected) ->
     ok;

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -254,7 +254,7 @@ confirm() ->
 
     Obj15 = erlcloud_s3:get_object(?TEST_BUCKET, "object_four", U1C2Config),
     ?assertEqual(Object4A, proplists:get_value(content,Obj15)),
-    pass.
+    rtcs:pass().
 
 enable_pg(SourceLeader, SinkName, ANodes, BNodes, BPort) ->
     repl_helpers:connect_clusters13(SourceLeader, ANodes, BPort, SinkName),

--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -81,5 +81,5 @@ confirm() ->
     ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
     lager:info("deleting bucket ~p", [?TEST_BUCKET]),
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
-    pass.
+    rtcs:pass().
 

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -49,7 +49,7 @@ confirm() ->
     confirm_stat_count(Stats1, <<"object_get">>, 1),
     confirm_stat_count(Stats1, <<"object_put">>, 1),
     confirm_stat_count(Stats1, <<"object_delete">>, 1),
-    pass.
+    rtcs:pass().
 
 query_stats(UserConfig, Port) ->
     lager:debug("Querying stats"),

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -68,7 +68,7 @@ confirm() ->
                           assert_storage_json_stats(Spec, JsonStat),
                           assert_storage_xml_stats(Spec, XmlStat)
                   end, TestSpecs),
-    pass.
+    rtcs:pass().
 
 %% @doc garbage data to check #840 regression,
 %% due to this garbages, following tests may fail
@@ -221,14 +221,14 @@ assert_storage_json_stats({Bucket, ExpectedObjects, ExpectedBytes}, Sample) ->
     ?assertEqual(ExpectedBytes,   rtcs:json_get([list_to_binary(Bucket), <<"Bytes">>],     Sample)),
     ?assert(rtcs:json_get([<<"StartTime">>], Sample) =/= notfound),
     ?assert(rtcs:json_get([<<"EndTime">>],   Sample) =/= notfound),
-    pass.
+    ok.
 
 assert_storage_xml_stats({Bucket, ExpectedObjects, ExpectedBytes}, Sample) ->
     ?assertEqual(ExpectedObjects, proplists:get_value('Objects', proplists:get_value(Bucket, Sample))),
     ?assertEqual(ExpectedBytes,   proplists:get_value('Bytes', proplists:get_value(Bucket, Sample))),
     ?assert(proplists:get_value('StartTime', Sample) =/= notfound),
     ?assert(proplists:get_value('EndTime', Sample)   =/= notfound),
-    pass.
+    ok.
 
 storage_stats_request(UserConfig, Begin, End) ->
     {storage_stats_json_request(UserConfig, Begin, End),

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -55,7 +55,7 @@ confirm() ->
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
 
     ?assertError({aws_error, {http_error, 404, _, _}}, erlcloud_s3:list_objects(?TEST_BUCKET, UserConfig)),
-    pass.
+    rtcs:pass().
 
 generate_part_data(X, Size)
   when 0 =< X, X =< 255 ->

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -51,7 +51,7 @@ confirm() ->
     user_listing_xml_test_case(Users, AdminUserConfig, HeadRiakNode),
     update_user_json_test_case(AdminUserConfig, HeadRiakNode),
     update_user_xml_test_case(AdminUserConfig, HeadRiakNode),
-    pass.
+    rtcs:pass().
 
 japanese_aiueo() ->
     %% To avoid dependency on source code encoding, create list from chars.

--- a/src/riak_cs_auth.erl
+++ b/src/riak_cs_auth.erl
@@ -25,9 +25,9 @@
 -type wm_reqdata() :: tuple().
 -type wm_context() :: tuple().
 
-%% TODO: arguments of identify/2, and 3rd&4th arguments of
-%%       authenticate/4 are actually #wm_reqdata{} and #context{}
-%%       from webmachine, but can't compile after webmachine.hrl import.
+%% TODO: arguments of `identify/2', and 3rd and 4th arguments of
+%%       authenticate/4 are actually `#wm_reqdata{}' and `#context{}'
+%%       from webmachine, but can't compile after `webmachine.hrl' import.
 -callback identify(RD :: wm_reqdata(), Ctx :: wm_context()) ->
     failed | {string() | undefined, string() | tuple()} |
     {string(), undefined}.

--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -55,17 +55,12 @@
 %%% API
 %%%===================================================================
 
-%%--------------------------------------------------------------------
-%% @doc
-%% Starts the server
-%%
-%% @spec start_link(lfs_manifest()) -> {ok, Pid} | ignore | {error, Error}
-%% @spec start_link(lfs_manifest(), riak_client()) -> {ok, Pid} | ignore | {error, Error}
-%% @end
-%%--------------------------------------------------------------------
+%% @doc Starts the server
+-spec start_link(lfs_manifest()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Manifest) ->
     gen_server:start_link(?MODULE, [Manifest], []).
 
+-spec start_link(lfs_manifest(), riak_client()) -> {ok, pid()} | ignore | {error, term()}.
 start_link(Manifest, RcPid) ->
     gen_server:start_link(?MODULE, [Manifest, RcPid], []).
 

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -159,7 +159,7 @@ policy_module() ->
     get_env(riak_cs, policy_module, ?DEFAULT_POLICY_MODULE).
 
 %% @doc paginated 2i is supported after Riak 1.4
-%% When using Riak CS >= 1.5 with Riak =< 1.3 (it rarely happens)
+%% When using Riak CS `>= 1.5' with Riak `=< 1.3' (it rarely happens)
 %% this should be set as false at app.config.
 -spec gc_paginated_indexes() -> atom().
 gc_paginated_indexes() ->

--- a/src/riak_cs_gc_d.erl
+++ b/src/riak_cs_gc_d.erl
@@ -612,16 +612,16 @@ current_state() ->
 
 -ifdef(TEST).
 
-%% @doc Start the garbage collection server
+%% Start the garbage collection server
 test_link() ->
     gen_fsm:start_link({local, ?SERVER}, ?MODULE, [testing], []).
 
-%% @doc Start the garbage collection server
+%% Start the garbage collection server
 test_link(Interval) ->
     application:set_env(riak_cs, gc_interval, Interval),
     test_link().
 
-%% @doc Manipulate the current state of the fsm for testing
+%% Manipulate the current state of the fsm for testing
 change_state(State) ->
     gen_fsm:sync_send_all_state_event(?SERVER, {change_state, State}).
 

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -84,7 +84,6 @@
 %% initialize. To ensure a synchronized start-up procedure, this
 %% function does not return until Module:init/1 has returned.
 %%
-%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
 %% @end
 %%--------------------------------------------------------------------
 start_link(Bucket, Key, RcPid) ->

--- a/src/riak_cs_oos_response.erl
+++ b/src/riak_cs_oos_response.erl
@@ -109,10 +109,8 @@ error_code_to_atom(ErrorCode) ->
             unknown
     end.
 
--spec error_message(atom() | {'riak_connect_failed', term()}) -> string().
--spec error_code(atom() | {'riak_connect_failed', term()}) -> string().
--spec status_code(atom() | {'riak_connect_failed', term()}) -> pos_integer().
 
+-spec error_message(atom() | {'riak_connect_failed', term()}) -> string().
 error_message(invalid_access_key_id) ->
     "The AWS Access Key Id you provided does not exist in our records.";
 error_message(invalid_email_address) ->
@@ -160,6 +158,7 @@ error_message(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "Please reduce your request rate.".
 
+-spec error_code(atom() | {'riak_connect_failed', term()}) -> string().
 error_code(invalid_access_key_id) -> "InvalidAccessKeyId";
 error_code(access_denied) -> "AccessDenied";
 error_code(bucket_not_empty) -> "BucketNotEmpty";
@@ -197,6 +196,7 @@ error_code(ErrorName) ->
 %% These should match:
 %% http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 
+-spec status_code(atom() | {'riak_connect_failed', term()}) -> pos_integer().
 status_code(invalid_access_key_id) -> 403;
 status_code(invalid_email_address) -> 400;
 status_code(access_denied) ->  403;

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -690,6 +690,7 @@ parse_principals([{<<"AWS">>,<<"*">>}|TL], Principal) ->
 %% TODO: CanonicalUser as principal is not yet supported,
 %%  Because to use at Riak CS, key_id is better to specify user, because
 %%  getting canonical ID from Riak is not enough efficient
+%% ```
 %% parse_principals([{<<"CanonicalUser">>,CanonicalIds}|TL], Principal) ->
 %%     case CanonicalIds of
 %%         [H|_] when is_binary(H) ->
@@ -703,6 +704,7 @@ parse_principals([{<<"AWS">>,<<"*">>}|TL], Principal) ->
 %%             %% in case of just a string ["CAFEBABE..."]
 %%             parse_principals(TL, [{canonical_id, binary_to_list(CanonicalId)}|Principal])
 %%     end.
+%% '''
 
 print_principal('*') -> <<"*">>;
 print_principal({aws, '*'}) ->
@@ -831,9 +833,11 @@ parse_bool(MaybeBool) when is_binary(MaybeBool) ->
     end;
 parse_bool(_) -> {error, notbool}.
 
-% TODO: IPv6
-% <<"10.1.2.3/24">> -> {{10,1,2,3}, {255,255,255,0}}
-% "10.1.2.3/24 -> {{10,1,2,3}, {255,255,255,0}}
+%% TODO: IPv6
+%% ```
+%% <<"10.1.2.3/24">> -> {{10,1,2,3}, {255,255,255,0}}
+%% "10.1.2.3/24 -> {{10,1,2,3}, {255,255,255,0}}
+%% '''
 %% NOTE: Returns false on a bad ip
 -spec parse_ip(binary() | string()) -> {inet:ip_address(), inet:ip_address()} | {error, term()}.
 parse_ip(Bin) when is_binary(Bin) ->

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -44,7 +44,7 @@
 
 %% @doc Sum the number of bytes stored in active files in all of the
 %% given user's directories.  The result is a list of pairs of
-%% `{BucketName, Bytes}`.
+%% `{BucketName, Bytes}'.
 -spec sum_user(riak_client(), string()) -> {ok, [{string(), integer()}]}
                                  | {error, term()}.
 sum_user(RcPid, User) when is_binary(User) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -354,15 +354,19 @@ maybe_process_resolved(Object, ResolvedManifestsHandler, ErrorReturn) ->
 reduce_keys_and_manifests(Acc, _) ->
     Acc.
 
--spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
--spec sha(binary()) -> binary().
 
 -ifdef(new_hash).
+-spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
 sha_mac(Key,STS) -> crypto:hmac(sha, Key,STS).
+
+-spec sha(binary()) -> binary().
 sha(Bin) -> crypto:hash(sha, Bin).
 
 -else.
+-spec sha_mac(iolist() | binary(), iolist() | binary()) -> binary().
 sha_mac(Key,STS) -> crypto:sha_mac(Key,STS).
+
+-spec sha(binary()) -> binary().
 sha(Bin) -> crypto:sha(Bin).
 
 -endif.
@@ -377,29 +381,28 @@ md5(List) when is_list(List) ->
 
 -ifdef(new_hash).
 -spec md5_init() -> crypto_context().
--spec md5_update(crypto_context(), binary()) -> crypto_context().
--spec md5_final(crypto_context()) -> digest().
-
 md5_init() -> crypto:hash_init(md5).
 
+-spec md5_update(crypto_context(), binary()) -> crypto_context().
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
     crypto:hash_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
     md5_update(crypto:hash_update(Ctx, Part), Rest).
+
+-spec md5_final(crypto_context()) -> digest().
 md5_final(Ctx) -> crypto:hash_final(Ctx).
 
 -else.
 -spec md5_init() -> binary().
--spec md5_update(binary(), binary()) -> binary().
--spec md5_final(binary()) -> digest().
-
 md5_init() -> crypto:md5_init().
 
+-spec md5_update(binary(), binary()) -> binary().
 md5_update(Ctx, Bin) when size(Bin) =< ?MAX_UPDATE_SIZE ->
     crypto:md5_update(Ctx, Bin);
 md5_update(Ctx, <<Part:?MAX_UPDATE_SIZE/binary, Rest/binary>>) ->
     md5_update(crypto:md5_update(Ctx, Part), Rest).
 
+-spec md5_final(binary()) -> digest().
 md5_final(Ctx) -> crypto:md5_final(Ctx).
 -endif.
 

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -567,7 +567,7 @@ default_produce_body(RD, Ctx=#context{submodule=Mod,
             ResponseMod:api_error(Reason, RD, Ctx)
     end.
 
-%% @doc this function will be called by `post_authenticate/2` if the user successfully
+%% @doc this function will be called by `post_authenticate/2' if the user successfully
 %% authenticates and the submodule does not provide an implementation
 %% of authorize/2. The default implementation does not perform any authorization
 %% and simply returns false to signify the request is not fobidden

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -63,7 +63,7 @@
 %% @doc parse XML and produce xmlElement (other comments and else are bad)
 %% in R15B03 (and maybe later version), xmerl_scan:string/2 may return any
 %% xml nodes, such as defined as xmlNode() above. It it unsafe because
-%% `String` is the Body sent from client, which can be anything.
+%% `String' is the Body sent from client, which can be anything.
 -spec scan(string()) -> {ok, xmlElement()} | {error, malformed_xml}.
 scan(String) ->
     case catch xmerl_scan:string(String, [{space, normalize}]) of


### PR DESCRIPTION
This will be the first pull request to adapt to Riak 2.0. To run this test:
- update `riak_test` to the latest branch, from `riak-1.4` branch
- add `sasl` to `incl_apps` of `riak_test`
- update `.riak_test.config` as

``` erlang
     {build_paths, [{root,              "/home/kuenishi/rt/riak"},
                    {current,           "/home/kuenishi/rt/riak/current"},
                    {ee_root,           "/home/kuenishi/rt/riak_ee"},
                    {ee_current,        "/home/kuenishi/rt/riak_ee/current"},
                    {ee_previous,       "/home/kuenishi/rt/riak_ee_onefour/current"},
                    {cs_root,           "/home/kuenishi/rt/riak_cs"},
                    {cs_current,        "/home/kuenishi/rt/riak_cs/current"},
                    {cs_previous,        "/home/kuenishi/rt/riak_cs/1.5.0"},
                    {stanchion_root,    "/home/kuenishi/rt/stanchion"},
                    {stanchion_current, "/home/kuenishi/rt/stanchion/current"},
                    {stanchion_previous,       "/home/kuenishi/rt/stanchion/1.5.0"}
                   ]},
```

Many things left to do (will be separate PR after this merged):
- merge `release/1.5` branch after 1.5.1 release
- `repl_v3_test` and `repl_test` still does not work with riak-ee-2.0
- discuss on deprecation of v2 replication
- migration tests
- introduce cuttlefish
