### PR TITLE
Add deprecated warning to old CLIs  [JIRA: RCS-219]

### DIFF
--- a/rel/files/riak-cs-access
+++ b/rel/files/riak-cs-access
@@ -1,3 +1,10 @@
 #!/bin/sh
 
+cat<<EOS
+### WARNING ################################################################
+# This command has been deprecated and will be removed in a future release.
+# Use "riak-cs-admin access <command>" instead of this.
+############################################################################
+EOS
+
 {{runner_script_dir}}/riak-cs-admin access "$@"

--- a/rel/files/riak-cs-gc
+++ b/rel/files/riak-cs-gc
@@ -1,3 +1,10 @@
 #!/bin/sh
 
+cat<<EOS
+### WARNING ################################################################
+# This command has been deprecated and will be removed in a future release.
+# Use "riak-cs-admin gc <command>" instead of this.
+############################################################################
+EOS
+
 {{runner_script_dir}}/riak-cs-admin gc "$@"

--- a/rel/files/riak-cs-stanchion
+++ b/rel/files/riak-cs-stanchion
@@ -1,3 +1,10 @@
 #!/bin/sh
 
+cat<<EOS
+### WARNING ################################################################
+# This command has been deprecated and will be removed in a future release.
+# Use "riak-cs-admin stanchion <command>" instead of this.
+############################################################################
+EOS
+
 {{runner_script_dir}}/riak-cs-admin stanchion "$@"

--- a/rel/files/riak-cs-storage
+++ b/rel/files/riak-cs-storage
@@ -1,3 +1,10 @@
 #!/bin/sh
 
+cat<<EOS
+### WARNING ################################################################
+# This command has been deprecated and will be removed in a future release.
+# Use "riak-cs-admin storage <command>" instead of this.
+############################################################################
+EOS
+
 {{runner_script_dir}}/riak-cs-admin storage "$@"


### PR DESCRIPTION
It would be better to show a user a deprecated warning message before removing these commands.
