### PR TITLE
Yessir riak client, part 1

### DIFF
--- a/rel/files/advanced.config
+++ b/rel/files/advanced.config
@@ -1,7 +1,31 @@
 [
  {riak_cs,
+  [
+   %% == Extra for easy development ==
+   {enforce_multipart_part_size, false},
+   {proxy_get, enabled},
+   {admin_auth_enabled, false},
 
-   [
+   {riak_client, riak_cs_yessir_riak_client},
+   %% {auth_bypass, true},
+   %% {auth_module, riak_cs_s3_passthru_auth},
 
-   ]}
+   {dummy, value}
+
+  ]},
+
+ {lager,
+  [
+   {colored, true},
+   {colors, [
+             {debug,     "\e[0;36m" }, %% 36 = cyan
+             {info,      "\e[0;35m" }, %% 35 = magenta
+             {notice,    "\e[1;32m" }, %% 32 = green
+             {warning,   "\e[1;34m" },
+             {error,     "\e[1;31m" }, %% 31 = red
+             {critical,  "\e[1;43m" }, %% 43 = background yellow
+             {alert,     "\e[1;43m" },
+             {emergency, "\e[1;43m" }
+            ]}
+  ]}
 ].

--- a/src/riak_cs_riak_client.erl
+++ b/src/riak_cs_riak_client.erl
@@ -62,13 +62,17 @@
          }).
 
 start_link(_Args) ->
-    case riak_cs_config:is_multibag_enabled() of
-        true ->
-            gen_server:start_link(riak_cs_multibag_riak_client, [], []);
-        false ->
-            gen_server:start_link(?MODULE, [], [])
+    case application:get_env(riak_cs, riak_client) of
+        {ok, Mod} ->
+            gen_server:start_link(Mod, [], []);
+        undefined ->
+            Mod = case riak_cs_config:is_multibag_enabled() of
+                      true  -> riak_cs_multibag_riak_client;
+                      false -> ?MODULE
+                  end,
+            application:set_env(riak_cs, riak_client, Mod),
+            gen_server:start_link(Mod, [], [])
     end.
-
 stop(Pid) ->
     gen_server:call(Pid, stop).
 

--- a/src/riak_cs_yessir_riak_client.erl
+++ b/src/riak_cs_yessir_riak_client.erl
@@ -1,0 +1,232 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_yessir_riak_client).
+
+-behaviour(gen_server).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
+-include_lib("riak_pb/include/riak_pb.hrl").
+-include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riakc/include/riakc.hrl").
+
+-include("riak_cs.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+          bucket_name,
+          user,
+          acl,
+          manifest
+         }).
+
+init([]) ->
+    {ok, fresh_state()}.
+
+handle_call(stop, _From, State) ->
+    _ = do_cleanup(State),
+    {stop, normal, ok, State};
+handle_call(cleanup, _From, State) ->
+    {reply, ok, do_cleanup(State)};
+handle_call({get_bucket, BucketName}, _From, #state{acl=Acl}=State) ->
+    UserMeta = [{?MD_ACL, term_to_binary(Acl)}],
+    Obj = riakc_obj:new_obj(?BUCKETS_BUCKET, BucketName, <<"vclock">>,
+                            [{dict:from_list([{?MD_USERMETA, UserMeta}]),
+                              BucketName}]),
+    {reply, {ok, Obj}, State#state{bucket_name = BucketName}};
+handle_call({set_bucket_name, BucketName}, _From, State) ->
+    {reply, ok, State#state{bucket_name=BucketName}};
+handle_call({get_user, UserKeyBin}, _From, State) ->
+    {User, Acl} = new_user(UserKeyBin),
+    Obj = user_to_robj(User),
+    {reply, {ok, {Obj, true}}, State#state{user=User, acl=Acl}};
+%% handle_call({save_user, User, OldUserObj}, _From, State) ->
+%%     case ensure_master_pbc(State) of
+%%         {ok, #state{master_pbc=MasterPbc} = NewState} ->
+%%             Res = save_user_with_pbc(MasterPbc, User, OldUserObj),
+%%             {reply, Res, NewState};
+%%         {error, Reason} ->
+%%             {reply, {error, Reason}, State}
+%%     end;
+handle_call({req, #rpbgetreq{} = RpbGetReq, _Timeout},
+            _From, State) ->
+    {Res, NewState} = process_get_req(RpbGetReq, State),
+    {reply, Res, NewState};
+handle_call({req, #rpbputreq{} = RpbPutReq, _Timeout},
+            _From, State) ->
+    {Res, NewState} = process_put_req(RpbPutReq, State),
+    {reply, Res, NewState};
+handle_call({req, #rpbcsbucketreq{max_results=_MaxResults,
+                                  start_key=_StartKey} = _Req,
+             _Timeout, {ReqId, Caller}=_Ctx}, From,
+            #state{bucket_name=BucketName, acl=Acl} = State) ->
+    gen_server:reply(From, {ok, ReqId}),
+    RiakcObjs = manifests_to_robjs([new_manifest(BucketName, <<"yessir-key1">>,
+                                                 3141592, Acl)]),
+    Caller ! {ReqId, {ok, RiakcObjs}},
+    Caller ! {ReqId, {done, continuation_ignored}},
+    {noreply, State};
+handle_call({req, #rpblistkeysreq{bucket=?USER_BUCKET} = _Req, _Timeout,
+             {ReqId, Caller}=_Ctx},
+            From,
+            #state{} = State) ->
+    gen_server:reply(From, {ok, ReqId}),
+    Keys = [list_to_binary("yessir" ++ integer_to_list(Index)) ||
+               Index <- lists:seq(1, 100)],
+    Caller ! {ReqId, {keys, Keys}},
+    Caller ! {ReqId, done},
+    {noreply, State};
+handle_call({req, #rpbindexreq{bucket=?GC_BUCKET} = _Req, _Timeout},
+            _From, #state{} = State) ->
+    Res = {ok, #index_results_v1{keys=[], terms=[],
+                                 continuation=undefined}},
+    {reply, Res, State};
+
+handle_call({set_manifest, _Manifest}, _From, State) ->
+    {reply, ok, State};
+handle_call({set_manifest_bag, _ManifestBagId}, _From, State) ->
+    {reply, ok, State};
+handle_call(master_pbc, _From, State) ->
+    {reply, {ok, self()}, State};
+handle_call(manifest_pbc, _From, State) ->
+    {reply, {ok, self()}, State};
+handle_call(block_pbc, _From, State) ->
+    {reply, {ok, self()}, State};
+
+handle_call(Request, _From, State) ->
+    lager:warning("Unknown request: ~p~n", [Request]),
+    Reply = {error, {invalid_request, Request}},
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%% Internal functions
+
+process_get_req(#rpbgetreq{bucket=Bucket, key=Key} = _RpbGetReq,
+                #state{bucket_name=BucketName, acl=Acl} = State) ->
+    case which_bucket(Bucket) of
+        objects ->
+            ContentLength = 10,
+            M = new_manifest(BucketName, Key, ContentLength, Acl),
+            Dict = riak_cs_manifest_utils:new_dict(M?MANIFEST.uuid, M),
+            ValueBin = riak_cs_utils:encode_term(Dict),
+            Obj = riakc_obj:new_obj(Bucket, Key, <<"vclock">>,
+                                    [{dict:new(), ValueBin}]),
+            {{ok, Obj}, State#state{manifest = M}};
+        blocks ->
+            UUIDSize = byte_size(Key) - 32 div 8,
+            <<_UUID:UUIDSize/binary, _BlockNumber:32>> = Key,
+            Obj = riakc_obj:new_obj(Bucket, Key, <<"vclock">>,
+                                    [{dict:new(), binary:copy(<<"a">>, 10)}]),
+            {{ok, Obj}, State};
+        Other ->
+            lager:warning("Unknown #rpbgetreq{} for ~p, bucket=~p, key=~p~n",
+                          [Other, Bucket, Key]),
+            error({not_implemented, {rpbgetreq, Other, Bucket, Key}})
+    end.
+
+process_put_req(#rpbputreq{} = _RpbPutReq, State) ->
+    {ok, State}.
+
+new_user(UserKeyBin) ->
+    UserKey = binary_to_list(UserKeyBin),
+    DisplayName = UserKey ++ "+DisplayName",
+    CanonicalId = UserKey ++ "+CanonicalId",
+    DefaultAcl = default_acl(DisplayName, CanonicalId, UserKey),
+    {#rcs_user_v2{name = UserKey,
+                  display_name = UserKey,
+                  email = UserKey ++ "@example.com",
+                  key_id = UserKey,
+                  key_secret = UserKey ++ "+Secret",
+                  canonical_id = CanonicalId,
+                  buckets=[#moss_bucket_v1{name = UserKey ++ "-yessir-bucket-1",
+                                           acl = DefaultAcl}]},
+     DefaultAcl}.
+
+user_to_robj(#rcs_user_v2{key_id=Key} = User) ->
+    UserKeyBin = list_to_binary(Key),
+    riakc_obj:new_obj(?USER_BUCKET, UserKeyBin, <<"vclock">>,
+                      [{dict:new(), term_to_binary(User)}]).
+
+default_acl(DisplayName, CannicalId, KeyId) ->
+    riak_cs_acl_utils:default_acl(DisplayName, CannicalId, KeyId).
+
+new_manifest(BucketName, Key, ContentLength, Acl) ->
+    %% TODO: iteration is needed for large content length
+    CMd5 = riak_cs_utils:md5(binary:copy(<<"a">>, ContentLength)),
+    ?MANIFEST{
+       block_size = riak_cs_lfs_utils:block_size(),
+       bkey = {BucketName, Key},
+       metadata = [],
+       created = riak_cs_wm_utils:iso_8601_datetime(),
+       uuid = druuid:v4(),
+
+       content_length = ContentLength,
+       content_type = <<"application/octet-stream">>,
+       content_md5 = CMd5,
+       acl = Acl,
+
+       state = active,
+       props = []}.
+
+manifests_to_robjs(Manifests) ->
+    [manifest_to_robj(M) || M <- Manifests].
+
+manifest_to_robj(?MANIFEST{bkey={Bucket, Key}, uuid=UUID}=M) ->
+    Dict = riak_cs_manifest_utils:new_dict(UUID, M),
+    ManifestBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    riakc_obj:new(ManifestBucket, Key, riak_cs_utils:encode_term(Dict)).
+
+which_bucket(?USER_BUCKET) ->
+    users;
+which_bucket(?BUCKETS_BUCKET) ->
+    buckets;
+which_bucket(?ACCESS_BUCKET) ->
+    access;
+which_bucket(?STORAGE_BUCKET) ->
+    storage;
+which_bucket(?GC_BUCKET) ->
+    gc;
+which_bucket(Bucket) ->
+    case binary:part(Bucket, 0, 3) of
+        ?OBJECT_BUCKET_PREFIX -> objects;
+        ?BLOCK_BUCKET_PREFIX -> blocks
+    end.
+
+fresh_state() ->
+    #state{}.
+
+do_cleanup(_State) ->
+    fresh_state().


### PR DESCRIPTION
YESSIR riak_client part 1

Communication with Riak KV is stubbed out almost completely.
Main purpose is to benchmark/optimize on-memory logic of riak_cs.

_Caution_ Communication with Stanchion is NOT stubbed out.
Stanchion and Riak KV is needed for create user operation, etc.
Also, bucket properties verification at riak-cs startup interacts
with Riak KV actually.

---

Setting in advanced.config:

```
  {riak_client, riak_cs_yessir_riak_client}
```

For user credential, secret should be user key id + "+Secret",
example for s3cfg:

```
access_key = MZ59BPUOELYZNPTEPFR3
secret_key = MZ59BPUOELYZNPTEPFR3+Secret
```

Current Status is as following, not-yet-implemented functionalities
will come with subsequent PRs (hopefully):
- [x] list buckets (only one bucket)
- [x] list object (only one entry)
- [x] get object (10-byte, fixed content)
- [ ] put object
- [ ] delete object
- [x] GC list keys (empty key list)
- [ ] GC (with some keys)
- [x] access/storage stats PUT
- [ ] access/storage GET
