### PR TITLE
Add caching on user and bucket records; default is false

### DIFF
--- a/src/riak_cs_acl.erl
+++ b/src/riak_cs_acl.erl
@@ -177,7 +177,7 @@ bucket_access(_, RequestedAccess, CanonicalId, RcPid, Acl) ->
 -type bucket_acl_riak_error() :: {error, 'notfound' | term()}.
 -spec fetch_bucket_acl(binary(), riak_client()) -> bucket_acl_result() | bucket_acl_riak_error().
 fetch_bucket_acl(Bucket, RcPid) ->
-    case riak_cs_bucket:fetch_bucket_object(Bucket, RcPid) of
+    case riak_cs_bucket:maybe_cache_fetch_bucket_object(Bucket, RcPid) of
         {ok, Obj} ->
             bucket_acl(Obj);
         {error, Reason} ->

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -25,6 +25,7 @@
 
 %% Public API
 -export([
+         maybe_cache_fetch_bucket_object/2,
          fetch_bucket_object/2,
          create_bucket/6,
          delete_bucket/4,
@@ -325,7 +326,7 @@ delete_bucket_policy(User, UserObj, Bucket, RcPid) ->
 -spec get_bucket_acl_policy(binary(), atom(), riak_client()) ->
                                    {acl(), policy()} | {error, term()}.
 get_bucket_acl_policy(Bucket, PolicyMod, RcPid) ->
-    case fetch_bucket_object(Bucket, RcPid) of
+    case maybe_cache_fetch_bucket_object(Bucket, RcPid) of
         {ok, Obj} ->
             %% For buckets there should not be siblings, but in rare
             %% cases it may happen so check for them and attempt to
@@ -402,6 +403,14 @@ bucket_empty_handle_list_keys(_RcPid, _Bucket, _Error) ->
 bucket_empty_any_pred(RcPid, Bucket) ->
     fun (Key) ->
             riak_cs_utils:key_exists(RcPid, Bucket, Key)
+    end.
+
+maybe_cache_fetch_bucket_object(BucketName, RcPid) ->
+    case riak_cs_config:bucket_cache_enabled() of
+        true ->
+            riak_cs_record_cache:get('moss.buckets.cache', BucketName);
+        _ ->
+            fetch_bucket_object(BucketName, RcPid)
     end.
 
 %% @doc Fetches the bucket object and verify its status.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -49,6 +49,8 @@
          set_gc_key_suffix_max/1,
          user_buckets_prune_time/0,
          set_user_buckets_prune_time/1,
+         user_cache_enabled/0,
+         bucket_cache_enabled/0,
          riak_host_port/0,
          connect_timeout/0,
          queue_if_disconnected/0,
@@ -286,6 +288,15 @@ set_user_buckets_prune_time(PruneTime) when is_integer(PruneTime) andalso PruneT
     application:set_env(riak_cs, user_buckets_prune_time, PruneTime);
 set_user_buckets_prune_time(_PruneTime) ->
     {error, invalid_value}.
+
+user_cache_enabled() ->
+    get_env(riak_cs, user_cache_enabled, false).
+
+bucket_cache_enabled() ->
+    get_env(riak_cs, bucket_cache_enabled, false).
+
+%% manifest_cache_enabled() ->
+%%     get_env(riak_cs, manifest_cache_enabled, false).
 
 %% @doc copied from `riak_cs_access_archiver'
 -spec riak_host_port() -> {inet:hostname(), inet:port_number()}.

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -61,12 +61,12 @@ test_condition_and_permission(RcPid, SrcManifest, RD, Ctx) ->
 authorize_on_src(RcPid, SrcManifest, RD,
                  #context{auth_module=AuthMod, local_context=LocalCtx} = Ctx) ->
     {SrcBucket, SrcKey} = SrcManifest?MANIFEST.bkey,
-    {ok, SrcBucketObj} = riak_cs_bucket:fetch_bucket_object(SrcBucket, RcPid),
+    {ok, SrcBucketObj} = riak_cs_bucket:maybe_cache_fetch_bucket_object(SrcBucket, RcPid),
     {ok, SrcBucketAcl} = riak_cs_acl:bucket_acl(SrcBucketObj),
 
     {UserKey, _} = AuthMod:identify(RD, Ctx),
     {User, UserObj} =
-        case riak_cs_user:get_user(UserKey, RcPid) of
+        case riak_cs_user:maybe_cached_get_user(UserKey, RcPid) of
             {ok, {User0, UserObj0}} ->
                 {User0, UserObj0};
             {error, no_user_key} ->

--- a/src/riak_cs_mp_utils.erl
+++ b/src/riak_cs_mp_utils.erl
@@ -646,7 +646,7 @@ multipart_description(Manifest) ->
 %% @doc Will cause error:{badmatch, {m_ibco, _}} if CallerKeyId does not exist
 
 is_caller_bucket_owner(RcPid, Bucket, CallerKeyId) ->
-    {m_icbo, {ok, {C, _}}} = {m_icbo, riak_cs_user:get_user(CallerKeyId, RcPid)},
+    {m_icbo, {ok, {C, _}}} = {m_icbo, riak_cs_user:maybe_cached_get_user(CallerKeyId, RcPid)},
     Buckets = [iolist_to_binary(B?RCS_BUCKET.name) ||
                   B <- riak_cs_bucket:get_buckets(C)],
     lists:member(Bucket, Buckets).

--- a/src/riak_cs_record_cache.erl
+++ b/src/riak_cs_record_cache.erl
@@ -1,0 +1,167 @@
+%%%-------------------------------------------------------------------
+%%% @author UENISHI Kota <kota@basho.com>
+%%% @copyright (C) 2014, UENISHI Kota
+%%% @doc
+%%%  We can adopt much smarter cache design, but so far this is it.
+%%% @end
+%%% Created :  8 Aug 2014 by UENISHI Kota <kota@basho.com>
+%%%-------------------------------------------------------------------
+-module(riak_cs_record_cache).
+
+-behaviour(gen_server).
+
+%% API
+-export([start_link/2, get/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include("riak_cs.hrl").
+-define(SERVER, ?MODULE).
+-define(TTL, 4096000). %% microseconds
+-define(COMPACTION_INTERVAL, 1024000). %% milliseconds
+
+-type refresher_fun() :: fun((Key::binary(), riak_client()) -> {ok, Data::term()} | {error, term()}).
+
+-record(state, {
+          name :: atom(),
+          refresher_fun = fun(_, _) -> {error, none} end :: refresher_fun()
+         }).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Starts the server
+-spec start_link(atom(), refresher_fun()) -> {ok, pid()} | ignore | {error, Error::term()}.
+start_link(Name, RefresherFun) ->
+    gen_server:start_link({local, Name}, ?MODULE, [Name, RefresherFun], []).
+
+%% @doc opaque proxy
+-spec get(atom(), User::binary()) -> {ok,rcs_user()}.
+get(Name, AccessKey) ->
+    case ets:lookup(Name, AccessKey) of
+        [] ->
+            Now = erlang:now(),
+            gen_server:call(Name, {get, AccessKey, Now});
+        [{AccessKey, RcsUser, TimeCached}] ->
+            Now = erlang:now(),
+            case timer:now_diff(Now, TimeCached) > ?TTL of
+                true -> %% cache expired
+                    lager:info("cache expired for ~p", [AccessKey]),
+                    gen_server:call(Name, {get, AccessKey, Now});
+                false -> %% cache hit
+                    {ok,RcsUser}
+            end
+    end.
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%% @private
+%% @doc Initializes the server
+-spec init(list()) -> {ok, #state{}} |
+                      {ok, #state{}, non_neg_integer()} |
+                      ignore |
+                      {stop, Reason::atom()}.
+init([Name, RefresherFun]) ->
+    Name = ets:new(Name, [public,named_table,set,{read_concurrency,true}]),
+    erlang:send_after(?COMPACTION_INTERVAL, self(), compact),
+    {ok, #state{name=Name, refresher_fun=RefresherFun}}.
+
+%% @private
+%% @doc Handling call messages
+handle_call({get,AccessKey,Now}, _From, State = #state{name=Name, refresher_fun=RefresherFun}) ->
+    case ets:lookup(Name, AccessKey) of
+        [] ->
+            Reply = refresh(AccessKey, Name, RefresherFun),
+            {reply,Reply,State};
+        [{AccessKey, RcsUser, TimeCached}] ->
+            case timer:now_diff(Now, TimeCached) > ?TTL of
+                true -> %% cache expired
+                    Reply = refresh(AccessKey, Name, RefresherFun),
+                    {reply,Reply,State};
+                false -> %% cache hit
+                    {reply,{ok,RcsUser},State}
+            end
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(compact, State = #state{name=Name}) ->
+    ets:delete_all_objects(Name),
+    lager:debug("~s compaction at ~p cache", [?MODULE, Name]),
+    erlang:send_after(?COMPACTION_INTERVAL, self(), compact),
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, #state{name=Name} = _State) ->
+    ets:delete(Name),
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+refresh(Key, Name, RefresherFun) when is_binary(Key) ->
+    {ok, RcPid} = riak_cs_utils:riak_connection(request_pool),
+    Now = erlang:now(),
+    try
+        %% Reply = riak_cs_user:get_user(AccessKey, RcPid),
+        Reply = RefresherFun(Key, RcPid),
+        case Reply of
+            {ok, Data} ->
+                %% TODO: storing User only might be sufficient and space saving
+                true = ets:insert(Name, {Key, Data, Now}),
+                lager:info("cache updated for ~p at ~p", [Key, Name]);
+            _ ->
+                false
+        end,
+        Reply
+    after
+            ok = riak_cs_utils:close_riak_connection(request_pool, RcPid)
+    end.

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -271,7 +271,7 @@ log_supported_actions()->
                                 {'error', 'multiple_bucket_owners'}.
 -spec fetch_bucket_policy(binary(), riak_client()) -> bucket_policy_result().
 fetch_bucket_policy(Bucket, RcPid) ->
-    case riak_cs_bucket:fetch_bucket_object(Bucket, RcPid) of
+    case riak_cs_bucket:maybe_cache_fetch_bucket_object(Bucket, RcPid) of
         {ok, Obj} ->
             %% For buckets there should not be siblings, but in rare
             %% cases it may happen so check for them and attempt to

--- a/src/riak_cs_storage.erl
+++ b/src/riak_cs_storage.erl
@@ -50,7 +50,7 @@
 sum_user(RcPid, User) when is_binary(User) ->
     sum_user(RcPid, binary_to_list(User));
 sum_user(RcPid, User) when is_list(User) ->
-    case riak_cs_user:get_user(User, RcPid) of
+    case riak_cs_user:maybe_cached_get_user(User, RcPid) of
         {ok, {UserRecord, _UserObj}} ->
             Buckets = riak_cs_bucket:get_buckets(UserRecord),
             BucketUsages = [maybe_sum_bucket(User, B) || B <- Buckets],

--- a/src/riak_cs_wm_bucket_delete.erl
+++ b/src/riak_cs_wm_bucket_delete.erl
@@ -66,7 +66,7 @@ process_post(RD, Ctx=#context{bucket=Bucket,
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"multiple_delete">>, [], [UserName, Bucket]),
 
 
-    handle_with_bucket_obj(riak_cs_bucket:fetch_bucket_object(Bucket, RcPid), RD, Ctx).
+    handle_with_bucket_obj(riak_cs_bucket:maybe_cache_fetch_bucket_object(Bucket, RcPid), RD, Ctx).
 
 handle_with_bucket_obj({error, notfound}, RD,
                        #context{response_module=ResponseMod} = Ctx) ->

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -162,7 +162,7 @@ forbidden(RD, Ctx=#context{auth_module=AuthMod,
                                            [],
                                            [riak_cs_wm_utils:extract_name(UserKey)]),
                 UserLookupResult = maybe_create_user(
-                                     riak_cs_user:get_user(UserKey, RcPid),
+                                     riak_cs_user:maybe_cached_get_user(UserKey, RcPid),
                                      UserKey,
                                      Ctx#context.api,
                                      Ctx#context.auth_module,
@@ -204,7 +204,7 @@ maybe_create_user({error, NE}, KeyId, oos, _, {UserData, _}, RcPid)
     {_, Secret} = riak_cs_oos_utils:user_ec2_creds(UserId, KeyId),
     %% Attempt to create a Riak CS user to represent the OS tenant
     _ = riak_cs_user:create_user(Name, Email, KeyId, Secret),
-    riak_cs_user:get_user(KeyId, RcPid);
+    riak_cs_user:maybe_cached_get_user(KeyId, RcPid);
 maybe_create_user({error, NE}, KeyId, s3, riak_cs_keystone_auth, {UserData, _}, RcPid)
   when NE =:= not_found;
        NE =:= notfound;
@@ -213,7 +213,7 @@ maybe_create_user({error, NE}, KeyId, s3, riak_cs_keystone_auth, {UserData, _}, 
     {_, Secret} = riak_cs_oos_utils:user_ec2_creds(UserId, KeyId),
     %% Attempt to create a Riak CS user to represent the OS tenant
     _ = riak_cs_user:create_user(Name, Email, KeyId, Secret),
-    riak_cs_user:get_user(KeyId, RcPid);
+    riak_cs_user:maybe_cached_get_user(KeyId, RcPid);
 maybe_create_user({error, no_user_key}=Error, _, _, _, _, _) ->
     %% Anonymous access may be authorized by ACL or policy afterwards,
     %% no logging here.


### PR DESCRIPTION
Getting user records and bucket records can be bottleneck
under a workload of single user and single bucket, as all
requests are serialized. This does not affect existing codes
without any caching. The TTL is currently 4 seconds hard
coded.
