### PR TITLE
Upgrade to Riak 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,13 +16,11 @@ log/
 current_counterexample.eqc
 .int_test/
 .client_test/
-priv/riak_cs_drv.so
 pkg.vars.config
 client_tests/python/ceph_tests/s3-tests
 riak-cs.png
 .local_dialyzer_plt
-.eqc-info
-.riak_cs_list_objects_fsm_v2_eqc.txt
 dialyzer.ignore-warnings
 dialyzer_warnings
 dialyzer_unhandled_warnings
+riak_test/src/downgrade_bitcask.erl

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ compile-client-test: all
 compile-int-test: all
 	@./rebar int_test_compile
 
-compile-riak-test: all
+bitcask-downgrade-script: riak_test/src/downgrade_bitcask.erl
+
+## KLUDGE, as downgrade script is not included in the release.
+riak_test/src/downgrade_bitcask.erl:
+	@wget https://raw.githubusercontent.com/basho/bitcask/develop/priv/scripts/downgrade_bitcask.erl \
+		-O riak_test/src/downgrade_bitcask.erl
+
+compile-riak-test: all bitcask-downgrade-script
 	@./rebar skip_deps=true riak_test_compile
 	## There are some Riak CS internal modules that our riak_test
 	## test would like to use.  But riak_test doesn't have a nice

--- a/rebar.config
+++ b/rebar.config
@@ -57,5 +57,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.2"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "master"}}}
           ]}.

--- a/riak_test/README.md
+++ b/riak_test/README.md
@@ -1,10 +1,60 @@
-1. Ensure that s3cmd is installed and that `~/.s3cfg` contains access
-   credentials for the Basho account.
+# General instruction
+
+1. Make sure that your `riak_test` is the latest one for 2.0.
+
 1. Ensure that riak_test builds are in place for:
     * Riak
     * Riak EE
     * Riak CS
     * Stanchion
+
+Example to setup old and new CS:
+
+```
+$ mkdir ~/rt
+$ cd ~/rt
+$ cd path/to/repo/riak_cs
+$ export RIAK_CS_EE_DEPS=true
+## change runtime to Basho's patched R15B01
+$ riak_test/bin/rtdev-build-releases.sh
+$ riak_test/bin/rtdev-setup-releases.sh
+## make sure runtime is Basho's patched R16B02-basho5
+$ make devrel && riak_test/bin/rtdev-current.sh
+```
+
+Example to setup old and new Stanchion:
+
+```
+$ cd path/to/repo/stanchion
+## ch runtime to Basho's patched R15B01
+$ riak_test/bin/rtdev-build-releases.sh
+$ riak_test/bin/rtdev-setup-releases.sh
+## make sure runtime is Basho's patched R16B02-basho5
+$ make devrel && riak_test/bin/rtdev-current.sh
+```
+
+Example to setup 1.4.x and 2.0 as old and new Riak (maybe same as Riak
+OSS... while shell scripts are included in riak_test repo):
+
+```
+$ mkdir ~/rt/riak_ee
+## make sure runtime is Basho's patched R16B02-basho5
+$ tar xzf riak-ee-2.0.1.tar.gz
+$ cd riak-ee-2.0.1 && make devrel
+$ riak_test/bin/rteedev-setup-releases.sh
+$ riak_test/bin/rteedev-current.sh
+
+## ch runtime to Basho's patched R15B01
+$ tar xzf riak-ee-1.4.10.tar.gz
+$ cd riak-ee-1.4.10 && make devrel
+$ mkdir ~/rt/riak_ee/riak-ee-1.4.10
+$ cp -r dev ~/rt/riak_ee/riak-ee-1.4.10
+$ cd ~/rt/riak_ee
+$ git add riak-ee-1.4.10
+$ git commit -m "Add 1.4 series Riak EE"
+```
+
+
 1. Setup a `~/.riak_test.config` file like this:
 
 ```erlang
@@ -27,30 +77,35 @@
                       ]}
         ]}.
 
-    {rt_cs_dev, [
-         {rt_project, "riak_cs"},
-         {rt_deps, [
-                    "/Users/kelly/basho/riak_test_builds/riak/deps",
-                    "/Users/kelly/basho/riak_test_builds/riak_cs/deps",
-                    "/Users/kelly/basho/riak_test_builds/stanchion/deps"
+{rt_cs_dev, [
+  {rt_project, "riak_cs"},
+     {rt_deps, [
+                "/home/kuenishi/cs-2.0/riak_cs/deps"
+               ]},
+     {rt_retry_delay, 500},
+     {rt_harness, rt_cs_dev},
+     {build_paths, [{root,              "/home/kuenishi/rt/riak_ee"},
+                    {current,           "/home/kuenishi/rt/riak_ee/current"},
+                    {ee_root,           "/home/kuenishi/rt/riak_ee"},
+                    {ee_current,        "/home/kuenishi/rt/riak_ee/current"},
+                    {ee_previous,       "/home/kuenishi/rt/riak_ee/riak-ee-1.4.10"},
+                    {cs_root,           "/home/kuenishi/rt/riak_cs"},
+                    {cs_current,        "/home/kuenishi/rt/riak_cs/current"},
+                    {cs_previous,
+                           "/home/kuenishi/rt/riak_cs/riak-cs-1.5.1"},
+                    {stanchion_root,    "/home/kuenishi/rt/stanchion"},
+                    {stanchion_current, "/home/kuenishi/rt/stanchion/current"},
+                    {stanchion_previous,
+                       "/home/kuenishi/rt/stanchion/stanchion-1.5.0"}
                    ]},
-         {rt_retry_delay, 500},
-         {rt_harness, rt_cs_dev},
-         {build_paths, [{root, "/Users/kelly/rt/riak"},
-                        {current, "/Users/kelly/rt/riak/current"},
-                        {ee_root, "/Users/kelly/rt/riak_ee"},
-                        {ee_current, "/Users/kelly/rt/riak_ee/current"},
-                        {cs_root, "/Users/kelly/rt/riak_cs"},
-                        {cs_current, "/Users/kelly/rt/riak_cs/current"},
-                        {stanchion_root, "/Users/kelly/rt/stanchion"},
-                        {stanchion_current, "/Users/kelly/rt/stanchion/current"}
-                       ]},
-         {test_paths, ["/Users/kelly/basho/riak_test_builds/riak_cs/riak_test/ebin"]},
-         {src_paths, [{cs_src_root, "/Users/kelly/basho/riak_test_builds/riak_cs"}]},
-         {build_type, oss},
-         {backend, {multi_backend, bitcask}},
-         {flavor, basic}
-        ]}.
+     {test_paths, ["/home/kuenishi/cs-2.0/riak_cs/riak_test/ebin"]},
+     {src_paths, [{cs_src_root, "/home/kuenishi/cs-2.0/riak_cs"}]},
+     {lager_level, debug},
+     %%{build_type, oss},
+     {build_type, ee},
+     {flavor, basic},
+     {backend, {multi_backend, bitcask}}
+]}.
 ```
 
 Running the RiakCS tests for `riak_test` use a different test harness
@@ -107,6 +162,8 @@ bag with two riak nodes and two additional bags with one riak node each.
 * Your system must have libevent installed. If you see an error for a 
   missing 'event.h' file during test runs, this is because libevent is
   not installed.
+* Your system must have Ruby > 2.0 and PHP > 5.5 and PHP composer insalled.
+* Your system must have Golang (go, $GOHOME, $GOROOT) correctly installed.
 
 1. Before running the Riak client tests, your
 `~/.riak_test.config` file must contain an entry for `cs_src_root` in

--- a/riak_test/README.md
+++ b/riak_test/README.md
@@ -15,7 +15,6 @@ $ mkdir ~/rt
 $ cd ~/rt
 $ cd path/to/repo/riak_cs
 $ export RIAK_CS_EE_DEPS=true
-## change runtime to Basho's patched R15B01
 $ riak_test/bin/rtdev-build-releases.sh
 $ riak_test/bin/rtdev-setup-releases.sh
 ## make sure runtime is Basho's patched R16B02-basho5
@@ -26,7 +25,6 @@ Example to setup old and new Stanchion:
 
 ```
 $ cd path/to/repo/stanchion
-## ch runtime to Basho's patched R15B01
 $ riak_test/bin/rtdev-build-releases.sh
 $ riak_test/bin/rtdev-setup-releases.sh
 ## make sure runtime is Basho's patched R16B02-basho5
@@ -110,13 +108,12 @@ $ git commit -m "Add 1.4 series Riak EE"
 
 Running the RiakCS tests for `riak_test` use a different test harness
 (`rt_cs_dev`) than running the Riak tests and so requires a separate
-configuration section. Notice the extra `riak_ee/deps`, `riak_cs/deps`
-and `stanchion/deps` in the `rt_deps` section. `RT_DEST_DIR` should be
-replaced by the path used when setting up `riak_test` builds for Riak
-(by default `$HOME/rt/riak`). The same should be done for
-`RTEE_DEST_DIR` (default `$HOME/rt/riak_ee`), `RTCS_DEST_DIR` (default
-`$HOME/rt/riak_cs`) and `RTSTANCHION_DEST_DIR` (default
-`$HOME/rt/stanchion`).
+configuration section. Notice the extra `riak_cs/deps` in the
+`rt_deps` section. `RT_DEST_DIR` should be replaced by the path used
+when setting up `riak_test` builds for Riak (by default
+`$HOME/rt/riak`). The same should be done for `RTEE_DEST_DIR` (default
+`$HOME/rt/riak_ee`), `RTCS_DEST_DIR` (default `$HOME/rt/riak_cs`) and
+`RTSTANCHION_DEST_DIR` (default `$HOME/rt/stanchion`).
 
 The `build_type` option is used to differentiate between an
 open-source (`oss`) build of RiakCS and the enterprise version (`ee`).

--- a/riak_test/bin/rtdev-build-releases.sh
+++ b/riak_test/bin/rtdev-build-releases.sh
@@ -21,6 +21,7 @@ set -e
 
 R15B01=${R15B01:-$HOME/erlang/R15B01-64}
 R16B02=${R16B02:-$HOME/erlang/R16B02-64}
+: ${RTCS_DEST_DIR:="$HOME/rt/riak_cs"}
 
 checkbuild()
 {
@@ -71,10 +72,26 @@ build()
     cd ..
 }
 
+setup()
+{
+    SRCDIR=$1
+    cd $SRCDIR
+    VERSION=$SRCDIR
+    echo " - Copying devrel to $RTCS_DEST_DIR/$VERSION "
+    mkdir -p $RTCS_DEST_DIR/$VERSION/
+    cp -p -P -R dev $RTCS_DEST_DIR/$VERSION/
+    ## echo " - Writing $RTCS_DEST_DIR/$VERSION/VERSION"
+    ## echo -n $VERSION > $RTCS_DEST_DIR/$VERSION/VERSION
+    cd $RTCS_DEST_DIR
+    echo " - Adding $VERSION to git state of $RTCS_DEST_DIR"
+    git add $VERSION
+    git commit -a -m "riak_test adding version $VERSION" ## > /dev/null 2>&1
+}
+
 download()
 {
   URI=$1
-  FILENAME=`echo $URI | awk -F/ '{ print $7 }'`
+  FILENAME=`echo $URI | awk -F/ '{ print $8 }'`
   if [ ! -f $FILENAME ]; then
     wget $URI
   fi
@@ -87,3 +104,5 @@ download http://s3.amazonaws.com/builds.basho.com/riak-cs/1.5/1.5.1/riak-cs-1.5.
 
 tar -xf riak-cs-1.5.1.tar.gz
 build "riak-cs-1.5.1" $R15B01
+
+setup "riak-cs-1.5.1"

--- a/riak_test/bin/rtdev-build-releases.sh
+++ b/riak_test/bin/rtdev-build-releases.sh
@@ -104,5 +104,3 @@ download http://s3.amazonaws.com/builds.basho.com/riak-cs/1.5/1.5.1/riak-cs-1.5.
 
 tar -xf riak-cs-1.5.1.tar.gz
 build "riak-cs-1.5.1" $R15B01
-
-setup "riak-cs-1.5.1"

--- a/riak_test/bin/rtdev-setup-releases.sh
+++ b/riak_test/bin/rtdev-setup-releases.sh
@@ -38,5 +38,5 @@ git config user.name "Riak Test"
 git config user.email "dev@basho.com"
 
 git add .
-git commit -a -m "riak_test init"
+git commit -a -m "riak_test init" > /dev/null
 echo " - Successfully completed initial git commit of $RTCS_DEST_DIR"

--- a/riak_test/bin/rtdev-setup-releases.sh
+++ b/riak_test/bin/rtdev-setup-releases.sh
@@ -12,13 +12,31 @@ set -e
 
 rm -rf $RTCS_DEST_DIR
 mkdir $RTCS_DEST_DIR
-for rel in */dev; do
-    vsn=$(dirname "$rel")
-    mkdir "$RTCS_DEST_DIR/$vsn"
-    cp -p -P -R "$rel" "$RTCS_DEST_DIR/$vsn"
-done
+
+count=$(ls */dev 2> /dev/null | wc -l)
+if [ "$count" -ne "0" ]
+then
+    for rel in */dev; do
+        vsn=$(dirname "$rel")
+        echo " - Initializing $RTCS_DEST_DIR/$vsn"
+        mkdir -p "$RTCS_DEST_DIR/$vsn"
+        cp -p -P -R "$rel" "$RTCS_DEST_DIR/$vsn"
+    done
+else
+    # This is useful when only testing with 'current'
+    # The repo still needs to be initialized for current
+    # and we don't want to bomb out if */dev doesn't exist
+    touch $RTCS_DEST_DIR/.current_init
+    echo "No devdirs found. Not copying any releases."
+fi
+
 cd $RTCS_DEST_DIR
 git init
+
+## Some versions of git and/or OS require these fields
+git config user.name "Riak Test"
+git config user.email "dev@basho.com"
+
 git add .
 git commit -a -m "riak_test init"
-
+echo " - Successfully completed initial git commit of $RTCS_DEST_DIR"

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -141,7 +141,7 @@ configs(CustomConfigs) ->
 previous_configs() ->
     CSPrev = rt_config:get(?CS_PREVIOUS),
     AddPaths = filelib:wildcard(CSPrev ++ "/dev/dev1/lib/riak_cs*/ebin"),
-    
+
     [{riak, riak_config([{riak_kv, [{add_paths, AddPaths}]}])},
      {stanchion, stanchion_config()},
      {cs, cs_config()}].
@@ -646,7 +646,7 @@ gc(N, SubCmd, Vsn) ->
     Cmd = riakcs_gccmd(get_rt_config(cs, Vsn), N, SubCmd),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
-    
+
 
 calculate_storage(N, Vsn) ->
     Cmd = riakcs_storagecmd(get_rt_config(cs, Vsn), N, "batch -r"),
@@ -835,11 +835,11 @@ error_child_element_verifier(Code, Message, Resource) ->
 %% this function and go back to rt_cs_dev:upgrade/2. This is just
 %% copy&paste and modify.
 %% This also resets config and moves to default CS riak config.
-upgrade_to_20(Node, NewVersion) ->
+upgrade_20(Node, NewVersion) ->
     N = rt_cs_dev:node_id(Node),
     Version = rt_cs_dev:node_version(N),
     lager:info("Upgrading ~p : ~p -> ~p", [Node, Version, NewVersion]),
-    rt_cs_dev:stop(Node),
+    catch rt_cs_dev:stop(Node),
     rt:wait_until_unpingable(Node),
     OldPath = rt_cs_dev:relpath(Version),
     NewPath = rt_cs_dev:relpath(NewVersion),
@@ -864,8 +864,18 @@ upgrade_to_20(Node, NewVersion) ->
 
 %% @doc from previous to current, assuming CS is already stopped
 upgrade_cs(N, Config, AdminCreds) ->
-    update_cs_config(get_rt_config(cs, current),
+    upgrade_cs(N, Config, AdminCreds, current).
+
+upgrade_cs(N, Config, AdminCreds, Vsn) ->
+    update_cs_config(get_rt_config(cs, Vsn),
                      N,
                      proplists:get_value(cs, Config),
                      AdminCreds),
     ok.
+
+upgrade_stanchion(Config, AdminCreds, Vsn) ->
+    update_stanchion_config(get_rt_config(stanchion, Vsn),
+                            proplists:get_value(stanchion, Config),
+                            AdminCreds).
+
+%% maybe_stop_stanchion(1) ->

--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -30,7 +30,7 @@
 confirm() ->
     PrevConfig = rtcs:previous_configs(),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} =
-        rtcs:setup(1, PrevConfig, previous),
+        rtcs:setup(2, PrevConfig, previous),
 
     lager:info("nodes> ~p", [rt_config:get(rt_nodes)]),
     lager:info("versions> ~p", [rt_config:get(rt_versions)]),

--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -1,0 +1,52 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(upgrade_downgrade_test).
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
+
+-define(TEST_BUCKET, "riak-test-bucket").
+
+confirm() ->
+    {_UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, rtcs:default_configs(), previous),
+    %% confirm_initial_stats(query_stats(UserConfig, rtcs:cs_port(hd(RiakNodes)))),
+    lager:info("~p", [rt_config:get(rt_nodes)]),
+    lager:info("~p", [rt_config:get(rt_versions)]),
+    %% lager:info("creating bucket ~p", [?TEST_BUCKET]),
+    %% ?assertEqual(ok, erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
+
+    %% ?assertMatch([{buckets, [[{name, ?TEST_BUCKET}, _]]}],
+    %%     erlcloud_s3:list_buckets(UserConfig)),
+
+    %% Object = crypto:rand_bytes(500),
+    %% erlcloud_s3:put_object(?TEST_BUCKET, "object_one", Object, UserConfig),
+    %% erlcloud_s3:get_object(?TEST_BUCKET, "object_one", UserConfig),
+    %% erlcloud_s3:delete_object(?TEST_BUCKET, "object_one", UserConfig),
+    %% erlcloud_s3:list_buckets(UserConfig),
+
+    %% lager:info("Confirming stats"),
+    %% Stats1 = query_stats(UserConfig, rtcs:cs_port(hd(RiakNodes))),
+    %% confirm_stat_count(Stats1, <<"service_get_buckets">>, 2),
+    %% confirm_stat_count(Stats1, <<"object_get">>, 1),
+    %% confirm_stat_count(Stats1, <<"object_put">>, 1),
+    %% confirm_stat_count(Stats1, <<"object_delete">>, 1),
+    rtcs:pass().


### PR DESCRIPTION
This is a start of a series of updating Riak 2.0. To update your riak_test, update your Riak harness to the latest 2.0.x. Currently, there are no 2.0 specific thing so even after this commit, CS might work with Riak 1.4 and 2.0. My example .riak_test.config is as follows:

``` erlang
{rt_cs_dev, [
  {rt_project, "riak_cs"},
     {rt_deps, [
                "/home/kuenishi/cs-2.0/riak_cs/deps"
               ]},
     {rt_retry_delay, 500},
     {rt_harness, rt_cs_dev},
     {build_paths, [{root,              "/home/kuenishi/rt/riak_ee"},
                    {current,           "/home/kuenishi/rt/riak_ee/current"},
                    {ee_root,           "/home/kuenishi/rt/riak_ee"},
                    {ee_current,        "/home/kuenishi/rt/riak_ee/current"},
                    {ee_previous,       "/home/kuenishi/rt/riak_ee_onefour/current"},
                    {cs_root,           "/home/kuenishi/rt/riak_cs"},
                    {cs_current,        "/home/kuenishi/rt/riak_cs/current"},
                    {cs_previous,       "/home/kuenishi/rt/riak_cs/1.5"},
                    {stanchion_root,    "/home/kuenishi/rt/stanchion"},
                    {stanchion_current, "/home/kuenishi/rt/stanchion/current"},
                    {stanchion_previous,       "/home/kuenishi/rt/stanchion/1.5"}
                   ]},
     {test_paths, ["/home/kuenishi/cs-2.0/riak_cs/riak_test/ebin"]},
     {src_paths, [{cs_src_root, "/home/kuenishi/cs-2.0/riak_cs"}]},
     {lager_level, debug},
     {build_type, oss},
     {flavor, basic},
     {backend, {multi_backend, bitcask}}
]}.
```

I also recommend preserving your old CS 1.5 test firm with name like `rt_cs_dev_old`. As this is still WIP state, I'll add several upgrading tests.

CC: #962
