### PR TITLE
Fix race between reading file info and bitcask merge delete

### DIFF
--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -534,9 +534,9 @@ check_data_files_are_small_enough(_Node, _Vsn, []) ->
     true;
 check_data_files_are_small_enough(Node, Vsn, [VnodeName|Rest]) ->
     DataFiles = bitcask_data_files(Node, Vsn, VnodeName, abs),
-    FileSizes = [begin
-                     {ok, #file_info{size=S}} = file:read_file_info(F),
-                     {F, S}
+    FileSizes = [case file:read_file_info(F) of
+                     {ok, #file_info{size=S}} -> {F, S};
+                     {error, enoent} -> {F, 0} % already deleted
                  end || F <- DataFiles],
     lager:debug("FileSizes (~p): ~p~n", [{Node, VnodeName}, FileSizes]),
     TotalSize = lists:sum([S || {_, S} <- FileSizes]),


### PR DESCRIPTION
Between listing a directory and reading each file info's, merge
delete can interleave. Then read file info results in enoent error.
This commit treats it as zero size file.

Typical error message of this race is:

```
{{badmatch,{error,enoent}},
 [{cs_suites,'-check_data_files_are_small_enough/3-lc$^0/1-0-',1,
             [{file,"riak_test/src/cs_suites.erl"},{line,538}]},
```

This PR includes only change of riak_test code.
