### PR TITLE
Add switch to choose listkeys or fold_objects in storage calclation

### DIFF
--- a/dialyzer.ignore-warnings.ee
+++ b/dialyzer.ignore-warnings.ee
@@ -1,7 +1,7 @@
 # Errors
 riak_cs_block_server.erl:312: The pattern
 riak_cs_block_server.erl:347: The pattern
-riak_cs_config.erl:239: The pattern
+riak_cs_config.erl:240: The pattern
 # Warnings
 Unknown functions:
   app_helper:get_prop_or_env/3

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -55,7 +55,8 @@
          auto_reconnect/0,
          is_multibag_enabled/0,
          max_buckets_per_user/0,
-         read_before_last_manifest_write/0
+         read_before_last_manifest_write/0,
+         use_2i_for_storage_calc/0
         ]).
 
 %% Timeouts hitting Riak
@@ -373,6 +374,14 @@ max_buckets_per_user() ->
 read_before_last_manifest_write() ->
     get_env(riak_cs, read_before_last_manifest_write, true).
 
+%% @doc This switch changes mapreduce input from listkeys to
+%% fold_objects after riak_kv's mapreduce input optimization
+%% merged and enabled. With fold_objects it will have 1/2 IO
+%% when scanning the whole bucket.
+-spec use_2i_for_storage_calc() -> boolean().
+use_2i_for_storage_calc() ->
+    riak_cs_list_objects_utils:fold_objects_for_list_keys()
+        andalso get_env(riak_cs, use_2i_for_storage_calc, false).
 
 %% ===================================================================
 %% ALL Timeouts hitting Riak


### PR DESCRIPTION
Cleaner version of https://github.com/basho/riak_cs/compare/ku-optimize-storage-calc . Maybe the default value can be `true` as it doesn't affect performance.

```
Eshell V5.10.3  (abort with ^G)
(riak-cs@127.0.0.1)1> timer:tc(fun() -> riak_cs_storage:sum_bucket(<<"junk">>) end).
{2771516,
 {struct,[{<<"Objects">>,58457},{<<"Bytes">>,2784575686}]}}
(riak-cs@127.0.0.1)2> application:set_env(riak_cs, use_2i_for_storage_calc, true).  
ok
(riak-cs@127.0.0.1)3> timer:tc(fun() -> riak_cs_storage:sum_bucket(<<"junk">>) end).
{2756002,
 {struct,[{<<"Objects">>,58457},{<<"Bytes">>,2784575686}]}}
```

This experiment was with vanilla Riak - so it doesn't yet have improvement. This needs another optimization like https://github.com/basho/riak_kv/compare/2.0...ku-optimize-mapred-listkeys .
