### PR TITLE
Fix inaccurate webmachine log handler setting.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,6 +5,10 @@
 - Changed default value of `gc_max_workers` from 5 to 2 with its name
   changed to `gc.max_workers` with migration to config format change.
 
+## Notes on upgrading
+
+- Changed webmachine's access log handler module name.
+
 # Riak CS 1.5.4 Release Notes
 
 ## Bugs Fixed

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -286,7 +286,7 @@
  fun(Conf) ->
    Handler = case cuttlefish:conf_get("log.access.dir", Conf) of
      "" -> [];
-     Dir -> [{webmachine_log_handler, [Dir]}]
+     Dir -> [{webmachine_access_log_handler, [Dir]}]
    end,
    Handler ++ [{riak_cs_access_log_handler, []}]
  end

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -41,7 +41,7 @@ default_config_test() ->
                                               [{request_pool, {128, 0}},
                                                {bucket_list_pool, {5, 0}}]),
     cuttlefish_unit:assert_config(Config, "webmachine.log_handlers",
-                                              [{webmachine_log_handler, ["./log"]},
+                                              [{webmachine_access_log_handler, ["./log"]},
                                                {riak_cs_access_log_handler, []}]),
     cuttlefish_unit:assert_config(Config, "webmachine.server_name", "Riak CS"),
 %%    cuttlefish_unit:assert_config(Config, "vm_args.+scl", false),


### PR DESCRIPTION
`webmachine_log_handler` has been renamed to`webmachine_access_log_handler` on current webmachine.
