### PR TITLE
Filter out meta dir in offline gc tool  [JIRA: RCS-238]

### DIFF
--- a/priv/tools/internal/offline_delete.erl
+++ b/priv/tools/internal/offline_delete.erl
@@ -72,7 +72,7 @@ open_all_bitcask(BitcaskDir) ->
                             {match, _} ->
                                 true;
                             _ ->
-                                io:format("skipping ~p in the bitcask dir.", [X]),
+                                io:format("skipping ~p in the bitcask dir.~n", [X]),
                                 false
                         end
                 end,

--- a/priv/tools/internal/offline_delete.erl
+++ b/priv/tools/internal/offline_delete.erl
@@ -42,6 +42,15 @@ options() ->
      {yes, undefined, "yes", {boolean, false}, "Automatic yes to prompt"}].
 
 main(Args) ->
+    case code:ensure_loaded(bitcask) of
+        {module, bitcask} ->
+            ok;
+        {error, _} ->
+            io:format(standard_error,
+                      "\033[31m\033[1m[Error] Riak modules are not loaded. Make sure the script run with 'riak escript', not 'riak-cs escript'.\033[0m~n",
+                      []),
+            halt(1)
+    end,
     case getopt:parse(options(), Args) of
         {ok, {Options, [BitcaskDir, BlocksListFile]}} ->
             offline_delete(BitcaskDir, BlocksListFile, Options);


### PR DESCRIPTION
Offline GC script fails if bitcask data dir has `manual_cleanup` directory; so this change ignores meta directory like it.

This PR also includes the code which ensure the script run with Riak.
