### PR TITLE
Update cluster_info to 2.0.1 [JIRA: RCS-141]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -50,7 +50,7 @@
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "4bb0fd664ff065c4082ca8dd2e0683e920537d15"}},
         {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p2"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.2"}}},
-        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.0"}}},
+        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.1"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.5"}}},
         {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "3.1.0"}}}


### PR DESCRIPTION
Mainly for https://github.com/basho/cluster_info/pull/15
