### PR TITLE
Bugfix: storage calc on deleted buckets 1.4

### DIFF
--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -51,7 +51,8 @@ sum_user(Riak, User) when is_binary(User) ->
     sum_user(Riak, binary_to_list(User));
 sum_user(Riak, User) when is_list(User) ->
     case riak_cs_utils:get_user(User, Riak) of
-        {ok, {?RCS_USER{buckets=Buckets}, _UserObj}} ->
+        {ok, {UserRecord, _UserObj}} ->
+            Buckets = riak_cs_utils:get_buckets(UserRecord),
             BucketUsages = [maybe_sum_bucket(Riak, User, B)
                             || ?RCS_BUCKET{name=B} <- Buckets],
             {ok, BucketUsages};


### PR DESCRIPTION
This fixes a bug related to bucket name re-cycle,
storage calc wrongly includes deleted buckets.
An example of steps to reproduce is:
1. Alice creates a bucket foo
2. Alice deletes the bucket foo
3. Bob creates a bucket with the same name foo
4. Bob PUTs an object to the bucket
5. Then storage calc reports the bucket usage to both Alice and Bob

Condition: (A AND (B-1 OR B-2))

A. a user deletes a bucket and another user creates a bucket with the same name.

B-1. recycle of the bucket name is occured in leeway seconds (default: 1 day)
B-2. some nodes in cluster are down before another change to the user occures.

cf. There are another branch for patch on tag 1.4.5:
https://github.com/basho/riak_cs/compare/1.4.5...bugfix/storage-calc-on-deleted-buckets
