### PR TITLE
Fast user get option [JIRA: RCS-240]

### DIFF
--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -216,8 +216,9 @@
 %% to omit PR=all get at retrieving user object. When this is turned
 %% on, instead gets are performed with R=quorum and PR=one to avoid
 %% waiting for responses from slow node. The price for this option is
-%% a very slight possibility of stale user object (such as a list of
-%% owned buckets) being read.
+%% possibility to read stale user object (such as a list of owned
+%% buckets) being read, as well as the list of buckets in a user
+%% record never pruned.
 {mapping, "fast_user_get", "riak_cs.fast_user_get", [
   {default, off},
   {datatype, flag}

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -211,7 +211,13 @@
   {datatype, bytesize}
 ]}.
 
-%% @doc Whether to omit PR=all get at retrieving user info.
+%% @doc When some of the nodes are slow, getting user with PR=all may
+%% make all requests of the user slow. This option stands for whether
+%% to omit PR=all get at retrieving user object. When this is turned
+%% on, instead gets are performed with R=quorum and PR=one to avoid
+%% waiting for responses from slow node. The price for this option is
+%% a very slight possibility of stale user object (such as a list of
+%% owned buckets) being read.
 {mapping, "fast_user_get", "riak_cs.fast_user_get", [
   {default, off},
   {datatype, flag}

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -211,6 +211,12 @@
   {datatype, bytesize}
 ]}.
 
+%% @doc Whether to omit PR=all get at retrieving user info.
+{mapping, "fast_user_get", "riak_cs.fast_user_get", [
+  {default, off},
+  {datatype, flag}
+]}.
+
 %% == Access statistics ==
 
 %% @doc How often to flush the access stats; integer factor of

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -63,7 +63,8 @@
          use_2i_for_storage_calc/0,
          detailed_storage_calc/0,
          quota_modules/0,
-         active_delete_threshold/0
+         active_delete_threshold/0,
+         fast_user_get/0
         ]).
 
 %% Timeouts hitting Riak
@@ -423,6 +424,10 @@ quota_modules() ->
 -spec active_delete_threshold() -> non_neg_integer().
 active_delete_threshold() ->
     get_env(riak_cs, active_delete_threshold, 0).
+
+-spec fast_user_get() -> boolean().
+fast_user_get() ->
+    get_env(riak_cs, fast_user_get, false).
 
 %% ===================================================================
 %% ALL Timeouts hitting Riak

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -30,7 +30,6 @@
          is_admin/1,
          get_user/2,
          get_user_by_index/3,
-         from_riakc_obj/2,
          to_3tuple/1,
          save_user/3,
          update_key_secret/1,

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -153,7 +153,8 @@ get_user(KeyId, RcPid) ->
                     {ok, {User?RCS_USER{buckets=Buckets}, Obj}};
                 0 ->
                     {error, no_value};
-                _ ->
+                N ->
+                    _ = lager:warning("User object of '~s' has ~p siblings", [KeyId, N]),
                     Values = [binary_to_term(Value) ||
                                  Value <- riakc_obj:get_values(Obj),
                                  Value /= <<>>  % tombstone

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -30,6 +30,7 @@ default_config_test() ->
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_max_workers", 2),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_batch_size", 1000),
     cuttlefish_unit:assert_config(Config, "riak_cs.active_delete_threshold", 0),
+    cuttlefish_unit:assert_config(Config, "riak_cs.fast_user_get", false),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_log_flush_factor", 1),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_log_flush_size", 1000000),
     cuttlefish_unit:assert_config(Config, "riak_cs.access_archive_period", 3600),


### PR DESCRIPTION
If `fast_user_get` is turned on, all requests to get user record skip PR=3 get to Riak to avoid unnecessary unavailability. The case this merits is where one of Riak nodes is ~~down~~ slow or going to down, get_fsm should wait for all of them or request fails. For consistency PW=3 when updating user record would be enough. `fast_user_get` is off by default now, but will be on by default in some future.

All riak_test items have passed with this option (except `stats_test` which is currently failing continously), but I don't think additional riak_test for this because current riak_test does not simulate any failure (which we have to do some).
