### PR TITLE
Add tests for amendment log, and a bit code reformat

### DIFF
--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -111,7 +111,6 @@ verify_stats_lost_logging(UserConfig, RiakNodes, CSNodes) ->
     %% check logs, at same node with flush_access_stats
     CSNode = hd(CSNodes),
     lager:info("Checking log in ~p", [CSNode]),
-    true = rt:expect_in_log(CSNode, "Access archiver storage failed"),
     ExpectLine = io_lib:format("lost access stat: User=~s, Slice=", [KeyId]),
     lager:debug("expected log line: ~s", [ExpectLine]),
     true = rt:expect_in_log(CSNode, ExpectLine),

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -35,11 +35,14 @@
 confirm() ->
     Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
               {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
-    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, Config),
+    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2, Config),
+    rt:setup_log_capture(hd(CSNodes)),
+
     {Begin, End} = generate_some_accesses(UserConfig),
     flush_access_stats(),
     assert_access_stats(json, UserConfig, {Begin, End}),
     assert_access_stats(xml, UserConfig, {Begin, End}),
+    verify_stats_lost_logging(UserConfig, RiakNodes, CSNodes),
     pass.
 
 generate_some_accesses(UserConfig) ->
@@ -98,6 +101,23 @@ assert_access_stats(Format, UserConfig, {Begin, End}) ->
     ?assertEqual(  1, sum_samples(Format, "BucketDelete", "Count", Samples)),
     pass.
 
+verify_stats_lost_logging(UserConfig, RiakNodes, CSNodes) ->
+    KeyId = UserConfig#aws_config.access_key_id,
+    {_Begin, _End} = generate_some_accesses(UserConfig),
+    %% kill riak
+    [ rt:brutal_kill(Node) || Node <- RiakNodes ],
+    %% force archive
+    flush_access_stats(),
+    %% check logs, at same node with flush_access_stats
+    CSNode = hd(CSNodes),
+    lager:info("Checking log in ~p", [CSNode]),
+    true = rt:expect_in_log(CSNode, "Access archiver storage failed"),
+    ExpectLine = io_lib:format("lost access stat: User=~s, Slice=", [KeyId]),
+    lager:debug("expected log line: ~s", [ExpectLine]),
+    true = rt:expect_in_log(CSNode, ExpectLine),
+    pass.
+
+
 node_samples_from_content(json, Node, Content) ->
     Usage = mochijson2:decode(Content),
     ListOfNodeStats = rtcs:json_get([<<"Access">>, <<"Nodes">>], Usage),
@@ -128,7 +148,7 @@ sum_samples_json(Keys, [Sample | Samples], Sum) ->
                        0;
                    Value when is_integer(Value) ->
                        Value
-                  end,
+               end,
     sum_samples_json(Keys, Samples, Sum + InSample).
 
 sum_samples_xml(OperationType, StatsKey, Samples) ->

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -157,9 +157,12 @@ group_by_node(Samples) ->
 
 %% @doc If writing access failed, output the data to log
 flush_to_log(Table, Slice) ->
-    {Start, End} = Slice,
+    {Start0, End0} = Slice,
+    Start = rts:iso8601(Start0),
+    End = rts:iso8601(End0),
     Fun = fun({User, Accesses0}, _) ->
-                  Accesses = rts:build_json(Start, End, Accesses0),
+                  RiakObj = make_object(User, Accesses0, Slice),
+                  Accesses = riakc_obj:get_update_value(RiakObj),
                   flush_to_log(User, Accesses, Start, End)
           end,
     ets:foldl(Fun, ok, Table).

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -157,10 +157,9 @@ group_by_node(Samples) ->
 
 %% @doc If writing access failed, output the data to log
 flush_to_log(Table, Slice) ->
-    {Start0, End0} = Slice,
-    Start = rts:iso8601(Start0),
-    End = rts:iso8601(End0),
-    Fun = fun({User, Accesses}, _) ->
+    {Start, End} = Slice,
+    Fun = fun({User, Accesses0}, _) ->
+                  Accesses = rts:build_json(Start, End, Accesses0),
                   flush_to_log(User, Accesses, Start, End)
           end,
     ets:foldl(Fun, ok, Table).

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -27,7 +27,9 @@
          log_flush_interval/0,
          max_flush_size/0,
          make_object/3,
-         get_usage/4
+         get_usage/4,
+         flush_to_log/2,
+         flush_to_log/3
         ]).
 
 -include("riak_cs.hrl").
@@ -74,8 +76,8 @@ log_flush_interval() ->
                             {ok, AP div AF};
                         _ ->
                             {error, "riak_cs:access_log_flush_interval"
-                                    " does not evenly divide"
-                                    " riak_cs:access_archive_period"}
+                             " does not evenly divide"
+                             " riak_cs:access_archive_period"}
                     end;
                 APError ->
                     APError
@@ -105,7 +107,7 @@ max_flush_size() ->
 -spec make_object(iodata(),
                   [[{atom()|binary(), number()}]],
                   slice())
-         -> riakc_obj:riakc_obj().
+                 -> riakc_obj:riakc_obj().
 make_object(User, Accesses, {Start, End}) ->
     {ok, Period} = archive_period(),
     Aggregate = aggregate_accesses(Accesses),
@@ -137,7 +139,7 @@ merge_stats(Stats, Acc) ->
                 term(), %% TODO: riak_cs:user_key() type doesn't exist
                 calendar:datetime(),
                 calendar:datetime()) ->
-         {Usage::orddict:orddict(), Errors::[{slice(), term()}]}.
+                       {Usage::orddict:orddict(), Errors::[{slice(), term()}]}.
 get_usage(RcPid, User, Start, End) ->
     {ok, Period} = archive_period(),
     {Usage, Errors} = rts:find_samples(RcPid, ?ACCESS_BUCKET, User,
@@ -152,6 +154,28 @@ group_by_node(Samples) ->
                 end,
                 orddict:new(),
                 Samples).
+
+%% @doc If writing access failed, output the data to log
+flush_to_log(Table, Slice) ->
+    {Start0, End0} = Slice,
+    Start = rts:iso8601(Start0),
+    End = rts:iso8601(End0),
+    Fun = fun({User, Accesses}, _) ->
+                  flush_to_log(User, Accesses, Start, End)
+          end,
+    ets:foldl(Fun, ok, Table).
+
+%% @doc If writing access failed, output to log
+flush_to_log(User, Accesses, Slice) ->
+    {Start0, End0} = Slice,
+    Start = rts:iso8601(Start0),
+    End = rts:iso8601(End0),
+    flush_to_log(User, Accesses, Start, End).
+
+flush_to_log(User, Accesses, Start, End) ->
+    _ = lager:warning("lost access stat: User=~s, Slice=(~s, ~s), Accesses:'~s'",
+                      [User, Start, End, Accesses]).
+
 
 -ifdef(TEST).
 -ifdef(EQC).

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -161,7 +161,7 @@ flush_to_log(Table, Slice) ->
     Start = rts:iso8601(Start0),
     End = rts:iso8601(End0),
     Fun = fun({User, Accesses0}, _) ->
-                  RiakObj = make_object(User, Accesses0, Slice),
+                  RiakObj = make_object(User, [Accesses0], Slice),
                   Accesses = riakc_obj:get_update_value(RiakObj),
                   flush_to_log(User, Accesses, Start, End)
           end,

--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -207,9 +207,8 @@ store(User, RcPid, Record, Slice) ->
             ok = lager:debug("Archived access stats for ~s ~p",
                              [User, Slice]);
         {error, Reason} ->
-            ok = lager:error("Access archiver storage failed (~p), "
-                             "stats for ~s ~p were lost.",
-                             [Reason, User, Slice]),
+            riak_cs_pbc:check_connection_status(MasterPbc,
+                                                "riak_cs_access_archiver:store/4"),
             riak_cs_access:flush_access_object_to_log(User, Record, Slice),
             {error, Reason};
         {'EXIT', {noproc, _}} ->

--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -210,6 +210,9 @@ store(User, RcPid, Record, Slice) ->
             ok = lager:error("Access archiver storage failed (~p), "
                              "stats for ~s ~p were lost",
                              [Reason, User, Slice]),
+            riak_cs_access:flush_to_log(User,
+                                        riakc_obj:get_update_value(Record),
+                                        Slice),
             {error, Reason};
         {'EXIT', {noproc, _}} ->
             %% just haven't gotten the 'DOWN' yet

--- a/src/riak_cs_access_archiver.erl
+++ b/src/riak_cs_access_archiver.erl
@@ -210,9 +210,7 @@ store(User, RcPid, Record, Slice) ->
             ok = lager:error("Access archiver storage failed (~p), "
                              "stats for ~s ~p were lost",
                              [Reason, User, Slice]),
-            riak_cs_access:flush_to_log(User,
-                                        riakc_obj:get_update_value(Record),
-                                        Slice),
+            riak_cs_access:flush_access_object_to_log(User, Record, Slice),
             {error, Reason};
         {'EXIT', {noproc, _}} ->
             %% just haven't gotten the 'DOWN' yet

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -156,7 +156,7 @@ close_riak_connection(Pool, Pid) ->
 %% {error, notfound} counts as success in this case,
 %% with the list of UUIDs being [].
 -spec delete_object(binary(), binary(), riak_client()) ->
-    {ok, [binary()]} | {error, term()}.
+                           {ok, [binary()]} | {error, term()}.
 delete_object(Bucket, Key, RcPid) ->
     ok = riak_cs_stats:update_with_start(object_delete, os:timestamp()),
     riak_cs_gc:gc_active_manifests(Bucket, Key, RcPid).
@@ -316,7 +316,7 @@ md5_final(Ctx) -> crypto:md5_final(Ctx).
 
 -spec active_manifest_from_response({ok, orddict:orddict()} |
                                     {error, notfound}) ->
-    {ok, lfs_manifest()} | {error, notfound}.
+                                           {ok, lfs_manifest()} | {error, notfound}.
 active_manifest_from_response({ok, Manifests}) ->
     handle_active_manifests(riak_cs_manifest_utils:active_manifest(Manifests));
 active_manifest_from_response({error, notfound}=NotFound) ->
@@ -325,7 +325,7 @@ active_manifest_from_response({error, notfound}=NotFound) ->
 %% @private
 -spec handle_active_manifests({ok, lfs_manifest()} |
                               {error, no_active_manifest}) ->
-    {ok, lfs_manifest()} | {error, notfound}.
+                                     {ok, lfs_manifest()} | {error, notfound}.
 handle_active_manifests({ok, _Active}=ActiveReply) ->
     ActiveReply;
 handle_active_manifests({error, no_active_manifest}) ->
@@ -386,7 +386,7 @@ pow(Base, Power, Acc) ->
 -type resolve_ok() :: {term(), binary()}.
 -type resolve_error() :: {atom(), atom()}.
 -spec resolve_robj_siblings(RObj::term()) ->
-                      {resolve_ok() | resolve_error(), NeedsRepair::boolean()}.
+                                   {resolve_ok() | resolve_error(), NeedsRepair::boolean()}.
 
 resolve_robj_siblings(Cs) ->
     [{BestRating, BestMDV}|Rest] = lists:sort([{rate_a_dict(MD, V), MDV} ||
@@ -453,7 +453,7 @@ riak_connection(Pool) ->
 %% @doc Set the ACL for an object. Existing ACLs are only
 %% replaced, they cannot be updated.
 -spec set_object_acl(binary(), binary(), lfs_manifest(), acl(), riak_client()) ->
-            ok | {error, term()}.
+                            ok | {error, term()}.
 set_object_acl(Bucket, Key, Manifest, Acl, RcPid) ->
     StartTime = os:timestamp(),
     {ok, ManiPid} = riak_cs_manifest_fsm:start_link(Bucket, Key, RcPid),
@@ -561,7 +561,7 @@ from_bucket_name(BucketNameWithPrefix) ->
 %% @private
 -spec key_exists_handle_get_manifests({ok, riakc_obj:riakc_obj(), list()} |
                                       {error, term()}) ->
-    boolean().
+                                             boolean().
 key_exists_handle_get_manifests({ok, _Object, Manifests}) ->
     active_to_bool(active_manifest_from_response({ok, Manifests}));
 key_exists_handle_get_manifests(Error) ->

--- a/src/rts.erl
+++ b/src/rts.erl
@@ -42,6 +42,7 @@
 
 -export([
          new_sample/6,
+         build_json/3,
          find_samples/6,
          slice_containing/2,
          next_slice/2,
@@ -72,11 +73,14 @@
 new_sample(Bucket, KeyPostfix, Start, End, Period, Data) ->
     Slice = slice_containing(Start, Period),
     Key = slice_key(Slice, KeyPostfix),
+    Body = build_json(Start, End, Data),
+    riakc_obj:new(Bucket, Key, Body, "application/json").
+
+build_json(Start, End, Data) ->
     MJSON = {struct, [{?START_TIME, iso8601(Start)},
                       {?END_TIME, iso8601(End)}
                       |Data]},
-    Body = iolist_to_binary(mochijson2:encode(MJSON)),
-    riakc_obj:new(Bucket, Key, Body, "application/json").
+    iolist_to_binary(mochijson2:encode(MJSON)).
 
 %% @doc Fetch all of the samples from riak that overlap the specified
 %% time period for the given key postfix.

--- a/src/rts.erl
+++ b/src/rts.erl
@@ -42,7 +42,6 @@
 
 -export([
          new_sample/6,
-         build_json/3,
          find_samples/6,
          slice_containing/2,
          next_slice/2,
@@ -73,14 +72,11 @@
 new_sample(Bucket, KeyPostfix, Start, End, Period, Data) ->
     Slice = slice_containing(Start, Period),
     Key = slice_key(Slice, KeyPostfix),
-    Body = build_json(Start, End, Data),
-    riakc_obj:new(Bucket, Key, Body, "application/json").
-
-build_json(Start, End, Data) ->
     MJSON = {struct, [{?START_TIME, iso8601(Start)},
                       {?END_TIME, iso8601(End)}
                       |Data]},
-    iolist_to_binary(mochijson2:encode(MJSON)).
+    Body = iolist_to_binary(mochijson2:encode(MJSON)),
+    riakc_obj:new(Bucket, Key, Body, "application/json").
 
 %% @doc Fetch all of the samples from riak that overlap the specified
 %% time period for the given key postfix.


### PR DESCRIPTION
RIAK-1212
- Add a function `riak_cs_access:flush_to_log/2,3` which outputs one access key and value supposed to be put into `moss.access`.
- `flush_to_log/2` folds around all ets entries and outputs all of them to each line, with JSON encoded
- `flush_to_log/3` outputs single key and value to log.
- The test works as follows:
  - write some data to CS
  - kill all Riak process
  - try to flush the access stats
  - check Riak CS log and verifies whether correct log is updated or not.
