### PR TITLE
Run external_client_tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,16 @@ pulse: all
 	@rm -rf $(BASE_DIR)/.eunit
 	@./rebar -D PULSE eunit skip_deps=true suites=$(PULSE_TESTS)
 
-test-client: test-clojure test-python test-erlang test-ruby test-php test-go
+test-client: test-clojure test-boto test-ceph test-erlang test-ruby test-php test-go
 
 test-python:
 	@cd client_tests/python/ && make CS_HTTP_PORT=$(CS_HTTP_PORT)
+
+test-boto:
+	@cd client_tests/python/ && make boto_tests CS_HTTP_PORT=$(CS_HTTP_PORT)
+
+test-ceph:
+	@cd client_tests/python/ && make ceph_tests CS_HTTP_PORT=$(CS_HTTP_PORT)
 
 test-ruby:
 	@bundle --gemfile client_tests/ruby/Gemfile --path vendor

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -18,7 +18,7 @@ confirm() ->
     CsPortStr = integer_to_list(rtcs:cs_port(hd(RiakNodes))),
 
     Cmd = os:find_executable("make"),
-    Args = ["test-client"],
+    Args = ["-j", "8", "test-client"],
     Env = [{"CS_HTTP_PORT",          CsPortStr},
            {"AWS_ACCESS_KEY_ID",     UserConfig#aws_config.access_key_id},
            {"AWS_SECRET_ACCESS_KEY", UserConfig#aws_config.secret_access_key},


### PR DESCRIPTION
We can save 1 to 2 minutes for every execution of `external_client_tests` with this pull request.

First test with original develop branch

```
Test Results:
external_client_tests-cs_multi_backend: pass
---------------------------------------------
0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score

real    5m5.046s
user    1m33.868s
sys     0m12.844s
```

Second trial with `-j 8` added to Make command

```
Test Results:
external_client_tests-cs_multi_backend: pass
---------------------------------------------
0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score

real    3m46.466s
user    1m39.452s
sys     0m13.524s
```

Third trial with `-j` added to Make command

```
Test Results:
external_client_tests-cs_multi_backend: pass
---------------------------------------------
0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score

real    3m24.162s
user    1m46.288s
sys     0m14.440s
```

One more last trial with default develop branch, without any parallelism

```
Test Results:
external_client_tests-cs_multi_backend: pass
---------------------------------------------
0 Tests Failed
1 Tests Passed
That's 100.0% for those keeping score

real    4m57.735s
user    1m31.124s
sys     0m13.892s
```

Those results are with my 8 core 32Gig ram machine, so that's why just `-j` had the best performance. I'd rather put a safety as limiting to 8. This task is nor CPU intensive nor IO intensive, rather complex workload so just limiting to 8 might be enough. It should work for 2 or 4 core laptop. Let's save a minute.
