### PR TITLE
Add default riak_cs_wm_common's multiple_choices callback  [JIRA: RCS-221]

### DIFF
--- a/src/riak_cs_wm_bucket_uploads.erl
+++ b/src/riak_cs_wm_bucket_uploads.erl
@@ -34,7 +34,6 @@
          allowed_methods/0,
          malformed_request/2,
          content_types_accepted/2,
-         multiple_choices/2,
          finish_request/2]).
 
 -include("riak_cs.hrl").
@@ -114,9 +113,6 @@ to_xml(RD, Ctx=#context{local_context=LocalCtx,
         {error, Reason} ->
             riak_cs_s3_response:api_error(Reason, RD, Ctx)
     end.
-
-multiple_choices(RD, Ctx) ->
-    {false, RD, Ctx}.
 
 finish_request(RD, Ctx) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"finish_request">>, [0], []),

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -57,7 +57,8 @@
          default_validate_content_checksum/2,
          default_delete_resource/2,
          default_anon_ok/0,
-         default_produce_body/2]).
+         default_produce_body/2,
+         default_multiple_choices/2]).
 
 -include("riak_cs.hrl").
 -include("oos_api.hrl").
@@ -527,6 +528,8 @@ default(anon_ok) ->
     default_anon_ok;
 default(produce_body) ->
     default_produce_body;
+default(multiple_choices) ->
+    default_multiple_choices;
 default(_) ->
     undefined.
 
@@ -590,4 +593,7 @@ default_produce_body(RD, Ctx=#context{submodule=Mod,
 %% and simply returns false to signify the request is not fobidden
 -spec default_authorize(term(), term()) -> {false, term(), term()}.
 default_authorize(RD, Ctx) ->
+    {false, RD, Ctx}.
+
+default_multiple_choices(RD, Ctx) ->
     {false, RD, Ctx}.

--- a/src/riak_cs_wm_object_upload.erl
+++ b/src/riak_cs_wm_object_upload.erl
@@ -28,7 +28,6 @@
          content_types_accepted/2,
          post_is_create/2,
          process_post/2,
-         multiple_choices/2,
          valid_entity_length/2]).
 
 -include("riak_cs.hrl").
@@ -114,9 +113,6 @@ process_post_helper(RD, Ctx=#context{riak_client=RcPid, local_context=LocalCtx, 
         {error, Reason} ->
             riak_cs_s3_response:api_error(Reason, RD, Ctx)
     end.
-
-multiple_choices(RD, Ctx) ->
-    {false, RD, Ctx}.
 
 -spec valid_entity_length(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 valid_entity_length(RD, Ctx=#context{local_context=LocalCtx}) ->

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -28,7 +28,6 @@
          content_types_accepted/2,
          post_is_create/2,
          process_post/2,
-         multiple_choices/2,
          valid_entity_length/2,
          delete_resource/2,
          accept_body/2,
@@ -136,9 +135,6 @@ process_post(RD, Ctx=#context{local_context=LocalCtx, riak_client=RcPid}) ->
                     riak_cs_s3_response:api_error(Reason, RD, Ctx)
             end
     end.
-
-multiple_choices(RD, Ctx) ->
-    {false, RD, Ctx}.
 
 -spec valid_entity_length(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 valid_entity_length(RD, Ctx=#context{local_context=LocalCtx}) ->


### PR DESCRIPTION
And remove the identical implementations in sub-modules.

Without this default function, `riak_cs_wm_common:undefined/2` is
called and eventually `code_server:call()` is hit unless sub-module
does not implement it. This is one of possible bottleneck in
processing HTTP request in Riak CS.
