### PR TITLE
Suppress unnecessary warnings at startup

### DIFF
--- a/rel/files/app.config
+++ b/rel/files/app.config
@@ -110,6 +110,10 @@
               %% up; integer number of logs
               {access_archiver_max_backlog, 2},
 
+              %% How many workers to put access log data to Riak are
+              %% allowed to run concurrently; integer number of workers
+              {access_archiver_max_workers, 2},
+
               %% When to automatically start storage calculation
               %% batches; list of "HHMM" UTC times
               %% ([] == do not automatically calculation;

--- a/src/riak_cs_access_archiver_manager.erl
+++ b/src/riak_cs_access_archiver_manager.erl
@@ -125,7 +125,7 @@ init([]) ->
                      {ok, Workers} when is_integer(Workers) -> Workers;
                      _ ->
                          _ = lager:warning(
-                               "access_archiver_max_backlog was unset or"
+                               "access_archiver_max_workers was unset or"
                                " invalid; overriding with default of ~b",
                                [?DEFAULT_MAX_ARCHIVERS]),
                          ?DEFAULT_MAX_ARCHIVERS

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -28,7 +28,8 @@
 -export([start/2,
          stop/1,
          sanity_check/2,
-         check_bucket_props/2]).
+         check_bucket_props/2,
+         atoms_for_check_bucket_props/0]).
 
 -include("riak_cs.hrl").
 
@@ -93,6 +94,11 @@ check_bucket_props() ->
     after
         riakc_pb_socket:stop(MasterPbc)
     end.
+
+%% Put atoms into atom table to suppress warning logs in `check_bucket_props'
+atoms_for_check_bucket_props() ->
+    [riak_core_util, chash_std_keyfun,
+     riak_kv_wm_link_walker, mapreduce_linkfun].
 
 promote_errors(_Elem, {error, _Reason}=E) ->
     E;


### PR DESCRIPTION
This PR removes two kinds of warning logs at riak-cs start-up.
- Warning about `access_archiver_max_workers`, including typo fix
- Warning on creation of new atoms from `riak-erlang-client`
