### PR TITLE
Add audit tool to extract inconsistencies between users and buckets

### DIFF
--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { status | gc | access | storage | stanchion | cluster-info | cleanup-orphan-multipart | check-users-buckets}"
+    echo "Usage: $SCRIPT { status | gc | access | storage | stanchion | cluster-info | cleanup-orphan-multipart | audit-bucket-ownership}"
 }
 
 # Check the first argument for instructions
@@ -107,10 +107,10 @@ case "$1" in
 
         $NODETOOL rpc riak_cs_console cleanup_orphan_multipart "$@"
         ;;
-    check[_-]users[_-]buckets)
+    audit[_-]bucket[_-]ownership)
         shift
         node_up_check
-        $NODETOOL rpc riak_cs_console check_users_buckets "$@"
+        $NODETOOL rpc riak_cs_console audit_bucket_ownership "$@"
         ;;
     *)
         usage

--- a/rel/files/riak-cs-admin
+++ b/rel/files/riak-cs-admin
@@ -15,7 +15,7 @@ cd $RUNNER_BASE_DIR
 SCRIPT=`basename $0`
 
 usage() {
-    echo "Usage: $SCRIPT { status | gc | access | storage | stanchion | cluster-info | cleanup-orphan-multipart }"
+    echo "Usage: $SCRIPT { status | gc | access | storage | stanchion | cluster-info | cleanup-orphan-multipart | check-users-buckets}"
 }
 
 # Check the first argument for instructions
@@ -106,6 +106,11 @@ case "$1" in
         node_up_check
 
         $NODETOOL rpc riak_cs_console cleanup_orphan_multipart "$@"
+        ;;
+    check[_-]users[_-]buckets)
+        shift
+        node_up_check
+        $NODETOOL rpc riak_cs_console check_users_buckets "$@"
         ;;
     *)
         usage

--- a/src/riak_cs_bucket.erl
+++ b/src/riak_cs_bucket.erl
@@ -38,7 +38,8 @@
          update_bucket_record/1,
          delete_all_uploads/2,
          delete_old_uploads/3,
-         fold_all_buckets/3
+         fold_all_buckets/3,
+         fetch_bucket_keys/1
         ]).
 
 -include("riak_cs.hrl").
@@ -778,3 +779,11 @@ update_user_buckets(User, Bucket) ->
                     {ok, ignore}
             end
     end.
+
+%% @doc Grab the whole list of Riak CS bucket keys.
+-spec fetch_bucket_keys(riak_client()) -> {ok, [binary()]} | {error, term()}.
+fetch_bucket_keys(RcPid) ->
+    {ok, MasterPbc} = riak_cs_riak_client:master_pbc(RcPid),
+    Timeout = riak_cs_config:list_keys_list_buckets_timeout(),
+    riak_cs_pbc:list_keys(MasterPbc, ?BUCKETS_BUCKET, Timeout,
+                          [riakc, list_all_bucket_keys]).

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -88,6 +88,7 @@
          delete_gckey_timeout/0,
          list_keys_list_objects_timeout/0,
          list_keys_list_users_timeout/0,
+         list_keys_list_buckets_timeout/0,
          storage_calc_timeout/0,
          list_objects_timeout/0, %% using mapred (v0)
          fold_objects_timeout/0, %% for cs_bucket_fold
@@ -466,6 +467,7 @@ local_get_block_timeout() ->
 ?TIMEOUT_CONFIG_FUNC(delete_gckey_timeout).
 ?TIMEOUT_CONFIG_FUNC(list_keys_list_objects_timeout).
 ?TIMEOUT_CONFIG_FUNC(list_keys_list_users_timeout).
+?TIMEOUT_CONFIG_FUNC(list_keys_list_buckets_timeout).
 ?TIMEOUT_CONFIG_FUNC(storage_calc_timeout).
 ?TIMEOUT_CONFIG_FUNC(list_objects_timeout).
 ?TIMEOUT_CONFIG_FUNC(fold_objects_timeout).

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -23,7 +23,7 @@
 -export([
          status/1,
          cluster_info/1,
-         check_users_buckets/1,
+         audit_bucket_ownership/1,
          cleanup_orphan_multipart/0,
          cleanup_orphan_multipart/1
         ]).
@@ -63,39 +63,85 @@ cluster_info([OutFile]) ->
             error
     end.
 
-check_users_buckets(_Argv) ->
-    {ok, RcPid} = riak_cs_riak_client:start_link([]),
-    {ok, Users} = riak_cs_user:fetch_user_list(RcPid),
-    [ begin
-          UserStr = binary_to_list(User),
-          io:format("Checking user ~s ..~n", [UserStr]),
-          {ok, {RCSUser, _Obj}} = riak_cs_user:get_user(UserStr, RcPid),
-          ?RCS_USER{buckets=Buckets} = RCSUser,
-          [verify_bucket(RcPid, RCSUser, Bucket)
-           || Bucket <- Buckets]
-      end
-      || User <- Users ].
+%% @doc Audit bucket ownership by comparing information between
+%%      users bucket and buckets bucket.
+audit_bucket_ownership(_Args) when is_list(_Args) ->
+    audit_bucket_ownership().
 
-verify_bucket(RcPid,
-              ?RCS_USER{key_id=_KeyId} = _RCSUser,
-              ?RCS_BUCKET{last_action=LastAction, name=BucketName} = _Bucket) ->
-    case riak_cs_bucket:fetch_bucket_object(BucketName, RcPid) of
-        {ok, Obj} ->
-            case riakc_obj:value_count(Obj) of
-                1 ->
-                    %% Run check logic here
-                    ok;
-                N when N > 0 ->
-                    %% warning, continue with first value
-                    warning
-            end;
-        {error, notfound} when LastAction =:= deleted ->
-            ok; %% maybe inconsistent ... shouldbe, but okay
-        {error, notfound} when LastAction =:= created ->
-            bad;
-        {error, _} = E ->
-            E %% somethings is wrong; should stop the system now
+audit_bucket_ownership() ->
+    {ok, RcPid} = riak_cs_riak_client:start_link([]),
+    try
+        Inconsistencies = audit_bucket_ownership0(RcPid),
+        io:format("~p", [Inconsistencies])
+    after
+        riak_cs_riak_client:stop(RcPid)
     end.
+
+%% Construct two sets of {User, Bucket} tuples and
+%% return differences of subtraction in both directions, also output logs.
+audit_bucket_ownership0(RcPid) ->
+    FromUsers = ownership_from_users(RcPid),
+    {FromBuckets, OwnedBy} = ownership_from_buckets(RcPid),
+    lager:debug("FromUsers: ~p~n", [lists:usort(gb_sets:to_list(FromUsers))]),
+    lager:debug("FromBuckets: ~p~n", [lists:usort(gb_sets:to_list(FromBuckets))]),
+    lager:debug("OwnedBy: ~p~n", [lists:usort(gb_trees:to_list(OwnedBy))]),
+    Inconsistencies0 =
+        gb_sets:fold(
+          fun ({U, B}, Acc) ->
+                  lager:info(
+                    "Bucket is not tracked by user: {User, Bucket} = {~s, ~s}",
+                    [U, B]),
+                  [{not_tracked, {U, B}} | Acc]
+          end, [], gb_sets:subtract(FromBuckets, FromUsers)),
+    gb_sets:fold(
+      fun({U,B}, Acc) ->
+              case gb_trees:lookup(B, OwnedBy) of
+                  none ->
+                      lager:info(
+                        "Bucket does not exist: {User, Bucket} = {~s, ~s}", [U, B]),
+                      [{no_bucket_object, {U, B}} | Acc];
+                  {value, DifferentUser} ->
+                      lager:info(
+                        "Bucket is owned by different user: {User, Bucket, DifferentUser} = "
+                        "{~s, ~s, ~s}", [U, B, DifferentUser]),
+                      [{different_user, {U, B, DifferentUser}} | Acc]
+              end
+      end, Inconsistencies0, gb_sets:subtract(FromUsers, FromBuckets)).
+
+ownership_from_users(RcPid) ->
+    {ok, UserKeys} = riak_cs_user:fetch_user_keys(RcPid),
+    lists:foldl(
+      fun(UserKey, Ownership) ->
+              UserStr = binary_to_list(UserKey),
+              {ok, {RCSUser, _Obj}} = riak_cs_user:get_user(UserStr, RcPid),
+              ?RCS_USER{buckets=Buckets} = RCSUser,
+              lists:foldl(
+                fun(?RCS_BUCKET{name=BucketStr}, InnerOwnership) ->
+                        gb_sets:add_element({UserKey, list_to_binary(BucketStr)},
+                                            InnerOwnership)
+                end, Ownership, Buckets)
+      end, gb_sets:new(), UserKeys).
+
+ownership_from_buckets(RcPid) ->
+    {ok, BucketKeys} = riak_cs_bucket:fetch_bucket_keys(RcPid),
+    lists:foldl(
+      fun(BucketKey, {Ownership, OwnedBy}) ->
+              case riak_cs_bucket:fetch_bucket_object(BucketKey, RcPid) of
+                  {error, no_such_bucket} ->
+                      {Ownership, OwnedBy};
+                  {ok, BucketObj} ->
+                      OwnerIds = riakc_obj:get_values(BucketObj),
+                      %% Raise badmatch when something wrong, too sloppy?
+                      {ok, Owner} =
+                          case lists:usort(OwnerIds) of
+                              [Uniq] -> {ok, Uniq};
+                              [] ->     {error, {no_bucket_owner, BucketKey}};
+                              Owners -> {error, {multiple_owners, BucketKey, Owners}}
+                          end,
+                      {gb_sets:add_element({Owner, BucketKey}, Ownership),
+                       gb_trees:enter(BucketKey, Owner, OwnedBy)}
+              end
+      end, {gb_sets:new(), gb_trees:empty()}, BucketKeys).
 
 %% @doc This function is for operation, esp cleaning up multipart
 %% uploads which not completed nor aborted, and after that - bucket

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -23,6 +23,7 @@
 -export([
          status/1,
          cluster_info/1,
+         check_users_buckets/1,
          cleanup_orphan_multipart/0,
          cleanup_orphan_multipart/1
         ]).
@@ -60,6 +61,40 @@ cluster_info([OutFile]) ->
                 [Exception, Reason]),
             io:format("Cluster_info failed, see log for details~n"),
             error
+    end.
+
+check_users_buckets(_Argv) ->
+    {ok, RcPid} = riak_cs_riak_client:start_link([]),
+    {ok, Users} = riak_cs_user:fetch_user_list(RcPid),
+    [ begin
+          UserStr = binary_to_list(User),
+          io:format("Checking user ~s ..~n", [UserStr]),
+          {ok, {RCSUser, _Obj}} = riak_cs_user:get_user(UserStr, RcPid),
+          ?RCS_USER{buckets=Buckets} = RCSUser,
+          [verify_bucket(RcPid, RCSUser, Bucket)
+           || Bucket <- Buckets]
+      end
+      || User <- Users ].
+
+verify_bucket(RcPid,
+              ?RCS_USER{key_id=_KeyId} = _RCSUser,
+              ?RCS_BUCKET{last_action=LastAction, name=BucketName} = _Bucket) ->
+    case riak_cs_bucket:fetch_bucket_object(BucketName, RcPid) of
+        {ok, Obj} ->
+            case riakc_obj:value_count(Obj) of
+                1 ->
+                    %% Run check logic here
+                    ok;
+                N when N > 0 ->
+                    %% warning, continue with first value
+                    warning
+            end;
+        {error, notfound} when LastAction =:= deleted ->
+            ok; %% maybe inconsistent ... shouldbe, but okay
+        {error, notfound} when LastAction =:= created ->
+            bad;
+        {error, _} = E ->
+            E %% somethings is wrong; should stop the system now
     end.
 
 %% @doc This function is for operation, esp cleaning up multipart

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -70,9 +70,11 @@ audit_bucket_ownership(_Args) when is_list(_Args) ->
 
 audit_bucket_ownership() ->
     {ok, RcPid} = riak_cs_riak_client:start_link([]),
-    try
-        Inconsistencies = audit_bucket_ownership0(RcPid),
-        io:format("~p", [Inconsistencies])
+    try audit_bucket_ownership0(RcPid) of
+        [] ->
+            io:format("No Inconsistencies found.~n");
+        Inconsistencies ->
+            io:format("~p.~n", [Inconsistencies])
     after
         riak_cs_riak_client:stop(RcPid)
     end.

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -125,6 +125,7 @@ duration_metrics() ->
          [riakc, fold_manifest_objs],
          [riakc, mapred_storage],
          [riakc, list_all_user_keys],
+         [riakc, list_all_bucket_keys],
          [riakc, list_all_manifest_keys],
          [riakc, list_users_receive_chunk],
          [riakc, get_uploads_by_index],

--- a/src/riak_cs_storage_d.erl
+++ b/src/riak_cs_storage_d.erl
@@ -348,7 +348,15 @@ start_batch(Options, Time, State) ->
     %% socket process, so "starting" one here is the same as opening a
     %% connection, and avoids duplicating the configuration lookup code
     {ok, RcPid} = riak_cs_riak_client:start_link([]),
-    Batch = fetch_user_list(RcPid),
+    Batch =
+        case riak_cs_user:fetch_user_list(RcPid) of
+            {ok, Users} -> Users;
+            {error, Error} ->
+                _ = lager:error("Storage calculator was unable"
+                                " to fetch list of users (~p)",
+                                [Error]),
+                []
+        end,
 
     gen_fsm:send_event(?SERVER, continue),
     State#state{batch_start=BatchStart,
@@ -360,20 +368,6 @@ start_batch(Options, Time, State) ->
                 recalc=Recalc,
                 detailed=Detailed,
                 leeway_edge=LeewayEdge}.
-
-%% @doc Grab the whole list of Riak CS users.
-fetch_user_list(RcPid) ->
-    {ok, MasterPbc} = riak_cs_riak_client:master_pbc(RcPid),
-    Timeout = riak_cs_config:list_keys_list_users_timeout(),
-    case riak_cs_pbc:list_keys(MasterPbc, ?USER_BUCKET, Timeout,
-                               [riakc, list_all_user_keys]) of
-        {ok, Users} -> Users;
-        {error, Error} ->
-            _ = lager:error("Storage calculator was unable"
-                            " to fetch list of users (~p)",
-                            [Error]),
-            []
-    end.
 
 %% @doc Compute storage for the next user in the batch.
 calculate_next_user(#state{riak_client=RcPid,

--- a/src/riak_cs_storage_d.erl
+++ b/src/riak_cs_storage_d.erl
@@ -349,8 +349,8 @@ start_batch(Options, Time, State) ->
     %% connection, and avoids duplicating the configuration lookup code
     {ok, RcPid} = riak_cs_riak_client:start_link([]),
     Batch =
-        case riak_cs_user:fetch_user_list(RcPid) of
-            {ok, Users} -> Users;
+        case riak_cs_user:fetch_user_keys(RcPid) of
+            {ok, UserKeys} -> UserKeys;
             {error, Error} ->
                 _ = lager:error("Storage calculator was unable"
                                 " to fetch list of users (~p)",

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -34,7 +34,8 @@
          save_user/3,
          update_key_secret/1,
          update_user/3,
-         key_id/1
+         key_id/1,
+         fetch_user_list/1
         ]).
 
 -include("riak_cs.hrl").
@@ -235,6 +236,14 @@ update_key_secret(User=?RCS_USER{email=Email,
 display_name(Email) ->
     Index = string:chr(Email, $@),
     string:sub_string(Email, 1, Index-1).
+
+%% @doc Grab the whole list of Riak CS users.
+-spec fetch_user_list(riak_client()) -> {ok, [binary()]} | {error, term()}.
+fetch_user_list(RcPid) ->
+    {ok, MasterPbc} = riak_cs_riak_client:master_pbc(RcPid),
+    Timeout = riak_cs_config:list_keys_list_users_timeout(),
+    riak_cs_pbc:list_keys(MasterPbc, ?USER_BUCKET, Timeout,
+                          [riakc, list_all_user_keys]).
 
 %% ===================================================================
 %% Internal functions

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -35,7 +35,7 @@
          update_key_secret/1,
          update_user/3,
          key_id/1,
-         fetch_user_list/1
+         fetch_user_keys/1
         ]).
 
 -include("riak_cs.hrl").
@@ -237,9 +237,9 @@ display_name(Email) ->
     Index = string:chr(Email, $@),
     string:sub_string(Email, 1, Index-1).
 
-%% @doc Grab the whole list of Riak CS users.
--spec fetch_user_list(riak_client()) -> {ok, [binary()]} | {error, term()}.
-fetch_user_list(RcPid) ->
+%% @doc Grab the whole list of Riak CS user keys.
+-spec fetch_user_keys(riak_client()) -> {ok, [binary()]} | {error, term()}.
+fetch_user_keys(RcPid) ->
     {ok, MasterPbc} = riak_cs_riak_client:master_pbc(RcPid),
     Timeout = riak_cs_config:list_keys_list_users_timeout(),
     riak_cs_pbc:list_keys(MasterPbc, ?USER_BUCKET, Timeout,


### PR DESCRIPTION
There is possibility of inconsistencies between the user bucket `moss.users`
and the buckets bucket `moss.buckets` because no transaction is (can be) used.

This PR adds tool for detecting inconsistencies between them.
Three kinds of inconsistencies:
1. Bucket object in buckets bucket is not tracked by the user
   in its value. (`{not_tracked, {User, Bucket}}`)
2. A certain user thinks it owns a bucket but no objects in buckets bucket
   exists. (`{no_bucket_object, {User, Bucket}}`)
3. A certain user thinks it owns a bucket but the bucket is actually
   owned by different user. (`{different_user, {User, Bucket, DifferentUser}}`)

---

Sample execution by console command and log output in it:

```
% dev/dev1/bin/riak-cs-admin audit-bucket-ownership
[{no_bucket_object,{<<"T_RNSHIN22TIJ1MKF8BP">>,<<"corrupt">>}},
 {different_user,{<<"N4ADKYOVGZLKL5RVD0MA">>,<<"bob2">>,
                  <<"T_RNSHIN22TIJ1MKF8BP">>}},
 {not_tracked,{<<"T_RNSHIN22TIJ1MKF8BP">>,<<"missing-in-list">>}},
 {not_tracked,{<<"T_RNSHIN22TIJ1MKF8BP">>,<<"bob2">>}},
 {not_tracked,{<<"N4ADKYOVGZLKL5RVD0MA">>,<<"missing-in-bobs-list">>}}]
```

```
16:54:20.475 [info] Bucket is not tracked by user: {User, Bucket} = {N4ADKYOVGZLKL5RVD0MA, missing-in-bobs-list}
16:54:20.475 [info] Bucket is not tracked by user: {User, Bucket} = {T_RNSHIN22TIJ1MKF8BP, bob2}
16:54:20.475 [info] Bucket is not tracked by user: {User, Bucket} = {T_RNSHIN22TIJ1MKF8BP, missing-in-list}
16:54:20.475 [info] Bucket is owned by different user: {User, Bucket, DifferentUser} = {N4ADKYOVGZLKL5RVD0MA, bob2, T_RNSHIN22TIJ1MKF8BP}
16:54:20.475 [info] Bucket does not exist: {User, Bucket} = {T_RNSHIN22TIJ1MKF8BP, corrupt}
```

---

This PR is in the state of request-for-comment.  Any comments on categorization,
log format, command line output, implementation, etc is appreciated.
