### PR TITLE
Add max_scheduled_delete_manifests config into cuttlefish schema [RCS-247]

### DIFF
--- a/include/riak_cs_gc.hrl
+++ b/include/riak_cs_gc.hrl
@@ -94,6 +94,7 @@
 -define(DEFAULT_GC_BATCH_SIZE, 1000).
 -define(DEFAULT_GC_WORKERS, 2).
 -define(EPOCH_START, <<"0">>).
+-define(DEFAULT_MAX_SCHEDULED_DELETE_MANIFESTS, 50).
 
 -record(gc_manager_state, {
           next :: undefined | non_neg_integer(),

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -155,6 +155,14 @@
   {datatype, flag}
 ]}.
 
+%% @doc Max number of manifests that can be in the
+%% `scheduled_delete' state for a given key. `unlimited' means there
+%% is no maximum, and pruning will not happen based on count.
+{mapping, "max_scheduled_delete_manifests", "riak_cs.max_scheduled_delete_manifests", [
+  {default, 50},
+  {datatype, [integer, {atom, unlimited}]}
+]}.
+
 %% == Garbage Collection ==
 
 %% @doc The time to retain the block for an object after it has been

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -311,7 +311,7 @@ set_leeway_seconds(_LeewaySeconds) ->
 max_scheduled_delete_manifests() ->
     case application:get_env(riak_cs, max_scheduled_delete_manifests) of
         undefined ->
-            unlimited;
+            ?DEFAULT_MAX_SCHEDULED_DELETE_MANIFESTS;
         {ok, MaxCount} ->
             MaxCount
     end.

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -24,6 +24,7 @@ default_config_test() ->
     cuttlefish_unit:assert_config(Config, "riak_cs.max_buckets_per_user", 100),
     cuttlefish_unit:assert_config(Config, "riak_cs.trust_x_forwarded_for", false),
     cuttlefish_unit:assert_config(Config, "riak_cs.leeway_seconds", 86400),
+    cuttlefish_unit:assert_config(Config, "riak_cs.max_scheduled_delete_manifests", 50),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_interval", 900),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_retry_interval", 21600),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_paginated_indexes", true),
@@ -96,6 +97,12 @@ gc_interval_infinity_test() ->
     Conf = [{["gc", "interval"], infinity}],
     Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
     cuttlefish_unit:assert_config(Config, "riak_cs.gc_interval", infinity),
+    ok.
+
+max_scheduled_delete_manifests_unlimited_test() -> 
+    Conf = [{["max_scheduled_delete_manifests"], unlimited}],
+    Config = cuttlefish_unit:generate_templated_config(schema_files(), Conf, context()),
+    cuttlefish_unit:assert_config(Config, "riak_cs.max_scheduled_delete_manifests", unlimited),
     ok.
 
 active_delete_threshold_test() ->


### PR DESCRIPTION
This PR contains:
- add max_scheduled_delete_manifests into riak_cs.schema
- change default value of max_scheduled_delete_manifests from unlimited to 50

Changing the default value seems to need a discussion. However, in my opinion, it would be worth to change the default value from `unlimited`, since sometimes manifest histories grows up to large size in some use-case.
