### PR TITLE
Refactor/multibag simpler state transition

### DIFF
--- a/include/riak_cs_gc_d.hrl
+++ b/include/riak_cs_gc_d.hrl
@@ -62,6 +62,7 @@
 -record(gc_worker_state, {
           %% Riak connection pid
           riak_client :: undefined | riak_client(),
+          bag_id :: bag_id(),
           current_files :: [lfs_manifest()],
           current_fileset :: twop_set:twop_set(),
           current_riak_object :: riakc_obj:riakc_obj(),

--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -46,7 +46,8 @@
          handle_cast/2,
          handle_info/2,
          terminate/2,
-         code_change/3]).
+         code_change/3,
+         format_status/2]).
 
 -record(state, {riak_client :: riak_client(),
                 close_riak_connection=true :: boolean()}).
@@ -458,6 +459,13 @@ terminate(_Reason, #state{riak_client=RcPid,
 %%--------------------------------------------------------------------
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+%% Define custom `format_status' to include status information of
+%% internal `riak_client'.
+format_status(_Opt, [_PDict, #state{riak_client=RcPid} = State]) ->
+    RcState = (catch sys:get_status(RcPid)),
+    [{block_server_state, State}, {riak_client_state, RcState}].
+
 
 %%%===================================================================
 %%% Internal functions

--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -68,8 +68,8 @@
 %% ===================================================================
 
 %% @doc Start a `riak_cs_delete_fsm'.
-start_link(RcPid, Manifest, GCWorkerPid, GCKey, Options) ->
-    Args = [RcPid, Manifest, GCWorkerPid, GCKey, Options],
+start_link(BagId, Manifest, GCWorkerPid, GCKey, Options) ->
+    Args = [BagId, Manifest, GCWorkerPid, GCKey, Options],
     gen_fsm:start_link(?MODULE, Args, []).
 
 -spec block_deleted(pid(), {ok, {binary(), integer()}} | {error, binary()}) -> ok.
@@ -80,8 +80,11 @@ block_deleted(Pid, Response) ->
 %% gen_fsm callbacks
 %% ====================================================================
 
-init([RcPid, {UUID, Manifest}, GCWorkerPid, GCKey, _Options]) ->
+init([BagId, {UUID, Manifest}, GCWorkerPid, GCKey, _Options]) ->
     {Bucket, Key} = Manifest?MANIFEST.bkey,
+    {ok, RcPid} = riak_cs_riak_client:checkout(),
+    ok = riak_cs_riak_client:set_manifest_bag(RcPid, BagId),
+    ok = riak_cs_riak_client:set_manifest(RcPid, Manifest),
     State = #state{bucket=Bucket,
                    key=Key,
                    manifest=Manifest,

--- a/src/riak_cs_riak_client.erl
+++ b/src/riak_cs_riak_client.erl
@@ -132,7 +132,7 @@ save_user(RcPid, User, OldUserObj) ->
 
 -spec set_manifest(riak_client(), lfs_manifest()) -> ok | {error, term()}.
 set_manifest(RcPid, Manifest) ->
-    gen_server:call(RcPid, {set_manifest, Manifest}).
+    gen_server:call(RcPid, {set_manifest, {Manifest?MANIFEST.uuid, Manifest}}).
 
 -spec set_manifest_bag(riak_client(), binary()) -> ok | {error, term()}.
 set_manifest_bag(RcPid, ManifestBagId) ->
@@ -204,7 +204,7 @@ handle_call(manifest_pbc, _From, State) ->
         {error, Reason} ->
             {reply, {error, Reason}, State}
     end;
-handle_call({set_manifest, _Manifest}, _From, State) ->
+handle_call({set_manifest, {_UUID, _Manifest}}, _From, State) ->
     {reply, ok, State};
 handle_call({set_manifest_bag, _ManifestBagId}, _From, State) ->
     {reply, ok, State};


### PR DESCRIPTION
Add UUID to `set_manifest` call argument. This leads to simplification in multibag riak client state transition.

This PR depends on #1079 and includes its commit. There is only one last commit for that is unique for this PR.
