### PR TITLE
Update webmachine, riakc, poolboy and riak_repl_pb_api. Pin multibag. [JIRA: RCS-143]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,14 +41,14 @@
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}},
         {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.0"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
-        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.7"}}},
-        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.0.1"}}},
+        {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
+        {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.0"}}},
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.0.3"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "0.78"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
         {velvet, "1.3.*", {git, "git://github.com/basho/velvet", "4bb0fd664ff065c4082ca8dd2e0683e920537d15"}},
-        {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p2"}},
+        {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p3"}},
         {folsom, ".*", {git, "git://github.com/boundary/folsom", {tag, "0.8.2"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.1"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
@@ -57,6 +57,6 @@
        ]}.
 
 {deps_ee, [
-           {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.0.0"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {branch, "master"}}}
+           {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.1.0"}}},
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.0.0pre1"}}}
           ]}.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -2,7 +2,7 @@
 %% ex: ts=4 sw=4 et
 {sys, [
        {lib_dirs, ["../deps", "../apps"]},
-       {rel, "riak-cs", "1.5.4",
+       {rel, "riak-cs", "2.0.0",
         [
          kernel,
          stdlib,


### PR DESCRIPTION
...for upcoming code freeze. Pinned as 2.0.0 in reltool.config. Maybe https://github.com/basho/eper/pull/11 will follow later.
