### PR TITLE
Add read_before_last_manifest_write option to avoid sibling explosion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: erlang
-otp_release: R15B01
+otp_release:
+  - R16B02
+  - R15B01
 notifications:
   webhooks: http://basho-engbot.herokuapp.com/travis?key=7408e8628d324bc4b522deee77bf987ecff67b16
   email: eng@basho.com

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -343,7 +343,7 @@ max_buckets_per_user() ->
 %% explosion in such use cases that can debilitate a system.
 -spec read_before_last_manifest_write() -> boolean().
 read_before_last_manifest_write() ->
-    get_env(riak_cs, read_before_last_manifest_write, false).
+    get_env(riak_cs, read_before_last_manifest_write, true).
 
 
 %% ===================================================================

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -54,7 +54,8 @@
          queue_if_disconnected/0,
          auto_reconnect/0,
          is_multibag_enabled/0,
-         max_buckets_per_user/0
+         max_buckets_per_user/0,
+         read_before_last_manifest_write/0
         ]).
 
 %% OpenStack config
@@ -335,6 +336,15 @@ is_multibag_enabled() ->
 -spec max_buckets_per_user() -> non_neg_integer() | unlimited.
 max_buckets_per_user() ->
     get_env(riak_cs, max_buckets_per_user, ?DEFAULT_MAX_BUCKETS_PER_USER).
+
+%% @doc This options is useful for use case involving high churn and
+%% concurrency on a fixed set of keys and when not using a Riak
+%% version >= 2.0.0 with DVVs enabled. It helps to avoid sibling
+%% explosion in such use cases that can debilitate a system.
+-spec read_before_last_manifest_write() -> boolean().
+read_before_last_manifest_write() ->
+    get_env(riak_cs, read_before_last_manifest_write, false).
+
 
 %% ===================================================================
 %% S3 config options


### PR DESCRIPTION
Add read_before_last_manifest_write option to help avoid sibling
explosion for use cases involving high churn and concurrency on a
fixed set of keys. When sibling explosion occurs the objects stored in
Riak can become very large and severely impair the functioning of the
system. The trade-off in enabling this option is latency penalty of
doing an extra read before the final write of an object's manifest to
Riak; however, for use cases matching the description the minor
latency penalty is preferable to the system to the consequences of
sibling explosion. This option is not needed for Riak CS installations
using a Riak version that is >= 2.0.0 with DVVs enabled.
