### PR TITLE
Update ceph tests to the latest version.

### DIFF
--- a/client_tests/python/README.md
+++ b/client_tests/python/README.md
@@ -7,12 +7,13 @@
 
 ## Configuration
 
-Ensure that the Riak CS `app.config` has `anonymous_user_creation` set to
-`true` and `enforce_multipart_part_size` to `false`. Like:
+Ensure that the Riak CS `advanced.config` has the following items:
 
 ```erlang
 {anonymous_user_creation, true},
 {enforce_multipart_part_size, false},
+{max_buckets_per_user, 300},
+{auth_v4_enabled, true},
 ```
 
 ## Execution

--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -33,6 +33,8 @@ import boto
 
 def setup_auth_scheme():
     auth_mech=os.environ.get('CS_AUTH', 'auth-v2')
+    if not boto.config.has_section('s3'):
+        boto.config.add_section('s3')
     if auth_mech == 'auth-v4':
         setup_auth_v4()
     else:
@@ -41,13 +43,11 @@ def setup_auth_scheme():
 def setup_auth_v4():
     print('Use AWS Version 4 authentication')
     if not boto.config.get('s3', 'use-sigv4'):
-        boto.config.add_section('s3')
         boto.config.set('s3', 'use-sigv4', 'True')
 
 def setup_auth_v2():
     print('Use AWS Version 2 authentication')
     if not boto.config.get('s3', 'use-sigv4'):
-        boto.config.add_section('s3')
         boto.config.set('s3', 'use-sigv4', '')
 
 setup_auth_scheme()

--- a/client_tests/python/ceph_tests/Makefile
+++ b/client_tests/python/ceph_tests/Makefile
@@ -7,7 +7,7 @@ BIN = env/bin
 all: test
 
 s3-tests:
-	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-1.5
+	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-2.0
 
 env:
 	@cd s3-tests && virtualenv env

--- a/client_tests/python/ceph_tests/s3_conf.sh
+++ b/client_tests/python/ceph_tests/s3_conf.sh
@@ -56,6 +56,8 @@ proxy_port = $PORT
 ## say \"no\" to disable TLS
 is_secure = no
 
+api_name = us-east-1
+
 [fixtures]
 ## all the buckets created will start with this prefix;
 ## {random} will be filled with random characters to pad

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -43,7 +43,7 @@ cs_config() ->
        {stanchion_host, {"127.0.0.1", 9095}},
        {cs_version, 010300},
        {enforce_multipart_part_size, false},
-       {max_buckets_per_user, 150},
+       {max_buckets_per_user, 300},
        {auth_v4_enabled, true}
       ]
      }].

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -23,7 +23,7 @@ confirm() ->
            {"AWS_ACCESS_KEY_ID",     UserConfig#aws_config.access_key_id},
            {"AWS_SECRET_ACCESS_KEY", UserConfig#aws_config.secret_access_key},
            {"CS_BUCKET",             ?TEST_BUCKET}],
-    WaitTime = 2 * rt_config:get(rt_max_wait_time),
+    WaitTime = 5 * rt_config:get(rt_max_wait_time),
     case rtcs:cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}], WaitTime) of
         ok ->
             rtcs:pass();


### PR DESCRIPTION
https://github.com/basho/s3-tests/pull/2 is needed to pass the tests.
