### PR TITLE
Fix typos in relnote configuration table and source comment

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -257,7 +257,7 @@ value but an example is added.
 |`{cs_port, 8080}`                   |                                        |
 |`{riak_ip, "127.0.0.1"}`            |`riak_host = 127.0.0.1:8087`            |
 |`{riak_pb_port, 8087}`              |                                        |
-|`{stanchion_ip, "127.0.0.1"}`       |`stanchion_host = 127.0.0.=:8085`       |
+|`{stanchion_ip, "127.0.0.1"}`       |`stanchion_host = 127.0.0.1:8085`       |
 |`{stanchion_port, 8085 }`           |                                        |
 |`{stanchion_ssl, false }`           |`stanchion_ssl = off`                   |
 |`{anonymous_user_creation, false}`  |`anonymous_user_creation = off`         |
@@ -273,13 +273,13 @@ value but an example is added.
 |`{leeway_seconds, 86400}`           |`gc.leeway_period = 24h`                |
 |`{gc_interval, 900}`                |`gc.interval = 15m`                     |
 |`{gc_retry_interval, 21600}`        |`gc.retry_interval = 6h`                |
-|`{access_log_flush_factor, 1}`      |`access.stats.flush_factor = 1`         |
-|`{access_log_flush_size, 1000000}`  |`access.stats.flush_size = 1000000`     |
-|`{access_archive_period, 3600}`     |`access.stats.archive_period = 1h`      |
-|`{access_archiver_max_backlog, 2}`  |`access.stats.archiver.max_backlog = 2` |
-|no explicit default                 |`access.stats.archiver.max_workers = 2` |
-|`{storage_schedule, []}`            |`storage.stats.schedule.$time = "06:00"`|
-|`{storage_archive_period, 86400}`   |`storage.stats.archive_period = 1d`     |
+|`{access_log_flush_factor, 1}`      |`stats.access.flush_factor = 1`         |
+|`{access_log_flush_size, 1000000}`  |`stats.access.flush_size = 1000000`     |
+|`{access_archive_period, 3600}`     |`stats.access.archive_period = 1h`      |
+|`{access_archiver_max_backlog, 2}`  |`stats.access.archiver.max_backlog = 2` |
+|(no explicit default)               |`stats.access.archiver.max_workers = 2` |
+|`{storage_schedule, []}`            |`stats.storage.schedule.$time = "06:00"`|
+|`{storage_archive_period, 86400}`   |`stats.storage.archive_period = 1d`     |
 |`{usage_request_limit, 744}`        |`riak_cs.usage_request_limit = 31d`     |
 |`{cs_version, 10300 }`              |`cs_version = 10300`                    |
 |`{dtrace_support, false}`           |`dtrace = off`                          |

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -147,14 +147,6 @@ Including CS path: add following sentence to `advanced.config`:
 ]}.
 ```
 
-If multibag is to be used, add multibag ebin path:
-
-```erlang
-{riak_kv, [
-  {add_paths, ["/usr/lib/riak-cs/lib/riak_cs-2.0.0/ebin"]}
-]}.
-```
-
 ### Riak CS 1.5 to 2.0, including Stanchion
 
 Consult

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -204,7 +204,7 @@
 ]}.
 
 %% @doc How large each access archive object is. Should be a
-%% multiple of access_log_flush_interval.
+%% multiple of stats.access.flush_factor.
 {mapping, "stats.access.archive_period", "riak_cs.access_archive_period", [
   {default, "1h"},
   {datatype, {duration, s}}

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -63,7 +63,7 @@ archive_period() ->
 
 %% @doc Retrieve the number of seconds that should elapse between
 %% flushes of access stats.  This setting is controlled by the
-%% `access_log_flush_interval' environment variable of the `riak_cs'
+%% `access_log_flush_factor' environment variable of the `riak_cs'
 %% application.
 -spec log_flush_interval() -> {ok, integer()}|{error, term()}.
 log_flush_interval() ->
@@ -75,7 +75,7 @@ log_flush_interval() ->
                         0 ->
                             {ok, AP div AF};
                         _ ->
-                            {error, "riak_cs:access_log_flush_interval"
+                            {error, "riak_cs:access_log_flush_factor"
                              " does not evenly divide"
                              " riak_cs:access_archive_period"}
                     end;
@@ -83,7 +83,7 @@ log_flush_interval() ->
                     APError
             end;
         _ ->
-            {error, "riak_cs:access_log_flush_interval was not an integer"}
+            {error, "riak_cs:access_log_flush_factor was not an integer"}
     end.
 
 %% @doc Retrieve the maximum number of records that should be added to

--- a/src/riak_cs_access_log_handler.erl
+++ b/src/riak_cs_access_log_handler.erl
@@ -48,11 +48,11 @@
 %%
 %% The log is flushed to Riak at an interval specified by the
 %% `riak_cs' application environment variable
-%% `access_log_flush_interval'.  The value is the maximum number of
-%% seconds between flushes.  This number should be less than or equal
-%% to the `access_archive_period' setting, and should also evenly
-%% divide that setting, or results of later queries may miss
-%% information.
+%% `access_log_flush_factor'. How often to flush the access log;
+%% integer factor of `access_archive_period'
+%% (1 == once per period; 2 == twice per period, etc.)
+%% This number should evenly divide the `access_archive_period'
+%% setting, or results of later queries may miss information.
 
 -module(riak_cs_access_log_handler).
 


### PR DESCRIPTION
- Remove non-existent configuration name
- Fix configuration names in release note table
