### PR TITLE
Bugfix: Skip invalid state manifests in GC bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ compile-riak-test: all
 	## So we'll copy the BEAM files to a place that riak_test is
 	## already using.
 	cp -v ebin/riak_cs_wm_utils.beam riak_test/ebin
+	cp -v ebin/twop_set.beam riak_test/ebin
 
 clean-client-test:
 	@./rebar client_test_clean

--- a/riak_test/src/rc_helper.erl
+++ b/riak_test/src/rc_helper.erl
@@ -39,10 +39,17 @@ to_riak_key(Kind, _) ->
     error({not_yet_implemented, Kind}).
 
 -spec get_riakc_obj([term()], objects | blocks, binary(), term()) -> term().
-get_riakc_obj(RiakNodes, Kind, CsBucket, CsKey) ->
-    Pbc = rtcs:pbc(RiakNodes, Kind, CsBucket),
+get_riakc_obj(RiakNodes, Kind, CsBucket, Opts) ->
+    {Pbc, Key} = case Kind of
+                     objects ->
+                         {rtcs:pbc(RiakNodes, Kind, CsBucket), Opts};
+                     blocks ->
+                         {CsKey, UUID, Seq} = Opts,
+                         {rtcs:pbc(RiakNodes, Kind, {CsBucket, CsKey, UUID}),
+                          {UUID, Seq}}
+                   end,
     RiakBucket = to_riak_bucket(Kind, CsBucket),
-    RiakKey = to_riak_key(Kind, CsKey),
+    RiakKey = to_riak_key(Kind, Key),
     Result = riakc_pb_socket:get(Pbc, RiakBucket, RiakKey),
     riakc_pb_socket:stop(Pbc),
     Result.

--- a/riak_test/src/rc_helper.erl
+++ b/riak_test/src/rc_helper.erl
@@ -33,8 +33,10 @@ to_riak_bucket(_, CSBucket) ->
 
 to_riak_key(objects, CsKey) ->
     CsKey;
-to_riak_key(_,_) ->
-    throw(not_yet_implemented).
+to_riak_key(blocks, {UUID, Seq}) ->
+    <<UUID/binary, Seq:32>>;
+to_riak_key(Kind, _) ->
+    error({not_yet_implemented, Kind}).
 
 -spec get_riakc_obj([term()], objects | blocks, binary(), term()) -> term().
 get_riakc_obj(RiakNodes, Kind, CsBucket, CsKey) ->

--- a/riak_test/tests/gc_tests.erl
+++ b/riak_test/tests/gc_tests.erl
@@ -116,8 +116,9 @@ verify_gc_run(Node, GCKey) ->
     rtcs:gc(1, "batch"),
     true = rt:expect_in_log(Node,
                             "Invalid state manifest in GC bucket at <<\""
-                            ++ binary_to_list(GCKey)
-                            ++ "\">>: "),
+                            ++ binary_to_list(GCKey) ++ "\">>, "
+                            ++ "bucket=<<\"" ++ ?TEST_BUCKET ++ "\">> "
+                            ++ "key=<<\"" ++ ?TEST_KEY_BAD_STATE ++ "\">>: "),
     true = rt:expect_in_log(Node,
                             "Finished garbage collection: \\d+ seconds, "
                             "\\d batch_count, 0 batch_skips, "

--- a/riak_test/tests/gc_tests.erl
+++ b/riak_test/tests/gc_tests.erl
@@ -1,0 +1,134 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(gc_tests).
+
+%% @doc `riak_test' module for testing garbage collection
+
+-export([confirm/0]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("riak_cs.hrl").
+
+%% keys for non-multipart objects
+-define(TEST_BUCKET,        "riak-test-bucket").
+-define(TEST_KEY,          "riak_test_key").
+-define(TEST_KEY_MP,        "riak_test_mp").
+-define(TEST_KEY_BAD_STATE, "riak_test_key_bad_state").
+
+
+confirm() ->
+    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
+    %% Set up to grep logs to verify messages
+    rt:setup_log_capture(hd(CSNodes)),
+
+    {GCKey, {BKey, UUID}} = setup_obj(RiakNodes, UserConfig),
+    ok = verify_gc_run(hd(CSNodes), GCKey),
+    ok = verify_riak_object_remaining_for_bad_key(RiakNodes, GCKey, {BKey, UUID}),
+    pass.
+
+setup_obj(RiakNodes, UserConfig) ->
+    %% Setup bucket
+    lager:info("User is valid on the cluster, and has no buckets"),
+    ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
+    lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    %% Put and delete some objects
+    [begin
+         Block = crypto:rand_bytes(Size),
+         Key = ?TEST_KEY ++ Suffix,
+         erlcloud_s3:put_object(?TEST_BUCKET, Key, Block, UserConfig),
+         erlcloud_s3:delete_object(?TEST_BUCKET, Key, UserConfig)
+     end || {Suffix, Size} <- [{"1", 100}, {"2", 200}, {"3", 0}]],
+
+    %% Put and delete, but modified to pretend it is in wrong state
+    SingleBlock = crypto:rand_bytes(400),
+    erlcloud_s3:put_object(?TEST_BUCKET, ?TEST_KEY_BAD_STATE, SingleBlock, UserConfig),
+    erlcloud_s3:delete_object(?TEST_BUCKET, ?TEST_KEY_BAD_STATE, UserConfig),
+    %% Change the state in the manifest in gc bucket to active.
+    %% See https://github.com/basho/riak_cs/issues/827#issuecomment-54567839
+    Pbc = rtcs:pbc(RiakNodes, gc_bucket, not_used),
+    {ok, GCKeys} = riakc_pb_socket:list_keys(Pbc, ?GC_BUCKET),
+    BKey = {list_to_binary(?TEST_BUCKET), list_to_binary(?TEST_KEY_BAD_STATE)},
+    lager:info("Changing state to active ~p, ~p", [?TEST_BUCKET, ?TEST_KEY_BAD_STATE]),
+    {ok, GCKey, UUID} = change_state_to_active(Pbc, BKey, GCKeys),
+
+    %% Put and delete some more objects
+    [begin
+         Block = crypto:rand_bytes(Size),
+         Key = ?TEST_KEY ++ Suffix,
+         erlcloud_s3:put_object(?TEST_BUCKET, Key, Block, UserConfig),
+         erlcloud_s3:delete_object(?TEST_BUCKET, Key, UserConfig)
+     end || {Suffix, Size} <- [{"Z", 0}, {"Y", 150}, {"X", 1}]],
+
+    riakc_pb_socket:stop(Pbc),
+    {GCKey, {BKey, UUID}}.
+
+change_state_to_active(_Pbc, TargetBKey, []) ->
+    lager:warning("Target BKey ~p not found in GC bucket", [TargetBKey]),
+    {error, notfound};
+change_state_to_active(Pbc, TargetBKey, [GCKey|Rest]) ->
+    {ok, Obj0} = riakc_pb_socket:get(Pbc, ?GC_BUCKET, GCKey),
+    Manifests = twop_set:to_list(binary_to_term(riakc_obj:get_value(Obj0))),
+    case [{UUID, M?MANIFEST{state=active}} ||
+              {UUID, M} <- Manifests,
+              M?MANIFEST.bkey =:= TargetBKey] of
+        [] ->
+            change_state_to_active(Pbc, TargetBKey, Rest);
+        [{TargetUUID, TargetManifest}] ->
+            lager:info("Target BKey ~p found in GC bucket ~p", [TargetBKey, GCKey]),
+            NewManifestSet = lists:foldl(fun twop_set:add_element/2, twop_set:new(),
+                                         [{TargetUUID, TargetManifest?MANIFEST{state = active}} |
+                                          lists:keydelete(TargetUUID, 1, Manifests)]),
+            UpdObj = riakc_obj:update_value(Obj0, term_to_binary(NewManifestSet)),
+            ok = riakc_pb_socket:put(Pbc, UpdObj),
+            lager:info("Bad state manifests have been put at ~p: ~p~n",
+                       [GCKey, twop_set:to_list(NewManifestSet)]),
+            {ok, GCKey, TargetUUID}
+    end.
+
+verify_gc_run(Node, GCKey) ->
+    rtcs:gc(1, "set-leeway 1"),
+    timer:sleep(2000),
+    rtcs:gc(1, "batch"),
+    true = rt:expect_in_log(Node,
+                            "Invalid state manifest in GC bucket at <<\""
+                            ++ binary_to_list(GCKey)
+                            ++ "\">>: "),
+    true = rt:expect_in_log(Node,
+                            "Finished garbage collection: \\d+ seconds, "
+                            "\\d batch_count, 0 batch_skips, "
+                            "7 manif_count, 4 block_count"),
+    ok.
+
+%% Verify riak objects in gc buckets, manifest, block are all remaining.
+verify_riak_object_remaining_for_bad_key(RiakNodes, GCKey, {{Bucket, Key}, UUID}) ->
+    {ok, _BlockObj} = rc_helper:get_riakc_obj(RiakNodes, blocks, Bucket, {UUID, 0}),
+    {ok, _ManifestObj} = rc_helper:get_riakc_obj(RiakNodes, objects, Bucket, Key),
+
+    Pbc = rtcs:pbc(RiakNodes, gc_bucket, not_used),
+    {ok, FileSetObj} = riakc_pb_socket:get(Pbc, ?GC_BUCKET, GCKey),
+    Manifests = twop_set:to_list(binary_to_term(riakc_obj:get_value(FileSetObj))),
+    {UUID, Manifest} = lists:keyfind(UUID, 1, Manifests),
+    riakc_pb_socket:stop(Pbc),
+    lager:info("BAD manifest in GC bucket remains, stand off orphan manfiests/blocks: ~p",
+               [Manifest]),
+    ok.

--- a/riak_test/tests/gc_tests.erl
+++ b/riak_test/tests/gc_tests.erl
@@ -95,9 +95,14 @@ change_state_to_active(Pbc, TargetBKey, [GCKey|Rest]) ->
             change_state_to_active(Pbc, TargetBKey, Rest);
         [{TargetUUID, TargetManifest}] ->
             lager:info("Target BKey ~p found in GC bucket ~p", [TargetBKey, GCKey]),
-            NewManifestSet = lists:foldl(fun twop_set:add_element/2, twop_set:new(),
-                                         [{TargetUUID, TargetManifest?MANIFEST{state = active}} |
-                                          lists:keydelete(TargetUUID, 1, Manifests)]),
+            NewManifestSet =
+                lists:foldl(fun twop_set:add_element/2, twop_set:new(),
+                            [{TargetUUID,
+                              TargetManifest?MANIFEST{
+                                               state = active,
+                                               delete_marked_time=undefined,
+                                               delete_blocks_remaining=undefined}} |
+                             lists:keydelete(TargetUUID, 1, Manifests)]),
             UpdObj = riakc_obj:update_value(Obj0, term_to_binary(NewManifestSet)),
             ok = riakc_pb_socket:put(Pbc, UpdObj),
             lager:info("Bad state manifests have been put at ~p: ~p~n",

--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -32,7 +32,7 @@
 -endif.
 
 %% API
--export([start_link/4,
+-export([start_link/5,
          block_deleted/2]).
 
 %% gen_fsm callbacks
@@ -51,6 +51,9 @@
                 manifest :: lfs_manifest(),
                 riak_client :: riak_client(),
                 gc_worker_pid :: pid(),
+                %% Key in GC bucket which this manifest belongs to.
+                %% Set only once at init and unchanged. Used only for logs.
+                gc_key :: binary(),
                 delete_blocks_remaining :: ordsets:ordset({binary(), integer()}),
                 unacked_deletes=ordsets:new() :: ordsets:ordset(integer()),
                 all_delete_workers=[] :: list(pid()),
@@ -65,8 +68,8 @@
 %% ===================================================================
 
 %% @doc Start a `riak_cs_delete_fsm'.
-start_link(RcPid, Manifest, GCWorkerPid, Options) ->
-    Args = [RcPid, Manifest, GCWorkerPid, Options],
+start_link(RcPid, Manifest, GCWorkerPid, GCKey, Options) ->
+    Args = [RcPid, Manifest, GCWorkerPid, GCKey, Options],
     gen_fsm:start_link(?MODULE, Args, []).
 
 -spec block_deleted(pid(), {ok, {binary(), integer()}} | {error, binary()}) -> ok.
@@ -77,14 +80,15 @@ block_deleted(Pid, Response) ->
 %% gen_fsm callbacks
 %% ====================================================================
 
-init([RcPid, {UUID, Manifest}, GCWorkerPid, _Options]) ->
+init([RcPid, {UUID, Manifest}, GCWorkerPid, GCKey, _Options]) ->
     {Bucket, Key} = Manifest?MANIFEST.bkey,
     State = #state{bucket=Bucket,
                    key=Key,
                    manifest=Manifest,
                    uuid=UUID,
                    riak_client=RcPid,
-                   gc_worker_pid=GCWorkerPid},
+                   gc_worker_pid=GCWorkerPid,
+                   gc_key=GCKey},
     {ok, prepare, State, 0}.
 
 %% @TODO Make sure we avoid any race conditions here
@@ -160,15 +164,31 @@ deleting_state_result(_, State) ->
     {next_state, deleting, UpdState}.
 
 -spec handle_receiving_manifest(state()) ->
-    {next_state, atom(), state()}.
-handle_receiving_manifest(State=#state{riak_client=RcPid,
-                                       manifest=Manifest}) ->
-    {NewManifest, BlocksToDelete} = blocks_to_delete_from_manifest(Manifest),
-    BlockCount = ordsets:size(BlocksToDelete),
-    NewState = State#state{manifest=NewManifest,
-                           delete_blocks_remaining=BlocksToDelete,
-                           total_blocks=BlockCount},
+    {next_state, atom(), state()} | {stop, normal, state()}.
+handle_receiving_manifest(State=#state{manifest=Manifest,
+                                       gc_key=GCKey}) ->
+    case blocks_to_delete_from_manifest(Manifest) of
+        {ok, {NewManifest, BlocksToDelete}} ->
+            BlockCount = ordsets:size(BlocksToDelete),
+            NewState = State#state{manifest=NewManifest,
+                                   delete_blocks_remaining=BlocksToDelete,
+                                   total_blocks=BlockCount},
+            start_block_servers(NewState);
+        {error, invalid_state} ->
+            _ = lager:warning("Invalid state manifest in GC bucket at ~p: ~p",
+                              [GCKey, Manifest]),
+            %% If total blocks and deleted blocks are the same,
+            %% gc worker attempt to delete the manifest in fileset.
+            %% Then manifests and blocks becomes orphan.
+            %% To avoid it, set total_blocks > 0 here.
+            {stop, normal, State#state{total_blocks=1}}
+    end.
 
+-spec start_block_servers(state()) -> {next_state, atom(), state()} |
+                                      {stop, normal, state()}.
+start_block_servers(#state{riak_client=RcPid,
+                           manifest=Manifest,
+                           delete_blocks_remaining=BlocksToDelete} = State) ->
     %% Handle the case where there are 0 blocks to delete,
     %% i.e. content length of 0,
     %% and can not check-out any workers.
@@ -180,16 +200,16 @@ handle_receiving_manifest(State=#state{riak_client=RcPid,
                   riak_cs_lfs_utils:delete_concurrency()),
             case length(AllDeleteWorkers) of
                 0 ->
-                    {stop, normal, NewState};
+                    {stop, normal, State};
                 _ ->
                     FreeDeleters = ordsets:from_list(AllDeleteWorkers),
-                    NewState1 = NewState#state{all_delete_workers=AllDeleteWorkers,
-                                               free_deleters=FreeDeleters},
-                    StateAfterDeleteStart = maybe_delete_blocks(NewState1),
+                    NewState = State#state{all_delete_workers=AllDeleteWorkers,
+                                           free_deleters=FreeDeleters},
+                    StateAfterDeleteStart = maybe_delete_blocks(NewState),
                     {next_state, deleting, StateAfterDeleteStart}
             end;
         false ->
-            {stop, normal, NewState}
+            {stop, normal, State}
     end.
 
 maybe_delete_blocks(State=#state{free_deleters=[]}) ->
@@ -240,7 +260,8 @@ manifest_cleanup(_, _, _, _, _) ->
     ok.
 
 -spec blocks_to_delete_from_manifest(lfs_manifest()) ->
-    {lfs_manifest(), ordsets:ordset(integer())}.
+                                            {ok, {lfs_manifest(), ordsets:ordset(integer())}} |
+                                            {error, term()}.
 blocks_to_delete_from_manifest(Manifest=?MANIFEST{state=State,
                                                   delete_blocks_remaining=undefined})
   when State =:= pending_delete;State =:= writing; State =:= scheduled_delete ->
@@ -254,10 +275,11 @@ blocks_to_delete_from_manifest(Manifest=?MANIFEST{state=State,
         end,
     UpdManifest = Manifest?MANIFEST{delete_blocks_remaining=Blocks,
                                     state=UpdState},
-    {UpdManifest, Blocks};
+    {ok, {UpdManifest, Blocks}};
+blocks_to_delete_from_manifest(?MANIFEST{delete_blocks_remaining=undefined}) ->
+    {error, invalid_state};
 blocks_to_delete_from_manifest(Manifest) ->
-    {Manifest,
-        Manifest?MANIFEST.delete_blocks_remaining}.
+    {ok, {Manifest, Manifest?MANIFEST.delete_blocks_remaining}}.
 
 %% ===================================================================
 %% Test API

--- a/src/riak_cs_gc_worker.erl
+++ b/src/riak_cs_gc_worker.erl
@@ -124,13 +124,14 @@ initiating_file_delete(continue, ?STATE{batch=[_ManiSetKey | RestKeys],
     ok = continue(),
     {next_state, fetching_next_fileset, State?STATE{batch=RestKeys,
                                                     batch_count=1+BatchCount}};
-initiating_file_delete(continue, ?STATE{current_files=[Manifest | _RestManifests],
+initiating_file_delete(continue, ?STATE{batch=[CurrentFileSetKey | _],
+                                        current_files=[Manifest | _RestManifests],
                                         riak_client=RcPid}=State) ->
     %% Use an instance of `riak_cs_delete_fsm' to handle the
     %% deletion of the file blocks.
     %% Don't worry about delete_fsm failures. Manifests are
     %% rescheduled after a certain time.
-    Args = [RcPid, Manifest, self(), []],
+    Args = [RcPid, Manifest, self(), CurrentFileSetKey, []],
     %% The delete FSM is hard-coded to send a sync event to our registered
     %% name upon terminate(), so we do not have to pass our pid to it
     %% in order to get a reply.

--- a/test/riak_cs_gc_single_run_eqc.erl
+++ b/test/riak_cs_gc_single_run_eqc.erl
@@ -248,7 +248,7 @@ meck_delete_fsm_sup() ->
                 fun dummy_start_delete_fsm/2).
 
 dummy_start_delete_fsm(_Node, [_RcPid, {_UUID, ?MANIFEST{bkey={_, K}}=_Manifest},
-                               From, _Args]) ->
+                               From, _GCKey, _Args]) ->
     TotalBlocks = ?BLOCK_NUM_IN_MANIFEST,
     NumDeleted = case re:run(K, <<"^error:in_block_delete/">>) of
                      nomatch -> TotalBlocks;


### PR DESCRIPTION
Addresses #827 partly.

At present, the root cause why active state manifests are entered in GC bucket.
This PR does not process such manifests but just skip and log in order to
GC can proceed to other manifests instead of abort.

It's noteworthy that if `riak_cs_delete_fsm` replies ok with the same total blocks and deleted blocks
to `riak_cs_gc_worker`, then the worker attempt to delete manifest entry in `twop_set`.
Doing it _before_ deleting manfiests and blocks completely poses orphan manifests/blocks.
In this PR, `riak_cs_delete_fsm` replies with total blocks = 1 and deleted_blocks = 0.

To address #827 completely, further investigation on root cause needed. Information of logs
by this PR will help.
