### PR TITLE
Synchronous deletion of small objects

### DIFF
--- a/priv/tools/internal/riak_cs_inspector.erl
+++ b/priv/tools/internal/riak_cs_inspector.erl
@@ -872,8 +872,13 @@ get_manifest(RiakcPid, Bucket, Key)->
           {UUID, M} <- case MD of
                            tombstone ->
                                [{tombstone, {tombstone, {Bucket, Key}}}];
-                           _ ->
-                               binary_to_term(Value)
+                           _V ->
+                               case dict:find(<<"X-Riak-Deleted">>, MD) of
+                                   {ok, true} ->
+                                       [{tombstone, {tombstone, {Bucket, Key}}}];
+                                   _ ->
+                                       binary_to_term(Value)
+                               end
                        end]).
 
 get_gc_manifest(RiakcPid, Bucket, Key)->

--- a/rebar.config
+++ b/rebar.config
@@ -54,5 +54,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.1.0"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0-pre1"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0-pre2"}}}
           ]}.

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -200,6 +200,16 @@
   hidden
 ]}.
 
+%% @doc Small objects to be synchronously deleted including blocks on
+%% the fly. If this is used in combination with replication, cluster
+%% configuration must be carefully designed. Please consult our
+%% documentation for further information. To turn of synchronous
+%% deletion, set this as 0.
+{mapping, "active_delete_threshold", "riak_cs.active_delete_threshold", [
+  {default, "0"},
+  {datatype, bytesize}
+]}.
+
 %% == Access statistics ==
 
 %% @doc How often to flush the access stats; integer factor of

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -201,9 +201,9 @@
 ]}.
 
 %% @doc Small objects to be synchronously deleted including blocks on
-%% the fly. If this is used in combination with replication, cluster
-%% configuration must be carefully designed. Please consult our
-%% documentation for further information. To turn of synchronous
+%% the fly. If this is used in combination with MDC replication,
+%% cluster configuration must be carefully designed. Please consult
+%% our documentation for further information. To turn off synchronous
 %% deletion, set this as 0.
 {mapping, "active_delete_threshold", "riak_cs.active_delete_threshold", [
   {default, "0"},

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -200,11 +200,12 @@
   hidden
 ]}.
 
-%% @doc Small objects to be synchronously deleted including blocks on
-%% the fly. If this is used in combination with MDC replication,
-%% cluster configuration must be carefully designed. Please consult
-%% our documentation for further information. To turn off synchronous
-%% deletion, set this as 0.
+%% @doc Size threshold of deletion optimization for small objects.
+%% Blocks of objects smaller than this size will be synchronously
+%% deleted on the fly. If this is used in combination with MDC
+%% replication, cluster configuration must be carefully
+%% designed. Please consult our documentation for further
+%% information. To turn off synchronous deletion, set this as 0.
 {mapping, "active_delete_threshold", "riak_cs.active_delete_threshold", [
   {default, "0"},
   {datatype, bytesize}

--- a/riak_test/tests/active_delete_test.erl
+++ b/riak_test/tests/active_delete_test.erl
@@ -1,0 +1,38 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(active_delete_test).
+
+%% @doc `riak_test' module for testing active delete situation behavior.
+
+-export([confirm/0]).
+
+confirm() ->
+    %% 10MB threshold, for 3MB objects are used in cs_suites:run/2
+    CSConfig = rtcs:cs_config([{active_delete_threshold, 10000000}]),
+    Setup = rtcs:setup(1, [{cs, CSConfig}]),
+
+    %% Just do verify on typical normal case
+    History = [{cs_suites, run, ["run-1"]}],
+    {ok, InitialState} = cs_suites:new(Setup),
+    {ok, EvolvedState} = cs_suites:fold_with_state(InitialState, History),
+    {ok, _FinalState}  = cs_suites:cleanup(EvolvedState),
+
+    rtcs:pass().

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -62,7 +62,8 @@
          stanchion/0,
          use_2i_for_storage_calc/0,
          detailed_storage_calc/0,
-         quota_modules/0
+         quota_modules/0,
+         active_delete_threshold/0
         ]).
 
 %% Timeouts hitting Riak
@@ -415,6 +416,12 @@ detailed_storage_calc() ->
 -spec quota_modules() -> [module()].
 quota_modules() ->
     get_env(riak_cs, quota_modules, []).
+
+%% @doc smaller than block size recommended, to avoid multiple DELETE
+%% calls to riak per single manifest deletion.
+-spec active_delete_threshold() -> non_neg_integer().
+active_delete_threshold() ->
+    get_env(riak_cs, active_delete_threshold, 0).
 
 %% ===================================================================
 %% ALL Timeouts hitting Riak

--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -50,8 +50,9 @@
                 uuid :: binary(),
                 manifest :: lfs_manifest(),
                 riak_client :: riak_client(),
-                gc_worker_pid :: pid(),
-                %% Key in GC bucket which this manifest belongs to.
+                finished_callback :: fun(),
+                %% For GC, Key in GC bucket which this manifest belongs to.
+                %% For active deletion, not used.
                 %% Set only once at init and unchanged. Used only for logs.
                 gc_key :: binary(),
                 delete_blocks_remaining :: ordsets:ordset({binary(), integer()}),
@@ -59,7 +60,8 @@
                 all_delete_workers=[] :: list(pid()),
                 free_deleters = ordsets:new() :: ordsets:ordset(pid()),
                 deleted_blocks = 0 :: non_neg_integer(),
-                total_blocks = 0 :: non_neg_integer()}).
+                total_blocks = 0 :: non_neg_integer(),
+                cleanup_manifests = true :: boolean()}).
 
 -type state() :: #state{}.
 
@@ -80,18 +82,21 @@ block_deleted(Pid, Response) ->
 %% gen_fsm callbacks
 %% ====================================================================
 
-init([BagId, {UUID, Manifest}, GCWorkerPid, GCKey, _Options]) ->
+init([BagId, {UUID, Manifest}, FinishedCallback, GCKey, Options]) ->
     {Bucket, Key} = Manifest?MANIFEST.bkey,
     {ok, RcPid} = riak_cs_riak_client:checkout(),
     ok = riak_cs_riak_client:set_manifest_bag(RcPid, BagId),
     ok = riak_cs_riak_client:set_manifest(RcPid, Manifest),
+    CleanupManifests = proplists:get_value(cleanup_manifests,
+                                           Options, true),
     State = #state{bucket=Bucket,
                    key=Key,
                    manifest=Manifest,
                    uuid=UUID,
                    riak_client=RcPid,
-                   gc_worker_pid=GCWorkerPid,
-                   gc_key=GCKey},
+                   finished_callback=FinishedCallback,
+                   gc_key=GCKey,
+                   cleanup_manifests=CleanupManifests},
     {ok, prepare, State, 0}.
 
 %% @TODO Make sure we avoid any race conditions here
@@ -121,15 +126,21 @@ handle_sync_event(_Event, _From, StateName, State) ->
 handle_info(_Info, StateName, State) ->
     {next_state, StateName, State}.
 
-terminate(Reason, _StateName, #state{all_delete_workers=AllDeleteWorkers,
-                                     manifest=?MANIFEST{state=ManifestState},
-                                     bucket=Bucket,
-                                     key=Key,
-                                     uuid=UUID,
-                                     riak_client=RcPid} = State) ->
-    manifest_cleanup(ManifestState, Bucket, Key, UUID, RcPid),
+terminate(Reason, _StateName,
+          #state{all_delete_workers=AllDeleteWorkers,
+                 manifest=?MANIFEST{state=ManifestState},
+                 bucket=Bucket,
+                 key=Key,
+                 uuid=UUID,
+                 riak_client=RcPid,
+                 cleanup_manifests=CleanupManifests} = State) ->
+    if CleanupManifests ->
+            manifest_cleanup(ManifestState, Bucket, Key, UUID, RcPid);
+       true ->
+            noop
+    end,
     _ = [riak_cs_block_server:stop(P) || P <- AllDeleteWorkers],
-    notify_gc_worker(Reason, State),
+    notify_requester(Reason, State),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
@@ -240,18 +251,21 @@ maybe_delete_blocks(State=#state{bucket=Bucket,
                                     free_deleters=NewFreeDeleters,
                                     delete_blocks_remaining=NewDeleteBlocksRemaining}).
 
--spec notify_gc_worker(term(), state()) -> term().
-notify_gc_worker(Reason, State) ->
-    gen_fsm:sync_send_event(State#state.gc_worker_pid,
-                            notification_msg(Reason, State),
-                            infinity).
+-spec notify_requester(term(), state()) -> term().
+notify_requester(Reason, State = #state{finished_callback=FinishedCallback}) ->
+    FinishedCallback(notification_msg(Reason, State)).
 
 -spec notification_msg(term(), state()) -> {pid(),
                                             {ok, {non_neg_integer(), non_neg_integer()}} |
                                             {error, term()}}.
-notification_msg(normal, #state{deleted_blocks = DeletedBlocks,
-                                total_blocks = TotalBlocks}) ->
-    {self(), {ok, {DeletedBlocks, TotalBlocks}}};
+notification_msg(normal, #state{
+                            bucket=Bucket,
+                            key=Key,
+                            uuid=UUID,
+                            deleted_blocks = DeletedBlocks,
+                            total_blocks = TotalBlocks}) ->
+    Reply = {ok, {Bucket, Key, UUID, DeletedBlocks, TotalBlocks}},
+    {self(), Reply};
 notification_msg(Reason, _State) ->
     {self(), {error, Reason}}.
 

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -408,8 +408,8 @@ maybe_delete_small_objects(Manifests, RcPid, Threshold) ->
                             _ = lager:warning("Active deletion of ~p failed. Reason: ~p",
                                               [UUID, E]),
                             {[{UUID, Manifest}|Survivors], UUIDsToDelete};
-                        {maybe_delete_small_objects, Other} ->
-                            %% Handling unknown error
+                        Other ->
+                            %% Handling unknown error, or died unexpectedly
                             erlang:demonitor(Ref),
                             _ = lager:error("Active deletion failed. Reason: ~p", [Other]),
                             {[{UUID, Manifest}|Survivors], UUIDsToDelete}

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -403,17 +403,17 @@ maybe_delete_small_objects(Manifests, RcPid, Threshold) ->
                     receive
                         {maybe_delete_small_objects, {Pid, {ok, _}}} ->
                             %% successfully deleted
-                            erlang:demonitor(Ref),
+                            erlang:demonitor(Ref, [flush]),
                             _ = lager:debug("Active deletion of ~p succeeded", [UUID]),
                             {Survivors, [UUID|UUIDsToDelete]};
                         {maybe_delete_small_objects, {Pid, {error, _} = E}} ->
-                            erlang:demonitor(Ref),
+                            erlang:demonitor(Ref, [flush]),
                             _ = lager:warning("Active deletion of ~p failed. Reason: ~p",
                                               [UUID, E]),
                             {[{UUID, Manifest}|Survivors], UUIDsToDelete};
                         Other ->
                             %% Handling unknown error, or died unexpectedly
-                            erlang:demonitor(Ref),
+                            erlang:demonitor(Ref, [flush]),
                             _ = lager:error("Active deletion failed. Reason: ~p", [Other]),
                             {[{UUID, Manifest}|Survivors], UUIDsToDelete}
                     end;

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -391,7 +391,7 @@ maybe_delete_small_objects(Manifests, RcPid, Threshold) ->
                   when ContentLength < Threshold ->
                     %% actually this won't be scheduled :P
                     UUIDManifest = {UUID, Manifest?MANIFEST{state=scheduled_delete}},
-                    _ = lager:info("trying to delete ~p at ~p", [UUIDManifest, BagId]),
+                    _ = lager:debug("trying to delete ~p at ~p", [UUIDManifest, BagId]),
                     Args = [BagId, UUIDManifest, FinishedFun,
                             dummy_gc_key_in_sync_delete,
                             [{cleanup_manifests, false}]],

--- a/src/riak_cs_gc_worker.erl
+++ b/src/riak_cs_gc_worker.erl
@@ -140,7 +140,10 @@ initiating_file_delete(continue, ?STATE{batch=[CurrentFileSetKey | _],
     %% This is because one riak client process is assumed to be used for
     %% blocks in single bag. It's possible to use one riak client process
     %% for multiple block bags, but it introduce complexity of mutation.
-    Args = [BagId, Manifest, self(), CurrentFileSetKey, []],
+    Self = self(),
+    Args = [BagId, Manifest,
+            fun(Msg) -> gen_fsm:sync_send_event(Self, Msg, infinity) end,
+            CurrentFileSetKey, []],
     %% The delete FSM is hard-coded to send a sync event to our registered
     %% name upon terminate(), so we do not have to pass our pid to it
     %% in order to get a reply.
@@ -270,7 +273,7 @@ ok_reply(NextState, NextStateData) ->
 %% Refactor TODO:
 %%   1. delete_fsm_pid=undefined is desirable in both ok & error cases?
 %%   2. It's correct to *not* change pause_state?
-handle_delete_fsm_reply({ok, {TotalBlocks, TotalBlocks}},
+handle_delete_fsm_reply({ok, {_, _, _, TotalBlocks, TotalBlocks}},
                         ?STATE{current_files=[CurrentManifest | RestManifests],
                                current_fileset=FileSet,
                                block_count=BlockCount} = State) ->
@@ -280,7 +283,7 @@ handle_delete_fsm_reply({ok, {TotalBlocks, TotalBlocks}},
                 current_fileset=UpdFileSet,
                 current_files=RestManifests,
                 block_count=BlockCount+TotalBlocks};
-handle_delete_fsm_reply({ok, {NumDeleted, _TotalBlocks}},
+handle_delete_fsm_reply({ok, {_, _, _, NumDeleted, _TotalBlocks}},
                         ?STATE{current_files=[_CurrentManifest | RestManifests],
                                block_count=BlockCount} = State) ->
     ok = continue(),

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -37,7 +37,7 @@
          deleted_while_writing/1,
          mark_pending_delete/2,
          mark_deleted/2,
-         mark_scheduled_delete/2,
+         delete_or_mark_scheduled_delete/3,
          manifests_to_gc/2,
          prune/1,
          prune/3,
@@ -180,9 +180,9 @@ mark_pending_delete(Dict, UUIDsToMark) ->
 %% @doc Return `Dict' with the manifests in
 %% `UUIDsToMark' with their state changed to
 %% `scheduled_delete'
--spec mark_scheduled_delete(orddict:orddict(), list(binary())) ->
+-spec delete_or_mark_scheduled_delete(orddict:orddict(), list(cs_uuid()), list(cs_uuid())) ->
     orddict:orddict().
-mark_scheduled_delete(Dict, UUIDsToMark) ->
+delete_or_mark_scheduled_delete(Dict, UUIDsToMark, UUIDsToDelete) ->
     MapFun = fun(K, V) ->
             case lists:member(K, UUIDsToMark) of
                 true ->
@@ -192,7 +192,10 @@ mark_scheduled_delete(Dict, UUIDsToMark) ->
                     V
             end
     end,
-    orddict:map(MapFun, Dict).
+    FilterFun = fun(K, _) ->
+                        not lists:member(K, UUIDsToDelete)
+                end,
+    orddict:map(MapFun, orddict:filter(FilterFun, Dict)).
 
 %% @doc Return a list of manifests that are either
 %% in `PendingDeleteUUIDs' or are in the `pending_delete'

--- a/src/riak_cs_manifest_utils.erl
+++ b/src/riak_cs_manifest_utils.erl
@@ -37,7 +37,7 @@
          deleted_while_writing/1,
          mark_pending_delete/2,
          mark_deleted/2,
-         delete_or_mark_scheduled_delete/3,
+         mark_scheduled_delete/2,
          manifests_to_gc/2,
          prune/1,
          prune/3,
@@ -180,9 +180,9 @@ mark_pending_delete(Dict, UUIDsToMark) ->
 %% @doc Return `Dict' with the manifests in
 %% `UUIDsToMark' with their state changed to
 %% `scheduled_delete'
--spec delete_or_mark_scheduled_delete(orddict:orddict(), list(cs_uuid()), list(cs_uuid())) ->
-    orddict:orddict().
-delete_or_mark_scheduled_delete(Dict, UUIDsToMark, UUIDsToDelete) ->
+-spec mark_scheduled_delete(orddict:orddict(), list(cs_uuid())) ->
+                                   orddict:orddict().
+mark_scheduled_delete(Dict, UUIDsToMark) ->
     MapFun = fun(K, V) ->
             case lists:member(K, UUIDsToMark) of
                 true ->
@@ -192,10 +192,7 @@ delete_or_mark_scheduled_delete(Dict, UUIDsToMark, UUIDsToDelete) ->
                     V
             end
     end,
-    FilterFun = fun(K, _) ->
-                        not lists:member(K, UUIDsToDelete)
-                end,
-    orddict:map(MapFun, orddict:filter(FilterFun, Dict)).
+    orddict:map(MapFun, Dict).
 
 %% @doc Return a list of manifests that are either
 %% in `PendingDeleteUUIDs' or are in the `pending_delete'

--- a/src/riak_cs_riak_client.erl
+++ b/src/riak_cs_riak_client.erl
@@ -33,6 +33,7 @@
          get_user/2,
          save_user/3,
          set_manifest_bag/2,
+         get_manifest_bag/1,
          set_manifest/2,
          master_pbc/1,
          manifest_pbc/1,
@@ -144,6 +145,10 @@ set_manifest(RcPid, Manifest) ->
 set_manifest_bag(RcPid, ManifestBagId) ->
     gen_server:call(RcPid, {set_manifest_bag, ManifestBagId}).
 
+-spec get_manifest_bag(riak_client()) -> {ok, binary()} | {error, term()}.
+get_manifest_bag(RcPid) ->
+    gen_server:call(RcPid, get_manifest_bag).
+
 %% TODO: Using this function is more or less a cheat.
 %% It's better to export new  function to manipulate manifests
 %% from this module.
@@ -214,6 +219,8 @@ handle_call({set_manifest, {_UUID, _Manifest}}, _From, State) ->
     {reply, ok, State};
 handle_call({set_manifest_bag, _ManifestBagId}, _From, State) ->
     {reply, ok, State};
+handle_call(get_manifest_bag, _From, State) ->
+    {reply, {ok, master}, State};
 handle_call(block_pbc, _From, State) ->
     case ensure_master_pbc(State) of
         {ok, #state{master_pbc=MasterPbc} = NewState} ->

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -29,6 +29,7 @@ default_config_test() ->
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_paginated_indexes", true),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_max_workers", 2),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_batch_size", 1000),
+    cuttlefish_unit:assert_config(Config, "riak_cs.active_delete_threshold", 0),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_log_flush_factor", 1),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_log_flush_size", 1000000),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_archive_period", 3600),
@@ -95,6 +96,12 @@ gc_interval_infinity_test() ->
     Conf = [{["gc", "interval"], infinity}],
     Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_interval", infinity),
+    ok.
+
+active_delete_threshold_test() ->
+    Conf = [{["active_delete_threshold"], "10mb"}],
+    Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
+    cuttlefish_unit:assert_config(Config, "riak_cs.active_delete_threshold", 10*1024*1024),
     ok.
 
 lager_syslog_test() ->

--- a/test/riak_cs_gc_single_run_eqc.erl
+++ b/test/riak_cs_gc_single_run_eqc.erl
@@ -304,17 +304,14 @@ meck_delete_fsm_sup() ->
                 fun dummy_start_delete_fsm/2).
 
 dummy_start_delete_fsm(_Node, [_RcPid, {_UUID, ?MANIFEST{bkey={_, K}}=_Manifest},
-                               From, _GCKey, _Args]) ->
+                               FinishFun, _GCKey, _Args]) ->
     TotalBlocks = ?BLOCK_NUM_IN_MANIFEST,
     NumDeleted = case re:run(K, <<"^error:in_block_delete/">>) of
                      nomatch -> TotalBlocks;
                      {match, _} -> 0
                  end,
     DummyDeleteFsmPid =
-        spawn(fun() -> gen_fsm:sync_send_event(
-                         From,
-                         {self(), {ok, {NumDeleted, TotalBlocks}}})
-              end),
+        spawn(fun() -> FinishFun({self(), {ok, {b, k, uuid, NumDeleted, TotalBlocks}}}) end),
     {ok, DummyDeleteFsmPid}.
 
 %% ====================================================================


### PR DESCRIPTION
- add an configuration item `active_delete_threshold` (default is 0)
- ~~small objects (UUIDs) above that threshold are synchronously deleted
  right after marked as `pending_delete`~~, while others are to be
  marked as `scheduled_delete`
- Blocks of objects smaller than that threshold are synchronously deleted while its manifests will marked as `scheduled_delete` and stored there
- The deletion involves invoking `riak_cs_delete_fsm` and removing the
  UUID and manifest from that object history
- This does not change manifest handling semantics where any failure
  between marking as `pending_delete` and `scheduled_delete`.
- If active deletion failed, it will be handled next time that object
  is updated as `pending_delete` manifests as before.
- This commit introduces risk of blocks leak, in case where deleted
  UUIDs could be erased at sink side without deleting all blocks. If
  any RTQ drop were detected, block leak checker should be run against
  sink cluster.

Addresses #1138.
