### PR TITLE
Add log rotation items into cuttlefish schema [JIRA: RCS-216]

### DIFF
--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -400,10 +400,52 @@
   {datatype, file}
 ]}.
 
+%% @doc Maximum size of the console log in bytes, before it is rotated
+{mapping, "log.console.size", "lager.handlers", [
+  {default, "10MB"},
+  {datatype, bytesize}
+]}.
+
+%% @doc The schedule on which to rotate the console log.  For more
+%% information see:
+%% https://github.com/basho/lager/blob/master/README.md#internal-log-rotation
+{mapping, "log.console.rotation", "lager.handlers", [
+  {default, "$D0"}
+]}.
+
+%% @doc The number of rotated console logs to keep. When set to
+%% 'current', only the current open log file is kept.
+{mapping, "log.console.rotation.keep", "lager.handlers", [
+  {default, 5},
+  {datatype, [integer, {atom, current}]},
+  {validators, ["rotation_count"]}
+]}.
+
 %% @doc The file where error messages will be logged.
 {mapping, "log.error.file", "lager.handlers", [
   {default, "$(platform_log_dir)/error.log"},
   {datatype, file}
+]}.
+
+%% @doc Maximum size of the error log in bytes, before it is rotated
+{mapping, "log.error.size", "lager.handlers", [
+  {default, "10MB"},
+  {datatype, bytesize}
+]}.
+
+%% @doc The schedule on which to rotate the error log.  For more
+%% information see:
+%% https://github.com/basho/lager/blob/master/README.md#internal-log-rotation
+{mapping, "log.error.rotation", "lager.handlers", [
+  {default, "$D0"}
+]}.
+
+%% @doc The number of rotated error logs to keep. When set to
+%% 'current', only the current open log file is kept.
+{mapping, "log.error.rotation.keep", "lager.handlers", [
+  {default, 5},
+  {datatype, [integer, {atom, current}]},
+  {validators, ["rotation_count"]}
 ]}.
 
 %% @doc When set to 'on', enables log output to syslog.
@@ -446,24 +488,36 @@
         [{lager_syslog_backend, [Ident, Facility, LogLevel]}];
       _ -> []
     end,
+
+    TranslateKeep = fun(current) -> 0;
+                       (Int) -> Int
+                    end,
     ErrorHandler = case cuttlefish:conf_get("log.error.file", Conf) of
       undefined -> [];
-      ErrorFilename -> [{lager_file_backend, [{file, ErrorFilename},
-                                              {level, error},
-                                              {size, 10485760},
-                                              {date, "$D0"},
-                                              {count, 5}]}]
+      ErrorLogFilename ->
+         ErrorLogRotation = cuttlefish:conf_get("log.error.rotation", Conf),
+         ErrorLogRotationKeep = TranslateKeep(cuttlefish:conf_get("log.error.rotation.keep", Conf)),
+
+         ErrorLogSize = cuttlefish:conf_get("log.error.size", Conf),
+         [{lager_file_backend, [{file, ErrorLogFilename},
+                                {level, error},
+                                {size, ErrorLogSize},
+                                {date, ErrorLogRotation},
+                                {count, ErrorLogRotationKeep}]}]
     end,
 
     ConsoleLogLevel = cuttlefish:conf_get("log.console.level", Conf),
     ConsoleLogFile = cuttlefish:conf_get("log.console.file", Conf),
+    ConsoleLogSize = cuttlefish:conf_get("log.console.size", Conf),
+    ConsoleLogRotation = cuttlefish:conf_get("log.console.rotation", Conf),
+    ConsoleLogRotationKeep = TranslateKeep(cuttlefish:conf_get("log.console.rotation.keep", Conf)),
 
     ConsoleHandler = {lager_console_backend, ConsoleLogLevel},
     ConsoleFileHandler = {lager_file_backend, [{file, ConsoleLogFile},
                                                {level, ConsoleLogLevel},
-                                               {size, 10485760},
-                                               {date, "$D0"},
-                                               {count, 5}]},
+                                               {size, ConsoleLogSize},
+                                               {date, ConsoleLogRotation},
+                                               {count, ConsoleLogRotationKeep}]},
 
     ConsoleHandlers = case cuttlefish:conf_get("log.console", Conf) of
       off -> [];

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -44,6 +44,18 @@ default_config_test() ->
                                               [{webmachine_access_log_handler, ["./log"]},
                                                {riak_cs_access_log_handler, []}]),
     cuttlefish_unit:assert_config(Config, "webmachine.server_name", "Riak CS"),
+
+    {ok, [ConsoleLog, ErrorLog]} = cuttlefish_unit:path(cuttlefish_variable:tokenize("lager.handlers"), Config),
+    cuttlefish_unit:assert_config([ConsoleLog], "lager_file_backend", [{file, "./log/console.log"},
+                                                                     {level, info},
+                                                                     {size, 10485760},
+                                                                     {date, "$D0"},
+                                                                     {count, 5}]),
+    cuttlefish_unit:assert_config([ErrorLog], "lager_file_backend", [{file, "./log/error.log"},
+                                                                   {level, error},
+                                                                   {size, 10485760},
+                                                                   {date, "$D0"},
+                                                                   {count, 5}]),
 %%    cuttlefish_unit:assert_config(Config, "vm_args.+scl", false),
     ok.
 
@@ -92,6 +104,42 @@ lager_syslog_test() ->
            ],
     Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
     cuttlefish_unit:assert_config(Config, "lager.handlers.lager_syslog_backend", ["ident-test", local7, debug]),
+    ok.
+
+lager_hander_test() ->
+    Conf = [
+            {["log", "console", "file"], "./log/consolefile.log"},
+            {["log", "console", "level"], "debug"},
+            {["log", "console", "size"], "1MB"},
+            {["log", "console", "rotation"], "$D5"},
+            {["log", "console", "rotation", "keep"], "10"},
+            {["log", "error", "file"], "./log/errorfile.log"},
+            {["log", "error", "size"], "1KB"},
+            {["log", "error", "rotation"], "$D10"},
+            {["log", "error", "rotation", "keep"], "20"}
+           ],
+    Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
+    {ok, [ConsoleLog, ErrorLog]} = cuttlefish_unit:path(cuttlefish_variable:tokenize("lager.handlers"), Config),
+    cuttlefish_unit:assert_config([ConsoleLog], "lager_file_backend", [{file, "./log/consolefile.log"},
+                                                                       {level, debug},
+                                                                       {size, 1048576},
+                                                                       {date, "$D5"},
+                                                                       {count, 10}]),
+    cuttlefish_unit:assert_config([ErrorLog], "lager_file_backend", [{file, "./log/errorfile.log"},
+                                                                     {level, error},
+                                                                     {size, 1024},
+                                                                     {date, "$D10"},
+                                                                     {count, 20}]),
+
+    CurrentConf1 = [{["log", "console", "rotation", "keep"], "current"}],
+    Config1 = cuttlefish_unit:generate_templated_config(schema_files(), CurrentConf1, context()),
+    {ok, [ConsoleLog1, _ErrorLog1]} = cuttlefish_unit:path(cuttlefish_variable:tokenize("lager.handlers"), Config1),
+    cuttlefish_unit:assert_config([ConsoleLog1], "lager_file_backend.count", 0),
+
+    CurrentConf2 = [{["log", "error", "rotation", "keep"], "current"}],
+    Config2 = cuttlefish_unit:generate_templated_config(schema_files(), CurrentConf2, context()),
+    {ok, [_ConsoleLog2, ErrorLog2]} = cuttlefish_unit:path(cuttlefish_variable:tokenize("lager.handlers"), Config2),
+    cuttlefish_unit:assert_config([ErrorLog2], "lager_file_backend.count", 0),
     ok.
 
 max_buckets_per_user_test() ->


### PR DESCRIPTION
This supports log rotation items in cuttlefish schema. I use similar item names and description of crash log. Same changes should be merged into Stanchion and Riak.
#### New items:
- log.console.size
- log.console.rotation
- log.console.rotation.keep
- log.error.rotation
- log.error.rotation.keep
- log.error.size
#### log related items.

```
% rel/riak-cs/bin/riak-cs config effective | egrep "^log\.(console|error|crash)"
log.console = file
log.console.file = $(platform_log_dir)/console.log
log.console.level = info
log.console.rotation = $D0
log.console.rotation.keep = 5
log.console.size = 10MB
log.crash = on
log.crash.file = $(platform_log_dir)/crash.log
log.crash.maximum_message_size = 64KB
log.crash.rotation = $D0
log.crash.rotation.keep = 5
log.crash.size = 10MB
log.error.file = $(platform_log_dir)/error.log
log.error.messages_per_second = 100
log.error.redirect = on
log.error.rotation = $D0
log.error.rotation.keep = 5
log.error.size = 10MB
```
