### PR TITLE
Fix erlang client test compilation

### DIFF
--- a/client_tests/erlang/erlcloud_eqc.erl
+++ b/client_tests/erlang/erlcloud_eqc.erl
@@ -22,7 +22,7 @@
 
 -module(erlcloud_eqc).
 
--include("riak_cs_gc_d.hrl").
+-include("riak_cs.hrl").
 
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 


### PR DESCRIPTION
Looks like it have been broken since #1144 (RCS-199).
