### PR TITLE
Fix corruption of successive space charactors in XML request

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -8,6 +8,10 @@
   [riak_cs/#1115](https://github.com/basho/riak_cs/pull/1115)
 - Add missing `riak-cs.conf` items: `max_buckets_per_user` and `gc.batch_size`
   [riak_cs/#1115](https://github.com/basho/riak_cs/pull/1115)
+- Fix bugs around subsequent space characters for Delete Multiple
+  Objects API and user administration API with XML content
+  [riak_cs/#1129](https://github.com/basho/riak_cs/pull/1129)
+  [riak_cs/#1135](https://github.com/basho/riak_cs/pull/1135)
 
 # Riak CS 2.0.0 Release Notes
 

--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -198,7 +198,7 @@ class BasicTests(S3ApiVerificationTestBase):
 
     def test_delete_objects(self):
         bucket = self.conn.create_bucket(self.bucket_name)
-        keys = ['0', '1', u'Unicodeあいうえお', '2']
+        keys = ['0', '1', u'Unicodeあいうえお', '2', 'multiple   spaces']
         keys.sort()
         for key in keys:
             k = Key(bucket)

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -120,7 +120,7 @@ update_user_json_test_case(AdminConfig, Node) ->
 
 update_user_xml_test_case(AdminConfig, Node) ->
     Users = [{"gru@despicable.me", "Gru"},
-             {"minion@despicable.me", "Minion"},
+             {"minion@despicable.me", "Minion  Minion"},
              {"dr.nefario@despicable.me", "DrNefario"}],
     update_user_test(AdminConfig, Node, ?XML, Users).
 

--- a/src/riak_cs_acl_utils.erl
+++ b/src/riak_cs_acl_utils.erl
@@ -501,7 +501,7 @@ process_acl_contents([#xmlElement{content=Content,
     end;
 process_acl_contents([#xmlComment{} | RestElements], Acl, RcPid) ->
     process_acl_contents(RestElements, Acl, RcPid);
-process_acl_contents([#xmlText{value=" "} | RestElements], Acl, RcPid) ->
+process_acl_contents([#xmlText{} | RestElements], Acl, RcPid) ->
     %% skip normalized space
     process_acl_contents(RestElements, Acl, RcPid).
 

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -66,7 +66,7 @@
 %% `String' is the Body sent from client, which can be anything.
 -spec scan(string()) -> {ok, xmlElement()} | {error, malformed_xml}.
 scan(String) ->
-    case catch xmerl_scan:string(String, [{space, normalize}]) of
+    case catch xmerl_scan:string(String) of
         {'EXIT', _E} ->  {error, malformed_xml};
         { #xmlElement{} = ParsedData, _Rest} -> {ok, ParsedData};
         _E -> {error, malformed_xml}


### PR DESCRIPTION
Originally reported by zd://10707 and bug description is at #1129 (RCS-191).

Affected API
- user administration by XML
- Multiple delete

Other APIs that accepts XML as requests does not allow spaces in text nodes, so no actual harmful effect.

This PR fixes the bug by:
- Removing space normalization option for xml parsing by xmerl and
- broadening pattern match that depends on the option
