### PR TITLE
Fix proxy_get defined in riak-cs.conf not working [JIRA: RCS-236]

### DIFF
--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -277,16 +277,20 @@ set_md5_chunk_size(_) ->
 
 %% doc Check app.config to see if repl proxy_get is enabled
 %% Defaults to false.
+-spec proxy_get_active() -> boolean().
 proxy_get_active() ->
     case application:get_env(riak_cs, proxy_get) of
         {ok, enabled} ->
             true;
         {ok, disabled} ->
             false;
+        {ok, true} ->
+            true;
         {ok, _} ->
-            _ = lager:warning("proxy_get value in app.config is invalid"),
+            _ = lager:warning("proxy_get value in riak.conf (advanced.config) is invalid"),
             false;
-        undefined -> false
+        undefined ->
+            false
     end.
 
 -spec trust_x_forwarded_for() -> true | false.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -284,7 +284,7 @@ proxy_get_active() ->
         disabled -> false;
         Flag when is_boolean(Flag) -> Flag;
         Other ->
-            _ = lager:warning("proxy_get value in riak.conf (advanced.config) is invalid: ~p",
+            _ = lager:warning("proxy_get value in advanced.config is invalid: ~p",
                               [Other]),
             false
     end.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -279,17 +279,13 @@ set_md5_chunk_size(_) ->
 %% Defaults to false.
 -spec proxy_get_active() -> boolean().
 proxy_get_active() ->
-    case application:get_env(riak_cs, proxy_get) of
-        {ok, enabled} ->
-            true;
-        {ok, disabled} ->
-            false;
-        {ok, true} ->
-            true;
-        {ok, _} ->
-            _ = lager:warning("proxy_get value in riak.conf (advanced.config) is invalid"),
-            false;
-        undefined ->
+    case application:get_env(riak_cs, proxy_get, false) of
+        enabled ->   true;
+        disabled -> false;
+        Flag when is_boolean(Flag) -> Flag;
+        Other ->
+            _ = lager:warning("proxy_get value in riak.conf (advanced.config) is invalid: ~p",
+                              [Other]),
             false
     end.
 


### PR DESCRIPTION
Without this code you'll have excessive log output like this by default:

```
2015-07-21 18:35:34.842 [warning] <0.814.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
2015-07-21 18:35:35.949 [warning] <0.819.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
2015-07-21 18:35:37.534 [warning] <0.824.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
2015-07-21 18:35:38.381 [warning] <0.829.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
2015-07-21 18:35:38.957 [warning] <0.834.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
2015-07-21 18:35:39.834 [warning] <0.839.0>@riak_cs_config:proxy_get_active:289 proxy_get value in app.config is invalid
```

This is because `riak_cs_config:proxy_get_active/0` handles `proxy_get_active` config item in riak-cs.config badly, only accepting `enabled/disabled` atom which could be set at `advanced.config`.
