### PR TITLE
Updating rebar.config to be set purely to tags/SHAs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -57,5 +57,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.0.0"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "master"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.2"}}}
           ]}.


### PR DESCRIPTION
As requested following conversations with Andrew Stone, here's a PR to pin deps to the latest tags/SHAs available in subrepos. Be aware that work may be needed in those subrepos to actually bring in commits that are expected, as previous builds have been against branches.
