### PR TITLE
Orphan block scanner scripts

### DIFF
--- a/priv/tools/internal/block_audit.erl
+++ b/priv/tools/internal/block_audit.erl
@@ -1,0 +1,249 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(block_audit).
+
+-export([main/1]).
+
+-define(DEFAULT_RIAK_HOST, "127.0.0.1").
+-define(DEFAULT_RIAK_PORT, 8087).
+-define(BUCKET_TOMBSTONE, <<"0">>).
+-define(SLK_TIMEOUT, 360000000). %% 100 hours
+
+-include_lib("riak_cs/include/riak_cs.hrl").
+
+riak_host_and_port([]) ->
+    {?DEFAULT_RIAK_HOST, ?DEFAULT_RIAK_PORT};
+riak_host_and_port([Host, PortStr | _]) ->
+    try
+        Port = list_to_integer(PortStr),
+        {Host, Port}
+    catch _:_ ->
+            usage()
+    end.
+
+usage() ->
+    io:format("Usage: ./block_audit.escript <RIAK_HOST> <RIAK_PORT>~n").
+
+main(Args) when length(Args) < 2 ->
+    usage();
+main(Args) ->
+    {RiakHost, RiakPort} = riak_host_and_port(Args),
+    {ok, Pid} = riakc_pb_socket:start_link(RiakHost, RiakPort),
+    {ok, Buckets} = riakc_pb_socket:list_keys(Pid, ?BUCKETS_BUCKET),
+    riakc_pb_socket:stop(Pid),
+    io:format("Retrieved bucket list. There are ~p buckets, including tombstones.~n",
+        [length(Buckets)]),
+    io:format("Searching for orphaned blocks. This may take a while..."),
+    log_orphaned_blocks(find_orphaned_blocks(Buckets, RiakHost, RiakPort)).
+
+log_orphaned_blocks(OrphanedBlocks) ->
+    Filename = "orphanedBlocks.log",
+    {ok, File} = file:open(Filename, [write]),
+    TotalCount = lists:foldl(fun({Bucket, UuidCountTuples}, TotalCount) ->
+                    BlockCount = lists:foldl(fun({Uuid, Count}, Total) ->
+                                                 ok = io:format(File, "~p.~n", [{Bucket, Uuid, Count}]),
+                                                 Total + Count
+                                             end, 0, UuidCountTuples),
+                    TotalCount + BlockCount
+                end, 0, OrphanedBlocks),
+    ok = file:close(File),
+    io:format("~nTotal # Missing Manifests: ~p~n", [length(OrphanedBlocks)]),
+    io:format("Total # Orphaned Blocks: ~p (~p MB) ~n", [TotalCount, TotalCount]),
+    io:format("Orphaned Blocks written to ~p~n", [Filename]).
+
+find_orphaned_blocks(Buckets, RiakHost, RiakPort) ->
+    RegOrphanedBlocks = lists:foldl(
+        fun(Bucket, Blocks) ->
+            io:format("~nFinding Orphaned blocks for Bucket ~p~n", [Bucket]),
+            {ok, Pid} = riakc_pb_socket:start_link(RiakHost, RiakPort),
+            {ok, _BlocksTable} = cache_block_keys(Pid, Bucket),
+            case log_object_keys(Pid, Bucket) of
+                {ok, ObjectKeysFilename} ->
+                    ok = delete_cached_manifest_uuids(Pid, Bucket, ObjectKeysFilename),
+                    riakc_pb_socket:stop(Pid),
+                    MissingManifests = find_missing_uuids(Bucket),
+                    {Bucket, Missing} = MissingManifests,
+                    io:format("Found ~p missing manifests for bucket ~p~n", [length(Missing), Bucket]),
+                    NewBlocks = [MissingManifests | Blocks],
+                    ok = file:delete(ObjectKeysFilename),
+                    NewBlocks;
+                {error, Error, ObjectKeysFilename} ->
+                    io:format("Skipping bucket ~p due to error: ~p~n", [Bucket, Error]),
+                    Table = list_to_atom(binary_to_list(Bucket)),
+                    ets:delete(Table),
+                    riakc_pb_socket:stop(Pid),
+                    ok = file:delete(ObjectKeysFilename),
+                    Blocks
+            end
+        end, [], Buckets),
+    remove_gc_blocks_from_orphans(RegOrphanedBlocks, RiakHost, RiakPort).
+
+remove_gc_blocks_from_orphans(OrphanedBlocks, RiakHost, RiakPort) ->
+    {ok, Pid} = riakc_pb_socket:start_link(RiakHost, RiakPort),
+    io:format("~nSearching GC bucket...~n"),
+    {ok, Timestamps} = riakc_pb_socket:list_keys(Pid, ?GC_BUCKET),
+    io:format("~p timestamps in gc bucket~n", [length(Timestamps)]),
+    GcUuids = lists:foldl(fun(Timestamp, Acc) ->
+                case riakc_pb_socket:get(Pid, ?GC_BUCKET, Timestamp) of
+                    {ok, ManifestsObj} ->
+                        io:format("*"),
+                        P0 = riak_cs_gc:decode_and_merge_siblings(ManifestsObj, twop_set:new()),
+                        lists:foldl(fun({Uuid, _}, Uuids) ->
+                                        sets:add_element(Uuid, Uuids)
+                                    end, Acc, twop_set:to_list(P0));
+                        _ ->
+                           Acc
+                end
+            end, sets:new(), Timestamps),
+    io:format("~p block uuids retrieved from gc bucket~n", [sets:size(GcUuids)]),
+    Result = subtract_gc_uuids(GcUuids, OrphanedBlocks),
+    riakc_pb_socket:stop(Pid),
+    Result.
+
+-spec subtract_gc_uuids(set(), list()) -> list().
+subtract_gc_uuids(GcUuids, OrphanedBlocks) ->
+    io:format("~n"),
+    lists:foldl(fun({Bucket, UuidCountTuples}, Acc) ->
+                    io:format("X"),
+                    Uuids = sets:from_list([Uuid || {Uuid, _} <- UuidCountTuples]),
+                    RemovedUuids = sets:intersection(Uuids, GcUuids),
+                    RemainingUuidCountTuples = lists:foldl(fun(RemovedUuid, Tuples) ->
+                                                               lists:keydelete(RemovedUuid, 1, Tuples)
+                                                           end, UuidCountTuples, sets:to_list(RemovedUuids)),
+                    [{Bucket, RemainingUuidCountTuples} | Acc]
+                end, [], OrphanedBlocks).
+
+cache_block_keys(Pid, Bucket) ->
+    BlocksBucket = riak_cs_utils:to_bucket_name(blocks, Bucket),
+    {ok, ReqId} = riakc_pb_socket:stream_list_keys(Pid, BlocksBucket, ?SLK_TIMEOUT),
+    BlocksTable = list_to_atom(binary_to_list(Bucket)),
+    {ok, NumKeys} = receive_and_cache_blocks(ReqId, BlocksTable),
+    io:format("Logged ~p block keys to ~p~n", [NumKeys, BlocksTable]),
+    {ok, BlocksTable}.
+
+log_object_keys(Pid, Bucket) ->
+    ManifestsBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    {ok, ReqId} = riakc_pb_socket:stream_list_keys(Pid, ManifestsBucket, ?SLK_TIMEOUT),
+    ObjectKeysFilename = "./"++binary_to_list(Bucket)++"_object_keys.log",
+    case receive_and_log(ReqId, ObjectKeysFilename, objects) of
+        {ok, NumKeys} ->
+            io:format("Logged ~p object keys to ~p~n", [NumKeys, ObjectKeysFilename]),
+            {ok, ObjectKeysFilename};
+        {error, Reason} ->
+            {error, Reason, ObjectKeysFilename}
+    end.
+
+delete_cached_manifest_uuids(Pid, Bucket, ObjectKeysFilename) ->
+    Table = list_to_atom(binary_to_list(Bucket)),
+    {ok, ObjectKeysFile} = file:open(ObjectKeysFilename, [read]),
+    ok = delete_cached_manifest_uuids(Pid, Bucket, Table, ObjectKeysFile),
+    ok = file:close(ObjectKeysFile).
+
+delete_cached_manifest_uuids(Pid, Bucket, Table, ObjectKeysFile) ->
+    ManifestsBucket = riak_cs_utils:to_bucket_name(objects, Bucket),
+    case io:fread(ObjectKeysFile, meh, "~s") of
+        {ok, [Key]} ->
+            Uuids = get_uuids(riakc_pb_socket:get(Pid, ManifestsBucket, Key)),
+            [ets:delete(Table, Uuid) || Uuid <- Uuids],
+            delete_cached_manifest_uuids(Pid, Bucket, Table, ObjectKeysFile);
+        eof ->
+            ok;
+        Error ->
+            io:format("Error in delete_cached_manifest_uuids/5: ~p for Bucket ~p", [Error, Bucket]),
+            ok
+    end.
+
+receive_and_cache_blocks(ReqId, TableName) ->
+    ets:new(TableName, [ordered_set, named_table, public]),
+    io:format("Saving keys to ~p~n", [TableName]),
+    receive_and_cache_blocks(ReqId, TableName, 0).
+
+receive_and_cache_blocks(ReqId, Table, Count) ->
+    receive
+        {ReqId, done} ->
+            {ok, Count};
+        {ReqId, {error, Reason}} ->
+            io:format("receive_and_cache_blocks/3 got error: ~p for table ~p, count: ~p. Returning current count.~n",
+                [Reason, Table, Count]),
+            {ok, Count};
+        {ReqId, {_, Keys}} ->
+            lists:map(fun(Key) ->
+                        {Uuid, _} = riak_cs_lfs_utils:block_name_to_term(Key),
+                        case ets:lookup(Table, Uuid) of
+                            [{Uuid, BlockCount}] ->
+                                ets:insert(Table, {Uuid, BlockCount+1});
+                            [] ->
+                                ets:insert(Table, {Uuid, 1})
+                        end
+                      end, Keys),
+            receive_and_cache_blocks(ReqId, Table, Count+length(Keys))
+    end.
+
+receive_and_log(ReqId, Filename, Type) ->
+    file:delete(Filename),
+    io:format("Opening ~p~n", [Filename]),
+    {ok, File} = file:open(Filename, [append]),
+    Res = receive_and_log(ReqId, File, Type, 0),
+    ok = file:close(File),
+    Res.
+
+receive_and_log(ReqId, File, Type, Count) ->
+    receive
+        {ReqId, done} ->
+            {ok, Count};
+        {ReqId, {error, Reason}} ->
+            io:format("receive_and_log/3 got error: ~p for file ~p, count: ~p.",
+                [Reason, File, Count]),
+            {error, Reason};
+        {ReqId, {_, Keys}} ->
+            case Type of
+                objects ->
+                    [io:format(File, "~s~n", [Key]) || Key <- Keys];
+                blocks ->
+                    lists:map(fun(Key) ->
+                        {UuidBin, _} = riak_cs_lfs_utils:block_name_to_term(Key),
+                        Uuid = mochihex:to_hex(UuidBin),
+                        io:format(File, "~s~n", [Uuid])
+                    end, Keys)
+            end,
+            file:datasync(File),
+            receive_and_log(ReqId, File, Type, Count+length(Keys))
+    end.
+
+find_missing_uuids(Bucket) ->
+    Table = list_to_atom(binary_to_list(Bucket)),
+    MissingBlocks = ets:tab2list(Table),
+    ets:delete(Table),
+    {Bucket, MissingBlocks}.
+
+get_uuids({ok, Obj}) ->
+    UuidList = lists:foldl(fun(V, Uuids) ->
+                    case V of
+                        <<>> ->
+                            Uuids;
+                        _ ->
+                            Uuids2 = [Uuid || {Uuid, _} <- binary_to_term(V)],
+                            Uuids ++ Uuids2
+                    end
+                end, [], riakc_obj:get_values(Obj)),
+    sets:to_list(sets:from_list(UuidList));
+get_uuids(_) ->
+    [].

--- a/priv/tools/internal/block_audit2.erl
+++ b/priv/tools/internal/block_audit2.erl
@@ -1,0 +1,240 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(block_audit2).
+
+-mode(compile).
+
+-export([main/1]).
+-export([info/2, verbose/3]).
+
+-define(SLK_TIMEOUT, 360000000). %% 100 hours
+-define(MD_USERMETA, <<"X-Riak-Meta">>).
+
+-include_lib("riak_cs/include/riak_cs.hrl").
+
+main(Args) ->
+    _ = application:load(lager),
+    ok = application:set_env(lager, handlers, [{lager_console_backend, info}]),
+    ok = lager:start(),
+    {ok, {Options, _PlainArgs}} = getopt:parse(option_spec(), Args),
+    LogLevel = case proplists:get_value(debug, Options) of
+                   0 ->
+                       info;
+                   _ ->
+                       ok = lager:set_loglevel(lager_console_backend, debug),
+                       debug
+               end,
+    debug("Log level is set to ~p", [LogLevel]),
+    debug("Options: ~p", [Options]),
+    case proplists:get_value(host, Options) of
+        undefined ->
+            getopt:usage(option_spec(), "riak-cs escript /path/to/block_audit2.erl"),
+            halt(1);
+        Host ->
+            Port = proplists:get_value(port, Options),
+            debug("Connecting to Riak ~s:~B...", [Host, Port]),
+            case riakc_pb_socket:start_link(Host, Port) of
+                {ok, Pid} ->
+                    pong = riakc_pb_socket:ping(Pid),
+                    audit2(Pid, Options),
+                    timer:sleep(100);
+                {error, Reason} ->
+                    err("Connection to Riak failed ~p", [Reason]),
+                    halt(2)
+            end
+    end.
+
+option_spec() ->
+    [
+     {host, $h, "host", string, "Host of Riak PB"},
+     {port, $p, "port", {integer, 8087}, "Port number of Riak PB"},
+     {bucket, $b, "bucket", string, "CS Bucket to audit, repetitions possible"},
+     {input, $i, "input", {string, "maybe-orphaned-blocks"}, "Directory for input data"},
+     {output, $o, "output", {string, "actual-orphaned-blocks"}, "Directory to output resutls"},
+     %% {page_size, $s, "page-size", {integer, 1000}, "Specify page size for 2i listing"},
+     %% {dry_run, undefined, "dry-run", {boolean, false}, "if set, actual update does not happen"},
+     {debug, $d, "debug", {integer, 0}, "Enable debug (-dd for more verbose)"}
+    ].
+
+err(Format, Args) ->
+    log(error, Format, Args).
+
+debug(Format, Args) ->
+    log(debug, Format, Args).
+
+verbose(Options, Format, Args) ->
+    {debug, DebugLevel} = lists:keyfind(debug, 1, Options),
+    case DebugLevel of
+        Level when 2 =< Level ->
+            debug(Format, Args);
+        _ ->
+            ok
+    end.
+
+info(Format, Args) ->
+    log(info, Format, Args).
+
+log(Level, Format, Args) ->
+    lager:log(Level, self(), Format, Args).
+
+audit2(Pid, Opts) ->
+    info("Filter actual orphaned blocks from maybe ones. This may take a while...", []),
+    InDir = proplists:get_value(input, Opts),
+    info("Input directory: ~p", [InDir]),
+    {ok, Filenames} = file:list_dir(InDir),
+    OutDir = proplists:get_value(output, Opts),
+    filelib:ensure_dir(filename:join(OutDir, "dummy")),
+    filter_all_actually_orphaned_blocks(Pid, Opts, InDir, OutDir, Filenames),
+    ok.
+
+filter_all_actually_orphaned_blocks(_Pid, _Opts, _InDir, _OutDir, []) ->
+    ok;
+filter_all_actually_orphaned_blocks(Pid, Opts, InDir, OutDir, [Filename | Filenames]) ->
+    _ = filter_actually_orphaned_blocks(Pid, Opts, InDir, OutDir, Filename),
+    filter_all_actually_orphaned_blocks(Pid, Opts, InDir, OutDir, Filenames).
+
+filter_actually_orphaned_blocks(Pid, Opts, InDir, OutDir, Filename) ->
+    InFile = filename:join(InDir, Filename),
+    info("Filter actually orphaned blocks from ~p", [InFile]),
+    {ok, Input} = file:open(InFile, [read, raw, binary]),
+    {ok, Output} = file:open(filename:join(OutDir, Filename),
+                             [write, raw, delayed_write]),
+    try
+        handle_lines(Pid, Opts, Filename, Input, Output, undefined, undefined)
+    after
+        catch file:close(Input),
+        catch file:close(Output)
+    end.
+
+handle_lines(Pid, Opts, Filename, Input, Output, PrevUUID, PrevState) ->
+    case file:read_line(Input) of
+        eof -> ok;
+        {error, Reason} ->
+            err("error in processing ~p : ~p", [Filename, Reason]);
+        {ok, LineData} ->
+            [Bucket, UUIDHex, Seq] = binary:split(LineData,
+                                                  [<<$\n>>, <<$ >>], [global, trim]),
+            UUID = mochihex:to_bin(binary_to_list(UUIDHex)),
+            {ok, NewPrevState}  = handle_line(Pid, Opts, Output, PrevUUID, PrevState,
+                                              Bucket, UUID,
+                                              list_to_integer(binary_to_list(Seq))),
+            handle_lines(Pid, Opts, Filename, Input, Output, UUID, NewPrevState)
+    end.
+
+handle_line(_Pid, Opts, Output, PrevUUID, {actual_orphan, CSKey}, Bucket, PrevUUID, Seq) ->
+    write_uuid(Opts, Output, Bucket, PrevUUID, Seq, CSKey),
+    {ok, {actual_orphan, CSKey}};
+handle_line(_Pid, _Opts, _Output, PrevUUID, false_orphan, _Bucket, PrevUUID, _Seq) ->
+    {ok, false_orphan};
+handle_line(Pid, Opts, Output, _PrevUUID, _PrevState, Bucket, UUID, Seq) ->
+    case manifest_state(Pid, Opts, Output, Bucket, UUID, Seq) of
+        {ok, block_notfound} ->
+            {ok, undefined};
+        {ok, {actual_orphan, CSKey}} ->
+            write_uuid(Opts, Output, Bucket, UUID, Seq, CSKey),
+            {ok, {actual_orphan, CSKey}};
+        {error, existing} ->
+            {ok, false_orphan};
+        {error, {please_ignore_this_uuid, Reason}} ->
+            info("Ignore UUID ~p: ~p", [Reason]),
+            {ok, false_orphan};
+        {error, _Reason} ->
+            %% Error occured, skip subsequent sequence numbers for the same UUID
+            {ok, false_orphan}
+    end.
+
+-spec manifest_state(pid(), list(), IO::term(), binary(), binary(), non_neg_integer()) ->
+                            {ok, {actual_orphan, CSKey::binary()}} |
+                            {ok, block_notfound} |
+                            {error, existing} |
+                            {error, term()}.
+manifest_state(Pid, Opts, _Output, CSBucket, UUID, Seq) ->
+    BlocksBucket = riak_cs_utils:to_bucket_name(blocks, CSBucket),
+    BlockKey = riak_cs_lfs_utils:block_name(dummy_key, UUID, Seq),
+    case riakc_pb_socket:get(Pid, BlocksBucket, BlockKey) of
+        {error, notfound} ->
+            verbose(Opts, "Block notfound for ~p", [{CSBucket, UUID, Seq}]),
+            {ok, block_notfound};
+        {error, Reason} ->
+            err("block get error for ~p: ~p",
+                [{CSBucket, UUID, Seq}, Reason]),
+            {error, Reason};
+        {ok, BObj} ->
+            MDs = [MD ||
+                      {MD, V} <- riakc_obj:get_contents(BObj),
+                      not riak_cs_utils:has_tombstone({MD, V})],
+            case MDs of
+                [] ->
+                    %% this block has been deleted, blocks with the same UUIDs
+                    %% should be removed
+                    {ok, block_notfound};
+                _ ->
+                    MD = hd(MDs),
+                    %% verbose(Opts, "block metadata (to_list'ed): ~p", [dict:to_list(MD)]),
+                    {ok, UserMeta} = dict:find(?MD_USERMETA, MD),
+                    CSBucket = proplists:get_value(<<?USERMETA_BUCKET>>, UserMeta),
+                    CSKey = proplists:get_value(<<?USERMETA_KEY>>, UserMeta),
+                    ManifestsBucket = riak_cs_utils:to_bucket_name(objects, CSBucket),
+                    %% TODO: What is appropriate options here? Possible corner cases:
+                    %% - Only single replica existing.
+                    %% - Two small and one big replicas.
+                    %%   R=quorum can not fetch big one, almost by latency difference.
+                    %%   But R=all may make latencies horrible.
+                    MGetOpts = [{notfound_ok, false}, {basic_quorum, false}],
+                    case riakc_pb_socket:get(Pid, ManifestsBucket, CSKey, MGetOpts) of
+                        {error, notfound} ->
+                            verbose(Opts, "Manifests notfound for ~p", [{CSBucket, CSKey}]),
+                            {ok, {actual_orphan, CSKey}};
+                        {error, Reason2} ->
+                            err("manifest_state error for ~p: ~p",
+                                [{CSBucket, CSKey}, Reason2]),
+                            {error, Reason2};
+                        {ok, MObj} ->
+                            UUIDs = get_block_uuids(MObj),
+                            case lists:member(UUID, UUIDs) of
+                                false ->
+                                    verbose(Opts, "Block UUID ~p not found in manifest for ~p",
+                                            [UUID, {CSBucket, CSKey}]),
+                                    {ok, {actual_orphan, CSKey}};
+                                true ->
+                                    verbose(Opts, "Block UUID ~p found in manifest for ~p",
+                                            [UUID, {CSBucket, CSKey}]),
+                                    {error, existing}
+                            end
+                    end
+            end
+    end.
+
+get_block_uuids(Obj) ->
+    Manifests = riak_cs_manifest:manifests_from_riak_object(Obj),
+    BlockUUIDs = [UUID ||
+                     {_ManiUUID, M} <- Manifests,
+                     %% TODO: more efficient way
+                     {UUID, _} <- riak_cs_lfs_utils:block_sequences_for_manifest(M)],
+    lists:usort(BlockUUIDs).
+
+write_uuid(_Opts, Output, Bucket, UUID, Seq, CSKey) ->
+    ok = file:write(Output,
+                    [Bucket, $ ,
+                     mochihex:to_hex(UUID), $ ,
+                     integer_to_list(Seq), $ ,
+                     CSKey, $\n]).
+

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -408,6 +408,9 @@ lager_config() ->
 riak_bitcaskroot(Prefix, N) ->
     io_lib:format("~s/dev/dev~b/data/bitcask", [Prefix, N]).
 
+riakcs_home(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/", [Prefix, N]).
+
 riakcs_binpath(Prefix, N) ->
     io_lib:format("~s/dev/dev~b/bin/riak-cs", [Prefix, N]).
 
@@ -716,6 +719,19 @@ repair_gc_bucket(N, Options, Vsn) ->
                                     "priv/tools/repair_gc_bucket.erl"] , "/"),
     [RepairScript] = filelib:wildcard(RepairScriptWild),
     Cmd = riakcscmd(Prefix, N, "escript " ++ RepairScript ++
+                        " " ++ Options),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+exec_priv_escript(N, Command, Options) ->
+    exec_priv_escript(N, Command, Options, current).
+
+exec_priv_escript(N, Command, Options, Vsn) ->
+    Prefix = get_rt_config(cs, Vsn),
+    ScriptWild = string:join([riakcs_libpath(Prefix, N), "riak_cs*",
+                              "priv/tools/"] , "/"),
+    [ToolsDir] = filelib:wildcard(ScriptWild),
+    Cmd = riakcscmd(Prefix, N, "escript " ++ ToolsDir ++ "/" ++ Command ++
                         " " ++ Options),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).

--- a/riak_test/tests/block_audit_test.erl
+++ b/riak_test/tests/block_audit_test.erl
@@ -1,0 +1,123 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(block_audit_test).
+
+%% @doc `riak_test' module for testing block audit scripts
+
+-export([confirm/0]).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BUCKET1,               "rt-bucket1").
+-define(BUCKET2,               "rt-bucket2").
+
+-define(KEY_ALIVE,             "alive").
+-define(KEY_ORPHANED,          "orphaned").
+-define(KEY_FALSE_ORPHANED,    "false-orphaned").
+-define(KEY_ALIVE_MP,          "alive-mp").
+-define(KEY_ORPHANED_MP,       "orphaned-mp").
+-define(KEY_FALSE_ORPHANED_MP, "false-orphaned-mp").
+
+confirm() ->
+    case rt_config:get(flavor, basic) of
+        {multibag, _} ->
+            lager:info("Block audit script does not supprt multibag env."),
+            lager:info("Skip the test."),
+            pass;
+        _ -> confirm1()
+    end.
+
+confirm1() ->
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET1, UserConfig)),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET2, UserConfig)),
+    FalseOrphans1 =
+        [setup_objects(RiakNodes, UserConfig, Bucket, normal,
+                       ?KEY_ALIVE, ?KEY_ORPHANED, ?KEY_FALSE_ORPHANED) ||
+            Bucket <- [?BUCKET1, ?BUCKET2]],
+    FalseOrphans2 =
+        [setup_objects(RiakNodes, UserConfig, Bucket, mp,
+                       ?KEY_ALIVE_MP, ?KEY_ORPHANED_MP, ?KEY_FALSE_ORPHANED_MP) ||
+            Bucket <- [?BUCKET1, ?BUCKET2]],
+    Home = rtcs:riakcs_home(rtcs:get_rt_config(cs, current), 1),
+    os:cmd("rm -rf " ++ filename:join([Home, "maybe-orphaned-blocks"])),
+    os:cmd("rm -rf " ++ filename:join([Home, "actual-orphaned-blocks"])),
+    Res1 = rtcs:exec_priv_escript(1, "internal/block_audit.erl",
+                                  "-h 127.0.0.1 -p 10017 -dd"),
+    lager:debug("block_audit.erl output:\n~s", [Res1]),
+    lager:debug("block_audit.erl output:============= END"),
+    fake_false_orphans(RiakNodes, FalseOrphans1 ++ FalseOrphans2),
+    Res2 = rtcs:exec_priv_escript(1, "internal/block_audit2.erl",
+                                  "-h 127.0.0.1 -p 10017 -dd"),
+    lager:debug("block_audit2.erl output:\n~s", [Res2]),
+    lager:debug("block_audit2.erl output:============= END"),
+    assert_result(?BUCKET1),
+    assert_result(?BUCKET2),
+    pass.
+
+setup_objects(RiakNodes, UserConfig, Bucket, Type,
+              KeyAlive, KeyOrphaned, KeyFalseOrphaned) ->
+    case Type of
+        normal ->
+            SingleBlock = crypto:rand_bytes(400),
+            [erlcloud_s3:put_object(Bucket, Key, SingleBlock, UserConfig) ||
+             Key <- [KeyAlive, KeyOrphaned, KeyFalseOrphaned]];
+        mp ->
+            ok = rc_helper:delete_riakc_obj(RiakNodes, objects, Bucket, KeyOrphaned),
+            [rtcs_multipart:multipart_upload(Bucket, Key,
+                                             [mb(10), mb(5)], UserConfig) ||
+               Key <- [KeyAlive, KeyOrphaned, KeyFalseOrphaned]]
+    end,
+    ok = rc_helper:delete_riakc_obj(RiakNodes, objects, Bucket, KeyOrphaned),
+    lager:info("To fake deficit replicas for ~p, delete objects and restore it "
+               "between block_audit.er and block_audit2.erl runs",
+               [{Bucket, KeyFalseOrphaned}]),
+    {ok, FalseOrphanedRObj} = rc_helper:get_riakc_obj(RiakNodes, objects,
+                                                      Bucket, KeyFalseOrphaned),
+    ok = rc_helper:delete_riakc_obj(RiakNodes, objects, Bucket, KeyFalseOrphaned),
+    {Bucket, KeyFalseOrphaned, FalseOrphanedRObj}.
+
+fake_false_orphans(RiakNodes, FalseOrphans) ->
+    [begin
+         R = rc_helper:update_riakc_obj(RiakNodes, objects, B, K, O),
+         lager:debug("fake_false_orphans ~p: ~p", [{B, K}, R])
+     end ||
+        {B, K, O} <- FalseOrphans].
+
+assert_result(Bucket) ->
+    Home = rtcs:riakcs_home(rtcs:get_rt_config(cs, current), 1),
+    OutFile1 = filename:join([Home, "actual-orphaned-blocks", Bucket]),
+    BucketBin = list_to_binary(Bucket),
+    {ok, Bin} = file:read_file(OutFile1),
+    KeySeqs = [begin
+                   [BucketBin, _UUID, Seq, K] =
+                       binary:split(Line, [<<$ >>], [global, trim]),
+                   {binary_to_list(K), list_to_integer(binary_to_list(Seq))}
+               end || Line <- binary:split(Bin, [<<$\n>>], [global, trim])],
+    ?assertEqual([?KEY_ORPHANED, ?KEY_ORPHANED_MP],
+                 lists:sort(proplists:get_keys(KeySeqs))),
+    ?assertEqual([0], proplists:get_all_values(?KEY_ORPHANED, KeySeqs)),
+    ?assertEqual([0,0,1,1,2,2,3,3,4,4,5,6,7,8,9],
+                 lists:sort(proplists:get_all_values(?KEY_ORPHANED_MP, KeySeqs))),
+    ok.
+
+mb(MegaBytes) ->
+    MegaBytes * 1024 * 1024.
+


### PR DESCRIPTION
## Steps for scanning orphan blocks
1. List keys in `moss.buckets`
2. Iterate over all CS buckets (optionally ones listed in command line)
   1. List keys (streaming listkeys) on a `<<0b:...>>` bucket
      - _We MUST list keys of blocks at first_ to avoid race from API calls
   2. Collect all blocks, as `{UUID, [list of existing block seqs]}`
   3. List manifest UUIDs on `<<0o:...>>` bucket (by streaming `csbucketfold`)
   4. Check existence of corresponding manifest by subtracting the two
      results of list keys
   5. Complete maybe orphaned UUID list
3. Filter out false-orphaned block UUIDs.
   This is because list keys (or csbucketfold) of manifest buckets will
   be done by R=1, then replica deficit (e.g. by force-replace) leads to
   false-positiveness for orphan block extraction at previous step.
   R=quorum (or R=all) manifest GETs is needed to avoid false-positive.
   1. Get block object and get CS key of manifests from user metadata
   2. Get manifest for the key and verify existence of corresponding manifest
   3. Remove block UUIDs if manifest exists from orphaned list

Usage (for debugging)

```
% riak-cs escript /path/to/priv/tools/internal/block_audit.erl  \
      -h 127.0.0.1 -p 10017 \
      -dd \
      -o $PWD/blocks.local
% riak-cs escript /path/to/priv/tools/internal/block_audit2.erl \
      -h 127.0.0.1 -p 10017 \
      -dd \
      -i $PWD/blocks.local -o $PWD/blocks2.local
```

This PR adds scripts for gathering block {UUID, Sequence}s to be deleted.
For actual deletion, we can re-using block cleaner script in #1124.
But there is still some interface (file format) discrepancy, subsequent
PR is needed.
