### PR TITLE
Make call asynchronous to avoid deadlock between gc_manager and gc_batch  [JIRA: RCS-205]

### DIFF
--- a/test/riak_cs_gc_manager_eqc.erl
+++ b/test/riak_cs_gc_manager_eqc.erl
@@ -179,6 +179,8 @@ expected_result(S, S, set_interval) ->
 
 expected_result(idle, running, start_batch) ->
     ok;
+expected_result(idle, idle, finished) ->
+    ok;
 expected_result(idle, idle, _) ->
     {error, idle};
 


### PR DESCRIPTION
Commit b5104c1fef13e0f0bc6fd530 has introduced a deadlock bug where
gc_manager is sending gc_batch with `current_state` message to
gc_batch synchronously and gc_batch is sending `finished` message to
gc_manager synchronously. If both messages were interleaved each
other, both process will wait for each other. To avoid further
deadlock, _ALL_ call from gc_batch to gc_manager must be asynchronous,
while any call from gc_manager to gc_batch can be synchronous or
asynchronous.
