### PR TITLE
Remove one line from assertion of access log flush command

### DIFF
--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -70,7 +70,7 @@ generate_some_accesses(UserConfig) ->
 flush_access_stats() ->
     Res = rtcs:flush_access(1),
     lager:info("riak-cs-access flush result: ~s", [Res]),
-    ExpectRegexp = "0 more archives to flush\nAll access logs were flushed.\n$",
+    ExpectRegexp = "All access logs were flushed.\n$",
     ?assertMatch({match, _}, re:run(Res, ExpectRegexp)).
 
 assert_access_stats(Format, UserConfig, {Begin, End}) ->


### PR DESCRIPTION
`access_stats_test` keeps failing on my laptop because
there is a race whether the line "~b more archives to flush~n" is
output or not.  Remove the line from assertion and use only another
line of "All access logs were flushed.~n".
