### PR TITLE
Filter out detailed storage stats for normal users  [JIRA: RCS-202]

### DIFF
--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -268,19 +268,22 @@ assert_storage_xml_stats({Bucket, ExpectedObjects, ExpectedBytes}, Sample) ->
     ok.
 
 storage_stats_request(UserConfig, Begin, End) ->
-    {storage_stats_json_request(UserConfig, Begin, End),
-     storage_stats_xml_request(UserConfig, Begin, End)}.
+    storage_stats_request(UserConfig, UserConfig, Begin, End).
 
-storage_stats_json_request(UserConfig, Begin, End) ->
-    Samples = samples_from_json_request(UserConfig, {Begin, End}),
+storage_stats_request(SignUserConfig, UserConfig, Begin, End) ->
+    {storage_stats_json_request(SignUserConfig, UserConfig, Begin, End),
+     storage_stats_xml_request(SignUserConfig, UserConfig, Begin, End)}.
+
+storage_stats_json_request(SignUserConfig, UserConfig, Begin, End) ->
+    Samples = samples_from_json_request(SignUserConfig, UserConfig, {Begin, End}),
     lager:debug("Storage samples[json]: ~p", [Samples]),
     ?assertEqual(1, length(Samples)),
     [Sample] = Samples,
     lager:info("Storage sample[json]: ~p", [Sample]),
     Sample.
 
-storage_stats_xml_request(UserConfig, Begin, End) ->
-    Samples = samples_from_xml_request(UserConfig, {Begin, End}),
+storage_stats_xml_request(SignUserConfig, UserConfig, Begin, End) ->
+    Samples = samples_from_xml_request(SignUserConfig, UserConfig, {Begin, End}),
     lager:debug("Storage samples[xml]: ~p", [Samples]),
     ?assertEqual(1, length(Samples)),
     [Sample] = Samples,
@@ -288,19 +291,19 @@ storage_stats_xml_request(UserConfig, Begin, End) ->
     lager:info("Storage sample[xml]: ~p", [ParsedSample]),
     ParsedSample.
 
-samples_from_json_request(UserConfig, {Begin, End}) ->
+samples_from_json_request(SignUserConfig, UserConfig, {Begin, End}) ->
     KeyId = UserConfig#aws_config.access_key_id,
     StatsKey = string:join(["usage", KeyId, "bj", Begin, End], "/"),
-    GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, UserConfig),
+    GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, SignUserConfig),
     lager:debug("GET Storage stats response[json]: ~p", [GetResult]),
     Usage = mochijson2:decode(proplists:get_value(content, GetResult)),
     lager:debug("Usage Response[json]: ~p", [Usage]),
     rtcs:json_get([<<"Storage">>, <<"Samples">>], Usage).
 
-samples_from_xml_request(UserConfig, {Begin, End}) ->
+samples_from_xml_request(SignUserConfig, UserConfig, {Begin, End}) ->
     KeyId = UserConfig#aws_config.access_key_id,
     StatsKey = string:join(["usage", KeyId, "bx", Begin, End], "/"),
-    GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, UserConfig),
+    GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, SignUserConfig),
     lager:debug("GET Storage stats response[xml]: ~p", [GetResult]),
     {Usage, _Rest} = xmerl_scan:string(binary_to_list(proplists:get_value(content, GetResult))),
     lager:debug("Usage Response[xml]: ~p", [Usage]),

--- a/src/riak_cs_access.erl
+++ b/src/riak_cs_access.erl
@@ -27,7 +27,7 @@
          log_flush_interval/0,
          max_flush_size/0,
          make_object/3,
-         get_usage/4,
+         get_usage/5,
          flush_to_log/2,
          flush_access_object_to_log/3
         ]).
@@ -137,10 +137,11 @@ merge_stats(Stats, Acc) ->
 %% list of samples.  Each sample is an orddict full of metrics.
 -spec get_usage(riak_client(),
                 term(), %% TODO: riak_cs:user_key() type doesn't exist
+                boolean(),  %% Not used in this module
                 calendar:datetime(),
                 calendar:datetime()) ->
                        {Usage::orddict:orddict(), Errors::[{slice(), term()}]}.
-get_usage(RcPid, User, Start, End) ->
+get_usage(RcPid, User, _AdminAccess, Start, End) ->
     {ok, Period} = archive_period(),
     {Usage, Errors} = rts:find_samples(RcPid, ?ACCESS_BUCKET, User,
                                        Start, End, Period),

--- a/src/riak_cs_simple_quota.erl
+++ b/src/riak_cs_simple_quota.erl
@@ -223,7 +223,7 @@ get_latest_usage(Pid, User, ArchivePeriod, EndSec, N, Max) ->
     End = calendar:gregorian_seconds_to_datetime(EndSec),
     EndSec2 = EndSec - ArchivePeriod,
     ADayAgo = calendar:gregorian_seconds_to_datetime(EndSec2),
-    case riak_cs_storage:get_usage(Pid, User, ADayAgo, End) of
+    case riak_cs_storage:get_usage(Pid, User, false, ADayAgo, End) of
         {[], _} ->
             get_latest_usage(Pid, User, ArchivePeriod, EndSec2, N+1, Max);
         {Res, _} ->

--- a/src/riak_cs_storage_d.erl
+++ b/src/riak_cs_storage_d.erl
@@ -402,7 +402,7 @@ recalc(true, _RcPid, _User, _Time) ->
 recalc(false, RcPid, User, Time) ->
     {ok, Period} = riak_cs_storage:archive_period(),
     {Start, End} = rts:slice_containing(Time, Period),
-    case riak_cs_storage:get_usage(RcPid, User, Start, End) of
+    case riak_cs_storage:get_usage(RcPid, User, true, Start, End) of
         {[], _} ->
             %% No samples were found for this time period (or all
             %% attempts ended in error); calculate


### PR DESCRIPTION
Only "Objects" and "Bytes" for normal users as same as 2.0 or prior.
Server internal resource utilization is not appropriate for end users of service.

This is a follow-up code of #1120 
