### PR TITLE
Fix two lines of wrong rtcs:pass() usage in access_stats_test

### DIFF
--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -100,7 +100,7 @@ assert_access_stats(Format, UserConfig, {Begin, End}) ->
     ?assertEqual(  1, sum_samples(Format, "BucketRead",   "Count", Samples)),
     ?assertEqual(  1, sum_samples(Format, "KeyDelete",    "Count", Samples)),
     ?assertEqual(  1, sum_samples(Format, "BucketDelete", "Count", Samples)),
-    rtcs:pass().
+    pass.
 
 verify_stats_lost_logging(UserConfig, RiakNodes, CSNodes) ->
     KeyId = UserConfig#aws_config.access_key_id,
@@ -115,7 +115,7 @@ verify_stats_lost_logging(UserConfig, RiakNodes, CSNodes) ->
     ExpectLine = io_lib:format("lost access stat: User=~s, Slice=", [KeyId]),
     lager:debug("expected log line: ~s", [ExpectLine]),
     true = rt:expect_in_log(CSNode, ExpectLine),
-    rtcs:pass().
+    pass.
 
 
 node_samples_from_content(json, Node, Content) ->


### PR DESCRIPTION
The bug was introduced at commit a07eb28cbb3500d2295e395504851c42f29e5055.
This PR is a partial revert ot it.
