### PR TITLE
Update riak_cs_multibag tag to 1.5.4p1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -54,5 +54,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "0.2.5"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.2"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "1.5.4p1"}}}
           ]}.


### PR DESCRIPTION
There are several unreleased changes in release/1.5 branches of riak_cs and riak_cs_multibag.
This PR updates deps for riak_cs_multibag to tag/1.5.4p1 to avoid one step of manual checkout under deps.
