### PR TITLE
Remove riak_cs_s3_response dependency from mp_upload_test

### DIFF
--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -207,7 +207,7 @@ invalid_part_number_test_case(Bucket, Key, Config) ->
     ErrorPattern =
         "<Error><Code>InvalidArgument</Code>"
         "<Message>Part number must be an integer between 1 and 10000, inclusive</Message>",
-    ?assertMatch({match, _}, re:run(Body, ErrorPattern [multiline])),
+    ?assertMatch({match, _}, re:run(Body, ErrorPattern, [multiline])),
     abort_uploads(Bucket, Config).
 
 

--- a/riak_test/tests/mp_upload_test.erl
+++ b/riak_test/tests/mp_upload_test.erl
@@ -204,8 +204,10 @@ invalid_part_number_test_case(Bucket, Key, Config) ->
                                                  InvalidPartNumber,
                                                  generate_part_data(0, ?GOOD_PART_SIZE),
                                                  Config)),
-    ?assertMatch({match, _},
-                 re:run(Body, riak_cs_s3_response:error_message(invalid_part_number), [multiline])),
+    ErrorPattern =
+        "<Error><Code>InvalidArgument</Code>"
+        "<Message>Part number must be an integer between 1 and 10000, inclusive</Message>",
+    ?assertMatch({match, _}, re:run(Body, ErrorPattern [multiline])),
     abort_uploads(Bucket, Config).
 
 


### PR DESCRIPTION
`mp_upload_test' uses riak_cs_s3_response to in one of its assertion.
Not sure why it has passed since now but copying it every compile
time fixes it.
