### PR TITLE
Add latency stats items to S3 API and velvet calls  [JIRA: RCS-220]

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -97,10 +97,12 @@
                   %% The prefix is defined by `stats_prefix()' callback of sub-module.
                   %% If sub-module provides only `stats_prefix' (almost the case),
                   %% stats key is [Prefix, HttpMethod]. Otherwise, sum-module
-                  %% can set `stats_key' by any callback that returns this context
-                  %% to specific key.
+                  %% can set specific `stats_key' by any callback that returns
+                  %% this context.
                   stats_prefix = no_stats :: atom(),
-                  stats_key :: undefined | riak_cs_stats:key(),
+                  stats_key=prefix_and_method :: prefix_and_method |
+                                                 no_stats |
+                                                 riak_cs_stats:key(),
                   local_context :: term(),
                   api :: atom()
                  }).

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -91,8 +91,16 @@
                   auth_module :: atom(),
                   response_module :: atom(),
                   policy_module :: atom(),
-                  stats_prefix :: atom(),
-                  stats_key :: [atom()],
+                  %% Key for API rate and latency stats.
+                  %% If `stats_prefix' or `stats_key' is `no_stats', no stats
+                  %% will be gathered by riak_cs_wm_common.
+                  %% The prefix is defined by `stats_prefix()' callback of sub-module.
+                  %% If sub-module provides only `stats_prefix' (almost the case),
+                  %% stats key is [Prefix, HttpMethod]. Otherwise, sum-module
+                  %% can set `stats_key' by any callback that returns this context
+                  %% to specific key.
+                  stats_prefix = no_stats :: atom(),
+                  stats_key :: undefined | riak_cs_stats:key(),
                   local_context :: term(),
                   api :: atom()
                  }).

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -91,6 +91,8 @@
                   auth_module :: atom(),
                   response_module :: atom(),
                   policy_module :: atom(),
+                  stats_prefix :: atom(),
+                  stats_key :: [atom()],
                   local_context :: term(),
                   api :: atom()
                  }).

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -439,7 +439,7 @@ riakcscmd(Path, N, Cmd) ->
     lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
 
 riakcs_switchcmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s-stanchion ~s", [riakcs_binpath(Path, N), Cmd])).
+    lists:flatten(io_lib:format("~s-admin stanchion ~s", [riakcs_binpath(Path, N), Cmd])).
 
 riakcs_gccmd(Path, N, Cmd) ->
     lists:flatten(io_lib:format("~s-admin gc ~s", [riakcs_binpath(Path, N), Cmd])).

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -72,7 +72,7 @@ query_stats(UserConfig, Port) ->
 
 confirm_initial_stats(StatData) ->
     %% Check for values for all meters to be 0 when system is initially started
-    ?assertEqual(132, length(StatData)),
+    ?assertEqual(614, length(StatData)),
     [?assert(proplists:is_defined(StatType, StatData))
      || StatType <- [<<"block_gets">>,
                      <<"block_puts">>,

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -321,7 +321,7 @@ delete_bucket_policy(User, UserObj, Bucket, RcPid) ->
                          [velvet, delete_bucket_policy],
                          RcPid).
 
-% @doc fetch moss.bucket and return acl and policy
+%% @doc fetch moss.bucket and return acl and policy
 -spec get_bucket_acl_policy(binary(), atom(), riak_client()) ->
                                    {acl(), policy()} | {error, term()}.
 get_bucket_acl_policy(Bucket, PolicyMod, RcPid) ->
@@ -389,7 +389,7 @@ bucket_empty(Bucket, RcPid) ->
 -spec bucket_empty_handle_list_keys(riak_client(), binary(),
                                     {ok, list()} |
                                     {error, term()}) ->
-    boolean().
+                                           boolean().
 bucket_empty_handle_list_keys(RcPid, Bucket, {ok, Keys}) ->
     AnyPred = bucket_empty_any_pred(RcPid, Bucket),
     %% `lists:any/2' will break out early as soon
@@ -399,7 +399,7 @@ bucket_empty_handle_list_keys(_RcPid, _Bucket, _Error) ->
     false.
 
 -spec bucket_empty_any_pred(riak_client(), Bucket :: binary()) ->
-    fun((Key :: binary()) -> boolean()).
+                                   fun((Key :: binary()) -> boolean()).
 bucket_empty_any_pred(RcPid, Bucket) ->
     fun (Key) ->
             riak_cs_utils:key_exists(RcPid, Bucket, Key)
@@ -424,7 +424,7 @@ fetch_bucket_object(BucketName, RcPid) ->
 
 %% @doc Fetches the bucket object, even it is marked as free
 -spec fetch_bucket_object_raw(binary(), riak_client()) ->
-                                 {ok, riakc_obj:riakc_obj()} | {error, term()}.
+                                     {ok, riakc_obj:riakc_obj()} | {error, term()}.
 fetch_bucket_object_raw(BucketName, RcPid) ->
     case riak_cs_riak_client:get_bucket(RcPid, BucketName) of
         {ok, Obj} ->
@@ -438,7 +438,7 @@ fetch_bucket_object_raw(BucketName, RcPid) ->
 -spec maybe_log_sibling_warning(binary(), list(riakc_obj:value())) -> ok.
 maybe_log_sibling_warning(Bucket, Values) when length(Values) > 1 ->
     _ = lager:warning("The bucket ~s has ~b siblings that may need resolution.",
-                  [binary_to_list(Bucket), length(Values)]),
+                      [binary_to_list(Bucket), length(Values)]),
     ok;
 maybe_log_sibling_warning(_, _) ->
     ok.
@@ -446,8 +446,8 @@ maybe_log_sibling_warning(_, _) ->
 -spec maybe_log_bucket_owner_error(binary(), list(riakc_obj:value())) -> ok.
 maybe_log_bucket_owner_error(Bucket, Values) when length(Values) > 1 ->
     _ = lager:error("The bucket ~s has ~b owners."
-                      " This situation requires administrator intervention.",
-                      [binary_to_list(Bucket), length(Values)]),
+                    " This situation requires administrator intervention.",
+                    [binary_to_list(Bucket), length(Values)]),
     ok;
 maybe_log_bucket_owner_error(_, _) ->
     ok.
@@ -550,7 +550,7 @@ bucket_json(Bucket, BagId, ACL, KeyId)  ->
         mochijson2:encode({struct, [{<<"bucket">>, Bucket},
                                     {<<"requester">>, list_to_binary(KeyId)},
                                     stanchion_acl_utils:acl_to_json_term(ACL)] ++
-                          BagElement}))).
+                               BagElement}))).
 
 %% @doc Return a bucket record for the specified bucket name.
 -spec bucket_record(binary(), bucket_operation()) -> cs_bucket().
@@ -559,11 +559,11 @@ bucket_record(Name, Operation) ->
                  create -> created;
                  delete -> deleted;
                  _ -> undefined
-    end,
+             end,
     ?RCS_BUCKET{name=binary_to_list(Name),
-                 last_action=Action,
-                 creation_date=riak_cs_wm_utils:iso_8601_datetime(),
-                 modification_time=os:timestamp()}.
+                last_action=Action,
+                creation_date=riak_cs_wm_utils:iso_8601_datetime(),
+                modification_time=os:timestamp()}.
 
 %% @doc Check for and resolve any conflict between
 %% a bucket record from a user record sibling and
@@ -605,21 +605,21 @@ bucket_sorter(?RCS_BUCKET{name=Bucket1},
 cleanup_bucket(?RCS_BUCKET{last_action=created}) ->
     false;
 cleanup_bucket(?RCS_BUCKET{last_action=deleted,
-                            modification_time=ModTime}) ->
+                           modification_time=ModTime}) ->
     %% the prune-time is specified in seconds, so we must
     %% convert Erlang timestamps to seconds first
     NowSeconds = riak_cs_utils:second_resolution_timestamp(os:timestamp()),
     ModTimeSeconds = riak_cs_utils:second_resolution_timestamp(ModTime),
     (NowSeconds - ModTimeSeconds) >
-    riak_cs_config:user_buckets_prune_time().
+        riak_cs_config:user_buckets_prune_time().
 
 %% @doc Determine if an existing bucket from the resolution list
 %% should be kept or replaced when a conflict occurs.
 -spec keep_existing_bucket(cs_bucket(), cs_bucket()) -> boolean().
 keep_existing_bucket(?RCS_BUCKET{last_action=LastAction1,
-                                  modification_time=ModTime1},
+                                 modification_time=ModTime1},
                      ?RCS_BUCKET{last_action=LastAction2,
-                                  modification_time=ModTime2}) ->
+                                 modification_time=ModTime2}) ->
     if
         LastAction1 == LastAction2
         andalso
@@ -717,8 +717,8 @@ serialized_bucket_op(Bucket, BagId, ACL, User, UserObj, BucketOp, StatsKey, RcPi
 %% could come up, add branch here. See tests in
 %% tests/riak_cs_bucket_test.erl
 -spec handle_stanchion_response(200..503, string(), delete|create, binary()) ->
-                                    {error, remaining_multipart_upload} |
-                                    {error, atom()}.
+                                       {error, remaining_multipart_upload} |
+                                       {error, atom()}.
 handle_stanchion_response(409, ErrorDoc, Op, Bucket)
   when Op =:= delete orelse Op =:= create ->
 

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -294,7 +294,7 @@ set_bucket_acl(User, UserObj, Bucket, ACL, RcPid) ->
                          User,
                          UserObj,
                          update_acl,
-                         [bucket, put_acl],
+                         [bucket, put, acl],
                          RcPid).
 
 %% @doc Set the policy for a bucket. Existing policy is only overwritten.
@@ -306,7 +306,7 @@ set_bucket_policy(User, UserObj, Bucket, PolicyJson, RcPid) ->
                          User,
                          UserObj,
                          update_policy,
-                         [bucket, put_policy],
+                         [bucket, put, policy],
                          RcPid).
 
 %% @doc Set the policy for a bucket. Existing policy is only overwritten.
@@ -318,7 +318,7 @@ delete_bucket_policy(User, UserObj, Bucket, RcPid) ->
                          User,
                          UserObj,
                          delete_policy,
-                         [bucket, put_policy],
+                         [bucket, put, policy],
                          RcPid).
 
 % @doc fetch moss.bucket and return acl and policy
@@ -661,13 +661,13 @@ resolve_buckets([HeadUserRec | RestUserRecs], Buckets, _KeepDeleted) ->
                            rcs_user(),
                            riakc_obj:riakc_obj(),
                            bucket_operation(),
-                           riak_cs_stats:metric_name(),
+                           riak_cs_stats:metric_key(),
                            riak_client()) ->
                                   ok |
                                   {error, term()}.
-serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatName, RcPid) ->
+serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatKey, RcPid) ->
     serialized_bucket_op(Bucket, undefined, ACL, User, UserObj,
-                         BucketOp, StatName, RcPid).
+                         BucketOp, StatKey, RcPid).
 
 %% @doc Shared code used when doing a bucket creation or deletion.
 -spec serialized_bucket_op(binary(),
@@ -676,11 +676,11 @@ serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatName, RcPid) ->
                            rcs_user(),
                            riakc_obj:riakc_obj(),
                            bucket_operation(),
-                           riak_cs_stats:metric_name(),
+                           riak_cs_stats:metric_key(),
                            riak_client()) ->
                                   ok |
                                   {error, term()}.
-serialized_bucket_op(Bucket, BagId, ACL, User, UserObj, BucketOp, StatName, RcPid) ->
+serialized_bucket_op(Bucket, BagId, ACL, User, UserObj, BucketOp, StatKey, RcPid) ->
     StartTime = os:timestamp(),
     case riak_cs_config:admin_creds() of
         {ok, AdminCreds} ->
@@ -699,14 +699,16 @@ serialized_bucket_op(Bucket, BagId, ACL, User, UserObj, BucketOp, StatName, RcPi
                     BucketRecord = bucket_record(Bucket, BucketOp),
                     case update_user_buckets(User, BucketRecord) of
                         {ok, ignore} when BucketOp == update_acl ->
-                            ok = riak_cs_stats:update_with_start(StatName,
+                            %% TODO: FIX
+                            ok = riak_cs_stats:update_with_start(StatKey,
                                                                  StartTime),
                             OpResult;
                         {ok, ignore} ->
                             OpResult;
                         {ok, UpdUser} ->
                             X = riak_cs_user:save_user(UpdUser, UserObj, RcPid),
-                            ok = riak_cs_stats:update_with_start(StatName,
+                            %% TODO: FIX
+                            ok = riak_cs_stats:update_with_start(StatKey,
                                                                  StartTime),
                             X
                     end;

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -658,7 +658,7 @@ resolve_buckets([HeadUserRec | RestUserRecs], Buckets, _KeepDeleted) ->
                            rcs_user(),
                            riakc_obj:riakc_obj(),
                            bucket_operation(),
-                           riak_cs_stats:metric_key(),
+                           riak_cs_stats:key(),
                            riak_client()) ->
                                   ok |
                                   {error, term()}.
@@ -673,7 +673,7 @@ serialized_bucket_op(Bucket, ACL, User, UserObj, BucketOp, StatKey, RcPid) ->
                            rcs_user(),
                            riakc_obj:riakc_obj(),
                            bucket_operation(),
-                           riak_cs_stats:metric_key(),
+                           riak_cs_stats:key(),
                            riak_client()) ->
                                   ok |
                                   {error, term()}.

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -83,7 +83,7 @@ duration_metrics() ->
          [velvet, delete_bucket_policy],
 
          %% TODO: Remove backpresure sleep
-         [manifest, siblings, bp, sleep],
+         [manifest, siblings_bp_sleep],
 
          [block, get],
          [block, get, retry],

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -22,6 +22,7 @@
 
 %% API
 -export([update/2,
+         update_with_start/3,
          update_with_start/2,
          update_error_with_start/2,
          inflow/1,
@@ -71,11 +72,13 @@ duration_metrics() ->
          [multipart_upload, delete], % Abort
          [multipart_upload, get],    % List Parts
 
-         %% TODO velvet operation stats also use bucket prefix, fix them
-         [bucket, create],
-         [bucket, delete],
-         [bucket, delete, policy],
-         [bucket, put, acl],
+         [velvet, create_user],
+         [velvet, update_user],
+         [velvet, create_bucket],
+         [velvet, delete_bucket],
+         [velvet, set_bucket_acl],
+         [velvet, set_bucket_policy],
+         [velvet, delete_bucket_policy],
 
          %% TODO: Remove backpresure sleep
          [manifest, siblings, bp, sleep],
@@ -94,6 +97,16 @@ duration_metrics() ->
 inflow(Key) ->
     lager:debug("~p:inflow Key: ~p", [?MODULE, Key]),
     ok = exometer:update([riak_cs, in | Key], 1).
+
+-type op_result() :: ok | {ok, _} | {error, _}.
+-spec update_with_start(metric_key(), erlang:timestamp(), op_result()) ->
+                               ok | {error, any()}.
+update_with_start(BaseId, StartTime, ok) ->
+    update_with_start(BaseId, StartTime);
+update_with_start(BaseId, StartTime, {ok, _}) ->
+    update_with_start(BaseId, StartTime);
+update_with_start(BaseId, StartTime, {error, _}) ->
+    update_error_with_start(BaseId, StartTime).
 
 -spec update_with_start(metric_key(), erlang:timestamp()) ->
                                ok | {error, any()}.

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -168,7 +168,7 @@ report_duration(Key, SubKey, ExometerType) ->
         {AtomKey, {_DP, Value}} <- lists:zip(AtomKeys, Values)].
 
 datapoints(histogram) ->
-    [mean, median, 95, 99, 100];
+    [mean, median, 95, 99, max];
 datapoints(spiral) ->
     [one, count].
 
@@ -216,7 +216,8 @@ stats_test_() ->
                            ?assertEqual([1, 1], Report);
                        histogram ->
                            ?assertEqual(
-                              [16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 0],
+                              [16#deadbeef, 16#deadbeef, 16#deadbeef,
+                               16#deadbeef, 16#deadbeef],
                               Report)
                    end
                end || Key <- duration_metrics(),

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -21,201 +21,89 @@
 -module(riak_cs_stats).
 
 %% API
--export([safe_update/2,
-         update/2,
+-export([update/2,
          update_with_start/2,
+         update_error_with_start/2,
+         inflow/1,
          report_json/0,
          report_pretty_json/0,
          get_stats/0]).
 
+%% For debugging or investigation from shell
+-export([report_duration_item/3,
+         raw_report_pool/1]).
+
 -export([init/0]).
 
--type metric_name() :: list(atom()).
--export_type([metric_name/0]).
+-type metric_key() :: [atom()].
+-export_type([metric_key/0]).
 
--define(METRICS,
-        %% [{metric_name(), exometer:type(), [exometer:option()], Aliases}]
-        [{[block, get], spiral, [],
-          [{one, block_gets}, {count, block_gets_total}]},
-         {[block, get, retry], spiral, [],
-          [{one, block_gets_retry}, {count, block_gets_retry_total}]},
-         {[block, put], spiral, [],
-          [{one, block_puts}, {count, block_puts_total}]},
-         {[block, delete], spiral, [],
-          [{one, block_deletes}, {count, block_deletes_total}]},
+-spec duration_metrics() -> [metric_key()].
+duration_metrics() ->
+        [
+         [service, get],
 
-         {[block, get, time], histogram, [],
-          [{mean  , block_get_time_mean},
-           {median, block_get_time_median},
-           {95    , block_get_time_95},
-           {99    , block_get_time_99},
-           {100   , block_get_time_100}]},
-         {[block, get, retry, time], histogram, [],
-          [{mean  , block_get_retry_time_mean},
-           {median, block_get_retry_time_median},
-           {95    , block_get_retry_time_95},
-           {99    , block_get_retry_time_99},
-           {100   , block_get_retry_time_100}]},
-         {[block, put, time], histogram, [],
-          [{mean  , block_put_time_mean},
-           {median, block_put_time_median},
-           {95    , block_put_time_95},
-           {99    , block_put_time_99},
-           {100   , block_put_time_100}]},
-         {[block, delete, time], histogram, [],
-          [{mean  , block_delete_time_mean},
-           {median, block_delete_time_median},
-           {95    , block_delete_time_95},
-           {99    , block_delete_time_99},
-           {100   , block_delete_time_100}]},
+         [bucket, put],
+         [bucket, head],
+         [bucket, delete],
+         [bucket_acl, get],
+         [bucket_acl, put],
+         [bucket_policy, get],
+         [bucket_policy, put],
+         [bucket_policy, delete],
+         [bucket_location, get],
+         [bucket_versioning, get],
+         [list_uploads, get],
+         [multiple_delete, post],
+         [list_objects, get],
 
-         {[service, get, buckets], spiral, [],
-          [{one, service_get_buckets},
-           {count, service_get_buckets_total}]},
-         {[service, get, buckets, time], histogram, [],
-          [{mean  , service_get_buckets_time_mean},
-           {median, service_get_buckets_time_median},
-           {95    , service_get_buckets_time_95},
-           {99    , service_get_buckets_time_99},
-           {100   , service_get_buckets_time_100}]},
+         [object, get],
+         [object, put],
+         [object, put_copy],
+         [object, head],
+         [object, delete],
+         [object_acl, get],
+         [object_acl, put],
 
-         {[bucket, list_keys], spiral, [],
-          [{one, bucket_list_keys}, {count, bucket_list_keys_total}]},
-         {[bucket, create], spiral, [],
-          [{one, bucket_creates}, {count, bucket_creates_total}]},
-         {[bucket, delete], spiral, [],
-          [{one, bucket_deletes}, {count, bucket_deletes_total}]},
-         {[bucket, get_acl], spiral, [],
-          [{one, bucket_get_acl}, {count, bucket_get_acl_total}]},
-         {[bucket, put_acl], spiral, [],
-          [{one, bucket_put_acl}, {count, bucket_put_acl_total}]},
-         {[bucket, put_policy], spiral, [],
-          [{one, bucket_put_policy}, {count, bucket_put_policy_total}]},
+         [multipart, post],          % Initiate
+         [multipart_upload, put],    % Upload Part (Copy)
+         [multipart_upload, post],   % Complete
+         [multipart_upload, delete], % Abort
+         [multipart_upload, get],    % List Parts
 
-         {[bucket, list_keys, time], histogram, [],
-          [{mean  , bucket_list_keys_time_mean},
-           {median, bucket_list_keys_time_median},
-           {95    , bucket_list_keys_time_95},
-           {99    , bucket_list_keys_time_99},
-           {100   , bucket_list_keys_time_100}]},
-         {[bucket, create, time], histogram, [],
-          [{mean  , bucket_create_time_mean},
-           {median, bucket_create_time_median},
-           {95    , bucket_create_time_95},
-           {99    , bucket_create_time_99},
-           {100   , bucket_create_time_100}]},
-         {[bucket, delete, time], histogram, [],
-          [{mean  , bucket_delete_time_mean},
-           {median, bucket_delete_time_median},
-           {95    , bucket_delete_time_95},
-           {99    , bucket_delete_time_99},
-           {100   , bucket_delete_time_100}]},
-         {[bucket, get_acl, time], histogram, [],
-          [{mean  , bucket_get_acl_time_mean},
-           {median, bucket_get_acl_time_median},
-           {95    , bucket_get_acl_time_95},
-           {99    , bucket_get_acl_time_99},
-           {100   , bucket_get_acl_time_100}]},
-         {[bucket, put_acl, time], histogram, [],
-          [{mean  , bucket_put_acl_time_mean},
-           {median, bucket_put_acl_time_median},
-           {95    , bucket_put_acl_time_95},
-           {99    , bucket_put_acl_time_99},
-           {100   , bucket_put_acl_time_100}]},
-         {[bucket, put_policy, time], histogram, [],
-          [{mean  , bucket_put_policy_time_mean},
-           {median, bucket_put_policy_time_median},
-           {95    , bucket_put_policy_time_95},
-           {99    , bucket_put_policy_time_99},
-           {100   , bucket_put_policy_time_100}]},
+         %% TODO velvet operation stats also use bucket prefix, fix them
+         [bucket, create],
+         [bucket, delete],
+         [bucket, delete, policy],
+         [bucket, put, acl],
 
-         {[object, get], spiral, [],
-          [{one, object_gets}, {count, object_gets_total}]},
-         {[object, put], spiral, [],
-          [{one, object_puts}, {count, object_puts_total}]},
-         {[object, head], spiral, [],
-          [{one, object_heads}, {count, object_heads_total}]},
-         {[object, delete], spiral, [],
-          [{one, object_deletes}, {count, object_deletes_total}]},
-         {[object, get_acl], spiral, [],
-          [{one, object_get_acl}, {count, object_get_acl_total}]},
-         {[object, put_acl], spiral, [],
-          [{one, object_put_acl}, {count, object_put_acl_total}]},
+         %% TODO: Remove backpresure sleep
+         [manifest, siblings, bp, sleep],
 
-         {[object, get, time], histogram, [],
-          [{mean  , object_get_time_mean},
-           {median, object_get_time_median},
-           {95    , object_get_time_95},
-           {99    , object_get_time_99},
-           {100   , object_get_time_100}]},
-         {[object, put, time], histogram, [],
-          [{mean  , object_put_time_mean},
-           {median, object_put_time_median},
-           {95    , object_put_time_95},
-           {99    , object_put_time_99},
-           {100   , object_put_time_100}]},
-         {[object, head, time], histogram, [],
-          [{mean  , object_head_time_mean},
-           {median, object_head_time_median},
-           {95    , object_head_time_95},
-           {99    , object_head_time_99},
-           {100   , object_head_time_100}]},
-         {[object, delete, time], histogram, [],
-          [{mean  , object_delete_time_mean},
-           {median, object_delete_time_median},
-           {95    , object_delete_time_95},
-           {99    , object_delete_time_99},
-           {100   , object_delete_time_100}]},
-         {[object, get_acl, time], histogram, [],
-          [{mean  , object_get_acl_time_mean},
-           {median, object_get_acl_time_median},
-           {95    , object_get_acl_time_95},
-           {99    , object_get_acl_time_99},
-           {100   , object_get_acl_time_100}]},
-         {[object, put_acl, time], histogram, [],
-          [{mean  , object_put_acl_time_mean},
-           {median, object_put_acl_time_median},
-           {95    , object_put_acl_time_95},
-           {99    , object_put_acl_time_99},
-           {100   , object_put_acl_time_100}]},
-
-         {[manifest, siblings_bp_sleep], spiral, [],
-          [{one, manifest_siblings_bp_sleep},
-           {count, manifest_siblings_bp_sleep_total}]},
-         {[manifest, siblings_bp_sleep, time], histogram, [],
-          [{mean  , manifest_siblings_bp_sleep_time_mean},
-           {median, manifest_siblings_bp_sleep_time_median},
-           {95    , manifest_siblings_bp_sleep_time_95},
-           {99    , manifest_siblings_bp_sleep_time_99},
-           {100   , manifest_siblings_bp_sleep_time_100}]}
-        ]).
+         [block, get],
+         [block, get, retry],
+         [block, put],
+         [block, delete]
+        ].
 
 %% ====================================================================
 %% API
 %% ====================================================================
 
+-spec inflow(metric_key()) -> ok | {error, any()}.
+inflow(Key) ->
+    lager:debug("~p:inflow Key: ~p", [?MODULE, Key]),
+    ok = exometer:update([riak_cs, in | Key], 1).
 
-
--spec safe_update(metric_name(), integer()) -> ok | {error, any()}.
-safe_update(BaseId, ElapsedUs) ->
-    %% Just in case those metrics happen to be not registered; should
-    %% be a bug and also should not interrupt handling requests by
-    %% crashing.
-    try
-        update(BaseId, ElapsedUs)
-    catch T:E ->
-            lager:error("Failed on storing some metrics: ~p,~p", [T,E])
-    end.
-
--spec update(metric_name(), integer()) -> ok | {error, any()}.
-update(BaseId, ElapsedUs) ->
-    ok = exometer:update([riak_cs|BaseId], 1),
-    ok = exometer:update([riak_cs|BaseId]++[time], ElapsedUs).
-
--spec update_with_start(metric_name(), erlang:timestamp()) ->
-                                   ok | {error, any()}.
+-spec update_with_start(metric_key(), erlang:timestamp()) ->
+                               ok | {error, any()}.
 update_with_start(BaseId, StartTime) ->
     update(BaseId, timer:now_diff(os:timestamp(), StartTime)).
+
+-spec update_error_with_start(metric_key(), erlang:timestamp()) ->
+                                     ok | {error, any()}.
+update_error_with_start(BaseId, StartTime) ->
+    update([error | BaseId], timer:now_diff(os:timestamp(), StartTime)).
 
 -spec report_json() -> string().
 report_json() ->
@@ -227,27 +115,50 @@ report_pretty_json() ->
 
 -spec get_stats() -> proplists:proplist().
 get_stats() ->
-    Stats = [raw_report_item(I) || I <- ?METRICS]
+    Stats = [report_duration_item(K, Kind, ExometerType) ||
+                K <- duration_metrics(),
+                {Kind, ExometerType} <- [{[in], spiral},
+                                         {[out], spiral}, {[time], histogram},
+                                         {[out, error], spiral}, {[time, error], histogram}]]
         ++ [raw_report_pool(P) || P <- [request_pool, bucket_list_pool]],
     lists:flatten(Stats).
-
-init() ->
-    _ = [init_item(I) || I <- ?METRICS],
-    ok.
 
 %% ====================================================================
 %% Internal
 %% ====================================================================
 
-init_item({Name, Type, Opts, Aliases}) ->
-    ok = exometer:re_register([riak_cs|Name], Type,
-                              [{aliases, Aliases}|Opts]).
+init() ->
+    _ = [init_duration_item(I) || I <- duration_metrics()],
+    ok.
 
-raw_report_item({Name, _Type, _Options, Aliases}) ->
+init_duration_item(Key) ->
+    ok = exometer:re_register([riak_cs, in   | Key], spiral, []),
+    ok = exometer:re_register([riak_cs, out  | Key], spiral, []),
+    ok = exometer:re_register([riak_cs, time | Key], histogram, []),
+    ok = exometer:re_register([riak_cs, out,  error | Key], spiral, []),
+    ok = exometer:re_register([riak_cs, time, error | Key], histogram, []).
 
-    {ok, Values} = exometer:get_value([riak_cs|Name], [D||{D,_Alias}<-Aliases]),
-    [{Alias, Value} ||
-        {{D, Alias}, {D, Value}} <- lists:zip(Aliases, Values)].
+-spec update(metric_key(), integer()) -> ok | {error, any()}.
+update(Key, ElapsedUs) ->
+    lager:debug("~p:update Key: ~p", [?MODULE, Key]),
+    ok = exometer:update([riak_cs, out | Key], 1),
+    ok = exometer:update([riak_cs, time | Key], ElapsedUs).
+
+report_duration_item(Key, Kind, ExometerType) ->
+    AtomKeys = [metric_to_atom(Key ++ Kind, Suffix) || Suffix <- suffixes(ExometerType)],
+    {ok, Values} = exometer:get_value([riak_cs | Kind ++ Key], datapoints(ExometerType)),
+    [{AtomKey, Value} ||
+        {AtomKey, {_DP, Value}} <- lists:zip(AtomKeys, Values)].
+
+datapoints(histogram) ->
+    [mean, median, 95, 99, 100];
+datapoints(spiral) ->
+    [one, count].
+
+suffixes(histogram) ->
+    ["_mean", "_median", "_95", "_99", "_100"];
+suffixes(spiral) ->
+    ["_one", "_count"].
 
 raw_report_pool(Pool) ->
     {_PoolState, PoolWorkers, PoolOverflow, PoolSize} = poolboy:status(Pool),
@@ -256,28 +167,13 @@ raw_report_pool(Pool) ->
      {list_to_atom(lists:flatten([Name, $_, "overflow"])), PoolOverflow},
      {list_to_atom(lists:flatten([Name, $_, "size"])), PoolSize}].
 
-
+metric_to_atom(Key, Suffix) ->
+    StringKey = string:join([atom_to_list(Token) || Token <- Key], "_"),
+    list_to_atom(lists:flatten([StringKey, Suffix])).
 
 -ifdef(TEST).
 
 -include_lib("eunit/include/eunit.hrl").
-
-stats_metric_test() ->
-    [begin
-         ?debugVal(Key),
-         case lists:last(Key) of
-             time ->
-                 ?assertEqual(histogram, Type),
-                 [?assert(proplists:is_defined(M, Aliases))
-                  || M <- [mean, median, 95, 99, 100]];
-             _ ->
-                 ?assertNotEqual(false, lists:keyfind(Key, 1, ?METRICS)),
-                 ?assertEqual(spiral, Type),
-                 ?assert(proplists:is_defined(one, Aliases)),
-                 ?assert(proplists:is_defined(count, Aliases))
-         end,
-         ?assertEqual([], Options)
-     end || {Key, Type, Options, Aliases} <- ?METRICS].
 
 stats_test_() ->
     Apps = [setup, compiler, syntax_tools, goldrush, lager, exometer_core],
@@ -290,25 +186,15 @@ stats_test_() ->
              [ok = application:stop(App) || App <- Apps]
      end,
      [{inparallel, [fun() ->
-                            %% ?debugVal(Key),
-                            case lists:last(Key) of
-                                time -> ok;
-                                _ -> riak_cs_stats:update(Key, 16#deadbeef)
-                            end
-                    end || {Key, _, _, _} <- ?METRICS]},
-     fun() ->
-             [begin
-                  Items = raw_report_item(I),
-                  %% ?debugVal(Items),
-                  case length(Items) of
-                      2 ->
-                          ?assertEqual([1, 1],
-                                       [N || {_, N} <- Items]);
-                      5 ->
-                          ?assertEqual([16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 0],
-                                       [N || {_, N} <- Items])
-                  end
-              end || I <- ?METRICS]
-     end]}.
+                            riak_cs_stats:update(Key, 16#deadbeef)
+                    end || Key <- duration_metrics()]},
+      fun() ->
+              [begin
+                   ?assertEqual([1, 1],
+                                [N || {_, N} <- report_duration_item(I, spiral)]),
+                   ?assertEqual([16#deadbeef, 16#deadbeef, 16#deadbeef, 16#deadbeef, 0],
+                                [N || {_, N} <- report_duration_item(I, histogram)])
+               end || I <- duration_metrics()]
+      end]}.
 
 -endif.

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -463,11 +463,13 @@ riak_connection(Pool) ->
                             ok | {error, term()}.
 set_object_acl(Bucket, Key, Manifest, Acl, RcPid) ->
     {ok, ManiPid} = riak_cs_manifest_fsm:start_link(Bucket, Key, RcPid),
-    _ActiveMfst = riak_cs_manifest_fsm:get_active_manifest(ManiPid),
-    UpdManifest = Manifest?MANIFEST{acl=Acl},
-    Res = riak_cs_manifest_fsm:update_manifest_with_confirmation(ManiPid, UpdManifest),
-    riak_cs_manifest_fsm:stop(ManiPid),
-    Res.
+    try
+        _ActiveMfst = riak_cs_manifest_fsm:get_active_manifest(ManiPid),
+        UpdManifest = Manifest?MANIFEST{acl=Acl},
+        riak_cs_manifest_fsm:update_manifest_with_confirmation(ManiPid, UpdManifest)
+    after
+        riak_cs_manifest_fsm:stop(ManiPid)
+    end.
 
 -spec second_resolution_timestamp(erlang:timestamp()) -> non_neg_integer().
 %% @doc Return the number of seconds this timestamp represents. Truncated to

--- a/src/riak_cs_wm_bucket.erl
+++ b/src/riak_cs_wm_bucket.erl
@@ -147,8 +147,7 @@ accept_body(RD, Ctx=#context{user=User,
 %% @doc Callback for deleting a bucket.
 -spec delete_resource(#wm_reqdata{}, #context{}) ->
                              {boolean() | {'halt', term()}, #wm_reqdata{}, #context{}}.
-delete_resource(RD, Ctx=#context{start_time=StartTime,
-                                 user=User,
+delete_resource(RD, Ctx=#context{user=User,
                                  user_object=UserObj,
                                  response_module=ResponseMod,
                                  bucket=Bucket,
@@ -162,7 +161,6 @@ delete_resource(RD, Ctx=#context{start_time=StartTime,
         ok ->
             riak_cs_dtrace:dt_bucket_return(?MODULE, <<"bucket_delete">>,
                                                [200], [riak_cs_wm_utils:extract_name(User), Bucket]),
-            ok = riak_cs_stats:update_with_start([bucket, delete], StartTime),
             {true, RD, Ctx};
         {error, Reason} ->
             Code = ResponseMod:status_code(Reason),

--- a/src/riak_cs_wm_bucket_delete.erl
+++ b/src/riak_cs_wm_bucket_delete.erl
@@ -23,6 +23,7 @@
 -module(riak_cs_wm_bucket_delete).
 
 -export([init/1,
+         stats_prefix/0,
          allowed_methods/0,
          post_is_create/2,
          process_post/2
@@ -43,6 +44,9 @@
 -spec init(#context{}) -> {ok, #context{}}.
 init(Ctx) ->
     {ok, Ctx#context{rc_pool=?RIAKCPOOL}}.
+
+-spec stats_prefix() -> multiple_delete.
+stats_prefix() -> multiple_delete.
 
 -spec allowed_methods() -> [atom()].
 allowed_methods() ->

--- a/src/riak_cs_wm_bucket_location.erl
+++ b/src/riak_cs_wm_bucket_location.erl
@@ -21,7 +21,8 @@
 -module(riak_cs_wm_bucket_location).
 
 % TODO: add PUT
--export([content_types_provided/2,
+-export([stats_prefix/0,
+         content_types_provided/2,
          to_xml/2,
          allowed_methods/0
         ]).
@@ -30,6 +31,9 @@
 
 -include("riak_cs.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
+
+-spec stats_prefix() -> bucket_location.
+stats_prefix() -> bucket_location.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_bucket_policy.erl
+++ b/src/riak_cs_wm_bucket_policy.erl
@@ -20,7 +20,8 @@
 
 -module(riak_cs_wm_bucket_policy).
 
--export([content_types_provided/2,
+-export([stats_prefix/0,
+         content_types_provided/2,
          to_json/2,
          allowed_methods/0,
          content_types_accepted/2,
@@ -35,6 +36,9 @@
 -include_lib("webmachine/include/webmachine.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 
+
+-spec stats_prefix() -> bucket_policy.
+stats_prefix() -> bucket_policy.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -28,6 +28,7 @@
 -module(riak_cs_wm_bucket_uploads).
 
 -export([init/1,
+         stats_prefix/0,
          authorize/2,
          content_types_provided/2,
          to_xml/2,
@@ -45,6 +46,9 @@
 -spec init(#context{}) -> {ok, #context{}}.
 init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
+
+-spec stats_prefix() -> list_uploads.
+stats_prefix() -> list_uploads.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
 malformed_request(RD,Ctx=#context{local_context=LocalCtx0}) ->

--- a/src/riak_cs_wm_bucket_versioning.erl
+++ b/src/riak_cs_wm_bucket_versioning.erl
@@ -20,7 +20,8 @@
 
 -module(riak_cs_wm_bucket_versioning).
 
--export([content_types_provided/2,
+-export([stats_prefix/0,
+         content_types_provided/2,
          to_xml/2,
          allowed_methods/0]).
 
@@ -28,6 +29,9 @@
 
 -include("riak_cs.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
+
+-spec stats_prefix() -> bucket_versioning.
+stats_prefix() -> bucket_versioning.
 
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].

--- a/src/riak_cs_wm_buckets.erl
+++ b/src/riak_cs_wm_buckets.erl
@@ -20,7 +20,8 @@
 
 -module(riak_cs_wm_buckets).
 
--export([allowed_methods/0,
+-export([stats_prefix/0,
+         allowed_methods/0,
          api_request/2,
          anon_ok/0]).
 
@@ -28,18 +29,19 @@
 -include("riak_cs_api.hrl").
 -include_lib("webmachine/include/webmachine.hrl").
 
+-spec stats_prefix() -> service.
+stats_prefix() -> service.
+
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].
 allowed_methods() ->
     ['GET'].
 
 -spec api_request(#wm_reqdata{}, #context{}) -> ?LBRESP{}.
-api_request(_RD, #context{user=User,
-                          start_time=StartTime}) ->
+api_request(_RD, #context{user=User}) ->
     UserName = riak_cs_wm_utils:extract_name(User),
     riak_cs_dtrace:dt_service_entry(?MODULE, <<"service_get_buckets">>, [], [UserName]),
     Res = riak_cs_api:list_buckets(User),
-    ok = riak_cs_stats:update_with_start([service, get, buckets], StartTime),
     riak_cs_dtrace:dt_service_return(?MODULE, <<"service_get_buckets">>, [], [UserName]),
     Res.
 

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -522,7 +522,7 @@ update_stats(RD, #context{start_time=StartTime,
 
 update_stats(StartTime, Code, StatsPrefix, Method, StatsKey0) ->
     StatsKey = case StatsKey0 of
-                   undefined -> [StatsPrefix, Method];
+                   prefix_and_method -> [StatsPrefix, Method];
                    _  -> StatsKey0
                end,
     case Code of

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -45,6 +45,7 @@
          finish_request/2]).
 
 -export([default_allowed_methods/0,
+         default_stats_prefix/0,
          default_content_types_accepted/2,
          default_content_types_provided/2,
          default_generate_etag/2,
@@ -80,11 +81,13 @@ init(Config) ->
     PolicyModule = proplists:get_value(policy_module, Config),
     Exports = orddict:from_list(Mod:module_info(exports)),
     ExportsFun = exports_fun(Exports),
+    StatsPrefix = resource_call(Mod, stats_prefix, [], ExportsFun),
     Ctx = #context{auth_bypass=AuthBypass,
                    auth_module=AuthModule,
                    response_module=RespModule,
                    policy_module=PolicyModule,
                    exports_fun=ExportsFun,
+                   stats_prefix=StatsPrefix,
                    start_time=os:timestamp(),
                    submodule=Mod,
                    api=Api},
@@ -106,7 +109,11 @@ service_available(RD, Ctx=#context{submodule=Mod, rc_pool=Pool}) ->
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 malformed_request(RD, Ctx=#context{submodule=Mod,
-                                   exports_fun=ExportsFun}) ->
+                                   exports_fun=ExportsFun,
+                                   stats_prefix=StatsPrefix}) ->
+    %% Methoid is used in stats keys, updating inflow should be *after*
+    %% allowed_methods assertion.
+    _ = update_stats_inflow(RD, StatsPrefix),
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"malformed_request">>),
     {Malformed, _, _} = R = resource_call(Mod,
                                           malformed_request,
@@ -366,6 +373,7 @@ finish_request(RD, Ctx=#context{riak_client=RcPid,
                         [RD, Ctx],
                         ExportsFun),
     riak_cs_dtrace:dt_wm_return({?MODULE, Mod}, <<"finish_request">>, [0], []),
+    update_stats(RD, Ctx),
     Res;
 finish_request(RD, Ctx0=#context{riak_client=RcPid,
                                  rc_pool=Pool,
@@ -379,6 +387,7 @@ finish_request(RD, Ctx0=#context{riak_client=RcPid,
                         [RD, Ctx],
                         ExportsFun),
     riak_cs_dtrace:dt_wm_return({?MODULE, Mod}, <<"finish_request">>, [1], []),
+    update_stats(RD, Ctx),
     Res.
 
 %% ===================================================================
@@ -494,6 +503,34 @@ post_authentication({error, Reason}, RD, Ctx, _, _) ->
     _ = lager:debug("Authentication error: ~p", [Reason]),
     riak_cs_wm_utils:deny_invalid_key(RD, Ctx).
 
+update_stats_inflow(_RD, undefined = _StatsPrefix) ->
+    ok;
+update_stats_inflow(RD, StatsPrefix) ->
+    Method = riak_cs_wm_utils:lower_case_method(wrq:method(RD)),
+    Key = [StatsPrefix, Method],
+    riak_cs_stats:inflow(Key).
+
+update_stats(_RD, #context{stats_key=no_stats}) ->
+    ok;
+update_stats(_RD, #context{stats_prefix=no_stats}) ->
+    ok;
+update_stats(RD, #context{start_time=StartTime,
+                          stats_prefix=StatsPrefix, stats_key=StatsKey}) ->
+    update_stats(StartTime, wrq:response_code(RD),
+                 StatsPrefix, riak_cs_wm_utils:lower_case_method(wrq:method(RD)),
+                 StatsKey).
+
+update_stats(StartTime, Code, StatsPrefix, Method, StatsKey0) ->
+    StatsKey = case StatsKey0 of
+                   undefined -> [StatsPrefix, Method];
+                   _  -> StatsKey0
+               end,
+    case Code of
+        Success when is_integer(Success) andalso Success < 400 ->
+            riak_cs_stats:update_with_start(StatsKey, StartTime);
+        _Error ->
+            riak_cs_stats:update_error_with_start(StatsKey, StartTime)
+    end.
 
 %% ===================================================================
 %% Resource function defaults
@@ -501,6 +538,8 @@ post_authentication({error, Reason}, RD, Ctx, _, _) ->
 
 default(init) ->
     default_init;
+default(stats_prefix) ->
+    default_stats_prefix;
 default(allowed_methods) ->
     default_allowed_methods;
 default(content_types_accepted) ->
@@ -532,6 +571,9 @@ default(_) ->
 
 default_init(Ctx) ->
     {ok, Ctx}.
+
+default_stats_prefix() ->
+    no_stats.
 
 default_malformed_request(RD, Ctx) ->
     {false, RD, Ctx}.

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -197,6 +197,9 @@ produce_body(RD, Ctx=#context{rc_pool=RcPool,
                 {Ctx, fun() -> {<<>>, done} end};
             false ->
                 riak_cs_get_fsm:continue(GetFsmPid, {Start, End}),
+                %% Streaming by `known_length_stream' and `StreamBody' function
+                %% will be handled *after* WM's `finish_request' callback complets.
+                %% Use `no_stats` to avoid auto stats update by `riak_cs_wm_common'.
                 {Ctx#context{auto_rc_close=false, stats_key=no_stats},
                  {<<>>, fun() ->
                                 riak_cs_wm_utils:streaming_get(

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -21,6 +21,7 @@
 -module(riak_cs_wm_object_upload).
 
 -export([init/1,
+         stats_prefix/0,
          authorize/2,
          content_types_provided/2,
          allowed_methods/0,
@@ -37,6 +38,9 @@
 -spec init(#context{}) -> {ok, #context{}}.
 init(Ctx) ->
     {ok, Ctx#context{local_context=#key_context{}}}.
+
+-spec stats_prefix() -> multipart.
+stats_prefix() -> multipart.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
 malformed_request(RD,Ctx) ->

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -21,6 +21,7 @@
 -module(riak_cs_wm_object_upload_part).
 
 -export([init/1,
+         stats_prefix/0,
          authorize/2,
          content_types_provided/2,
          allowed_methods/0,
@@ -44,8 +45,11 @@ init(Ctx) ->
     %% {ok, Ctx#context{local_context=#key_context{}}}.
     {ok, Ctx#context{local_context=#key_context{}}}.
 
+-spec stats_prefix() -> multipart_upload.
+stats_prefix() -> multipart_upload.
+
 -spec malformed_request(#wm_reqdata{}, #context{}) ->
-    {false, #wm_reqdata{}, #context{}} | {{halt, pos_integer()}, #wm_reqdata{}, #context{}}.
+                               {false, #wm_reqdata{}, #context{}} | {{halt, pos_integer()}, #wm_reqdata{}, #context{}}.
 malformed_request(RD,Ctx) ->
     Method = wrq:method(RD),
     case Method == 'PUT' andalso not valid_part_number(RD) of

--- a/src/riak_cs_wm_objects.erl
+++ b/src/riak_cs_wm_objects.erl
@@ -23,6 +23,7 @@
 -module(riak_cs_wm_objects).
 
 -export([init/1,
+         stats_prefix/0,
          allowed_methods/0,
          api_request/2
         ]).
@@ -40,6 +41,9 @@
 init(Ctx) ->
     {ok, Ctx#context{rc_pool=?RIAKCPOOL}}.
 
+-spec stats_prefix() -> list_objects.
+stats_prefix() -> list_objects.
+
 -spec allowed_methods() -> [atom()].
 allowed_methods() ->
     %% GET is for object listing
@@ -54,8 +58,7 @@ authorize(RD, Ctx) ->
 -spec api_request(#wm_reqdata{}, #context{}) -> {ok, ?LORESP{}} | {error, term()}.
 api_request(RD, Ctx=#context{bucket=Bucket,
                              riak_client=RcPid,
-                             user=User,
-                             start_time=StartTime}) ->
+                             user=User}) ->
     UserName = riak_cs_wm_utils:extract_name(User),
     riak_cs_dtrace:dt_bucket_entry(?MODULE, <<"list_keys">>, [], [UserName, Bucket]),
     Res = riak_cs_api:list_objects(
@@ -65,7 +68,6 @@ api_request(RD, Ctx=#context{bucket=Bucket,
             get_max_keys(RD),
             get_options(RD),
             RcPid),
-    ok = riak_cs_stats:update_with_start([bucket, list_keys], StartTime),
     riak_cs_dtrace:dt_bucket_return(?MODULE, <<"list_keys">>, [200], [UserName, Bucket]),
     Res.
 

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -22,6 +22,7 @@
 
 -export([service_available/2,
          service_available/3,
+         lower_case_method/1,
          iso_8601_datetime/0,
          iso_8601_datetime/1,
          to_iso_8601/1,
@@ -347,6 +348,20 @@ streaming_get(RcPool, RcPid, FsmPid, StartTime, UserName, BFile_str) ->
         {chunk, Chunk} ->
             {Chunk, fun() -> streaming_get(RcPool, RcPid, FsmPid, StartTime, UserName, BFile_str) end}
     end.
+
+-spec lower_case_method(atom() | string()) -> atom().
+lower_case_method('GET') -> get;
+lower_case_method('HEAD') -> head;
+lower_case_method('POST') -> post;
+lower_case_method('PUT') -> put;
+lower_case_method('DELETE') -> delete;
+lower_case_method('TRACE') -> trace;
+lower_case_method('CONNECT') -> connect;
+lower_case_method('OPTIONS') -> options;
+lower_case_method(Method) when is_atom(Method) ->
+    lower_case_method(atom_to_list(Method));
+lower_case_method(Method) when is_list(Method) ->
+    list_to_atom(string:to_lower(Method)).
 
 %% @doc Get an ISO 8601 formatted timestamp representing
 %% current time.

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -349,7 +349,7 @@ streaming_get(RcPool, RcPid, FsmPid, StartTime, UserName, BFile_str) ->
             {Chunk, fun() -> streaming_get(RcPool, RcPid, FsmPid, StartTime, UserName, BFile_str) end}
     end.
 
--spec lower_case_method(atom() | string()) -> atom().
+-spec lower_case_method(atom()) -> atom().
 lower_case_method('GET') -> get;
 lower_case_method('HEAD') -> head;
 lower_case_method('POST') -> post;
@@ -357,11 +357,7 @@ lower_case_method('PUT') -> put;
 lower_case_method('DELETE') -> delete;
 lower_case_method('TRACE') -> trace;
 lower_case_method('CONNECT') -> connect;
-lower_case_method('OPTIONS') -> options;
-lower_case_method(Method) when is_atom(Method) ->
-    lower_case_method(atom_to_list(Method));
-lower_case_method(Method) when is_list(Method) ->
-    list_to_atom(string:to_lower(Method)).
+lower_case_method('OPTIONS') -> options.
 
 %% @doc Get an ISO 8601 formatted timestamp representing
 %% current time.


### PR DESCRIPTION
Part 2 of stats improvement following #1165 (RCS-204) and address #961 (RCS-37) (RCS-217) partially.

This PR adds:
- latency/counter stats for S3 API callback executions and
- latency/counter stats for velvet calls.
