### PR TITLE
Misc improvements around build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ clean-client-test:
 	@./rebar client_test_clean
 
 clean-riak-test:
-	@./rebar riak_test_clean
+	@./rebar riak_test_clean skip_deps=true
 
 deps:
 	@./rebar get-deps

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ OVERLAY_VARS    ?=
 CS_HTTP_PORT    ?= 8080
 PULSE_TESTS      = riak_cs_get_fsm_pulse
 
-.PHONY: rel stagedevrel deps test depgraph graphviz all compile
+.PHONY: rel stagedevrel deps test depgraph graphviz all compile compile-src
 
 all: compile
 
-compile: deps
+compile: compile-riak-test
+
+compile-src: deps
 	@(./rebar compile)
 
 compile-client-test: all
@@ -27,7 +29,7 @@ riak_test/src/downgrade_bitcask.erl:
 	@wget https://raw.githubusercontent.com/basho/bitcask/develop/priv/scripts/downgrade_bitcask.erl \
 		-O riak_test/src/downgrade_bitcask.erl
 
-compile-riak-test: all bitcask-downgrade-script
+compile-riak-test: compile-src bitcask-downgrade-script
 	@./rebar skip_deps=true riak_test_compile
 	## There are some Riak CS internal modules that our riak_test
 	## test would like to use.  But riak_test doesn't have a nice

--- a/riak_test/bin/rtdev-current.sh
+++ b/riak_test/bin/rtdev-current.sh
@@ -27,5 +27,5 @@ echo " - Writing $RTCS_DEST_DIR/current/VERSION"
 echo -n $VERSION > $RTCS_DEST_DIR/current/VERSION
 cd $RTCS_DEST_DIR
 echo " - Reinitializing git state"
-git add .
-git commit -a -m "riak_test init" --amend > /dev/null 2>&1
+git add --all .
+git commit -a -m "riak_test init" --amend > /dev/null


### PR DESCRIPTION
This PR consists of three independent commits.
- Add compile-riak-test to dependency of copile target c2f8057
- Skip deps in clean-riak-test 03628e9
- Add `--all` option to "git add" to suppress deprecation warning 01c7b81
