### PR TITLE
Bugfix/copy object bugs

### DIFF
--- a/riak_test/tests/put_copy_test.erl
+++ b/riak_test/tests/put_copy_test.erl
@@ -36,6 +36,10 @@
 -define(KEY2, "sidepocket").
 -define(KEY3, "superpocket").
 -define(BUCKET3, "the-other-put-target-bucket").
+-define(BUCKET4, "no-cl-bucket").
+-define(SRC_KEY, "source").
+-define(TGT_KEY, "target").
+-define(MP_TGT_KEY, "mp-target").
 
 confirm() ->
     {UserConfig, {RiakNodes, _CSNodes, _}} = rtcs:setup(1),
@@ -60,6 +64,7 @@ confirm() ->
     ok = verify_multipart_copy(UserConfig),
     ok = verify_security(UserConfig, UserConfig2, UserConfig3),
     ok = verify_source_not_found(UserConfig),
+    ok = verify_without_cl_header(UserConfig),
 
     ?assertEqual([{delete_marker, false}, {version_id, "null"}],
                  erlcloud_s3:delete_object(?BUCKET, ?KEY, UserConfig)),
@@ -248,3 +253,68 @@ verify_source_not_found(UserConfig) ->
     ?assert(string:str(ErrorXml,
                        "<Resource>/" ++ ?BUCKET ++
                            "/" ++ NonExistingKey ++ "</Resource>") > 0).
+
+%% Verify reuqests without Content-Length header, they should succeed.
+%% To avoid automatic Content-Length header addition by HTTP client library,
+%% this test uses `curl' command line utitlity, intended.
+verify_without_cl_header(UserConfig) ->
+    ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET4, UserConfig)),
+    Data = ?DATA0,
+    ?assertEqual([{version_id, "null"}],
+                 erlcloud_s3:put_object(?BUCKET4, ?SRC_KEY, Data, UserConfig)),
+    verify_without_cl_header(UserConfig, normal, Data),
+    verify_without_cl_header(UserConfig, mp, Data),
+    ok.
+
+verify_without_cl_header(UserConfig, normal, Data) ->
+    lager:info("Verify basic (non-MP) PUT copy without Content-Length header"),
+    Target = fmt("/~s/~s", [?BUCKET4, ?TGT_KEY]),
+    Source = fmt("/~s/~s", [?BUCKET4, ?SRC_KEY]),
+    _Res = exec_curl(UserConfig, "PUT", Target, [{"x-amz-copy-source", Source}]),
+
+    Props = erlcloud_s3:get_object(?BUCKET4, ?TGT_KEY, UserConfig),
+    ?assertEqual(Data, proplists:get_value(content, Props)),
+    ok;
+verify_without_cl_header(UserConfig, mp, Data) ->
+    lager:info("Verify Multipart upload copy without Content-Length header"),
+    InitUploadRes = erlcloud_s3_multipart:initiate_upload(
+                      ?BUCKET4, ?MP_TGT_KEY, "application/octet-stream",
+                      [], UserConfig),
+    UploadId = erlcloud_s3_multipart:upload_id(InitUploadRes),
+    lager:info("~p ~p", [InitUploadRes, UploadId]),
+    Source = fmt("/~s/~s", [?BUCKET4, ?SRC_KEY]),
+    MpTarget = fmt("/~s/~s?partNumber=1&uploadId=~s", [?BUCKET4, ?MP_TGT_KEY, UploadId]),
+    _Res = exec_curl(UserConfig, "PUT", MpTarget,
+                     [{"x-amz-copy-source", Source},
+                      {"x-amz-copy-source-range", "bytes=1-2"}]),
+
+    ListPartsXml = erlcloud_s3_multipart:list_parts(?BUCKET4, ?MP_TGT_KEY, UploadId, [], UserConfig),
+    lager:debug("ListParts: ~p", [ListPartsXml]),
+    ListPartsRes = erlcloud_s3_multipart:parts_to_term(ListPartsXml),
+    Parts = proplists:get_value(parts, ListPartsRes),
+    EtagList = [{PartNum, Etag} || {PartNum, [{etag, Etag}, {size, _Size}]} <- Parts],
+    lager:debug("EtagList: ~p", [EtagList]),
+    ?assertEqual(ok, erlcloud_s3_multipart:complete_upload(
+                       ?BUCKET4, ?MP_TGT_KEY, UploadId, EtagList, UserConfig)),
+    Props = erlcloud_s3:get_object(?BUCKET4, ?MP_TGT_KEY, UserConfig),
+    ExpectedBody = binary:part(Data, 1, 2),
+    ?assertEqual(ExpectedBody, proplists:get_value(content, Props)),
+    ok.
+
+exec_curl(#aws_config{s3_port=Port} = UserConfig, Method, Resource, AmzHeaders) ->
+    ContentType = "application/octet-stream",
+    Date = httpd_util:rfc1123_date(),
+    Auth = rtcs:make_authorization(Method, Resource, ContentType, UserConfig, Date,
+                                   AmzHeaders),
+    HeaderArgs = [fmt("-H '~s: ~s' ", [K, V]) ||
+                     {K, V} <- [{"Date", Date}, {"Authorization", Auth},
+                                {"Content-Type", ContentType} | AmzHeaders]],
+    Cmd="curl -X " ++ Method ++ " -v -s " ++ HeaderArgs ++
+        "'http://127.0.0.1:" ++ integer_to_list(Port) ++ Resource ++ "'",
+    lager:debug("Curl command line: ~s", [Cmd]),
+    Res = os:cmd(Cmd),
+    lager:debug("Curl result: ~s", [Res]),
+    Res.
+
+fmt(Fmt, Args) ->
+    lists:flatten(io_lib:format(Fmt, Args)).

--- a/riak_test/tests/regression_tests.erl
+++ b/riak_test/tests/regression_tests.erl
@@ -79,7 +79,7 @@ verify_cs347(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
             Result ->
                 Result
         end,
-    ?assert(rtcs:check_no_such_bucket(ListObjectRes1, "/"++?TEST_BUCKET_CS347)),
+    ?assert(rtcs:check_no_such_bucket(ListObjectRes1, "/" ++ ?TEST_BUCKET_CS347 ++ "/")),
 
     lager:info("creating bucket ~p", [BucketName]),
     ?assertEqual(ok, erlcloud_s3:create_bucket(BucketName, UserConfig)),
@@ -97,7 +97,7 @@ verify_cs347(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
             Result2 ->
                 Result2
         end,
-    ?assert(rtcs:check_no_such_bucket(ListObjectRes2, "/"++?TEST_BUCKET_CS347)),
+    ?assert(rtcs:check_no_such_bucket(ListObjectRes2, "/" ++ ?TEST_BUCKET_CS347 ++ "/")),
     ok.
 
 

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -143,7 +143,7 @@ query_stats(Type, UserConfig, Port) ->
                                stanchion -> {"/stats", velvet}
                            end,
     Cmd="curl -s -H 'Date: " ++ Date ++ "' -H 'Authorization: " ++
-        rtcs:make_authorization(SignType, "GET", Resource, [], UserConfig, Date) ++
+        rtcs:make_authorization(SignType, "GET", Resource, [], UserConfig, Date, []) ++
         "' http://localhost:" ++
         integer_to_list(Port) ++ Resource,
     lager:info("Stats query cmd: ~p", [Cmd]),

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -50,7 +50,7 @@ test_condition_and_permission(RcPid, SrcManifest, RD, Ctx) ->
     %% TODO: write tests around these conditions, any kind of test is okay
     case condition_check(RD, ETag, LastUpdate) of
         ok ->
-            _ = authorize_on_src(RcPid, SrcManifest, RD, Ctx);
+            authorize_on_src(RcPid, SrcManifest, RD, Ctx);
         Other ->
             {Other, RD, Ctx}
     end.

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -399,18 +399,20 @@ handle_copy_put(RD, Ctx, SrcBucket, SrcKey) ->
                     {true, _RD, _OtherCtx} ->
                         %% access to source object not authorized
                         %% TODO: check the return value / http status
-                        _ = lager:debug("access to source object denied (~s, ~s)", [SrcBucket, SrcKey]),
-                        {{halt, 403}, RD, Ctx};
-
+                        ResponseMod:api_error(copy_source_access_denied, RD, Ctx);
+                    {{halt, 403}, _RD, _OtherCtx} = Error ->
+                        %% access to source object not authorized either, but
+                        %% in different return value
+                        ResponseMod:api_error(copy_source_access_denied, RD, Ctx);
                     {Result, _, _} = Error ->
                         _ = lager:debug("~p on ~s ~s", [Result, SrcBucket, SrcKey]),
                         Error
 
                 end;
             {error, notfound} ->
-                ResponseMod:api_error(no_such_key, RD, Ctx);
+                ResponseMod:api_error(no_copy_source_key, RD, Ctx);
             {error, no_active_manifest} ->
-                ResponseMod:api_error(no_such_key, RD, Ctx);
+                ResponseMod:api_error(no_copy_source_key, RD, Ctx);
             {error, Err} ->
                 ResponseMod:api_error(Err, RD, Ctx)
         end

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -284,7 +284,7 @@ accept_body(RD, Ctx0=#context{local_context=LocalCtx0,
                                     riak_cs_riak_client:checkin(ReadRcPid)
                                 end
                         end;
-                    {error, notfond} ->
+                    {error, notfound} ->
                         riak_cs_s3_response:no_such_upload_response(UploadId, RD, Ctx0);
                     {error, Reason} ->
                         riak_cs_s3_response:api_error(Reason, RD, Ctx0)

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -141,27 +141,9 @@ process_post(RD, Ctx=#context{local_context=LocalCtx, riak_client=RcPid}) ->
     end.
 
 -spec valid_entity_length(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
-valid_entity_length(RD, Ctx=#context{local_context=LocalCtx}) ->
-    case wrq:method(RD) of
-        'PUT' ->
-            case catch(
-                   list_to_integer(
-                     wrq:get_req_header("Content-Length", RD))) of
-                Length when is_integer(Length) ->
-                    case Length =< riak_cs_lfs_utils:max_content_len() of
-                        false ->
-                            riak_cs_s3_response:api_error(
-                              entity_too_large, RD, Ctx);
-                        true ->
-                            UpdLocalCtx = LocalCtx#key_context{size=Length},
-                            {true, RD, Ctx#context{local_context=UpdLocalCtx}}
-                    end;
-                _ ->
-                    {false, RD, Ctx}
-            end;
-        _ ->
-            {true, RD, Ctx}
-    end.
+valid_entity_length(RD, Ctx) ->
+    MaxLen = riak_cs_lfs_utils:max_content_len(),
+    riak_cs_wm_utils:valid_entity_length(MaxLen, RD, Ctx).
 
 -spec delete_resource(#wm_reqdata{}, #context{}) ->
                              {boolean() | {'halt', term()}, #wm_reqdata{}, #context{}}.


### PR DESCRIPTION
This PR fixes a few bugs around PUT Copy / Multipart Upload Copy APIs.
- Fix bugs of the resource value in error response XML when source is
  not existent or not accessible, source bucket/key should be displayed
  there instead of target bucket/key.  The bug description is at
  https://github.com/basho/riak_cs/issues/1169, but this PR does not
  cover error response XML structure compatibility with S3.
- Fix Copy requests _without_ Content-Length request headers (https://github.com/basho/riak_cs/issues/939).
  Before this PR, such requests fails with 5xx errors. This PR allows
  requests without CL header in Copy API calls. Additionally, Copy API
  calls with CL more than zero is made to explicitly errors.
- Fix typo bug in upload ID seek, this makes error response of
  unknown upload ID correct (or more understandable.)
