### PR TITLE
Feature/update clojure test

### DIFF
--- a/client_tests/clojure/clj-s3/README.md
+++ b/client_tests/clojure/clj-s3/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-These tests are written using a [fork](https://github.com/reiddraper/clj-aws-s3)
-of [clj-aws-s3](https://github.com/weavejester/clj-aws-s3). The fork adds proxy
-configuration needed to test Riak CS. You can see that, and the other
-dependencies in `project.clj`. There is code for creating Riak CS users in:
+These tests are written using a copy of
+[clj-aws-s3](https://github.com/weavejester/clj-aws-s3) at tag 0.3.10,
+for S3 API call. On the other hand, Riak CS specific administrative API
+call is implemented in
 
 ```bash
 client_tests/clojure/clj-s3/src/java_s3_tests/user_creation.clj

--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -2,7 +2,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  ;; aws-sdk-java deps
-                 [com.amazonaws/aws-java-sdk "1.10.8" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk-s3 "1.10.8" :exclusions [joda-time]]
                  [joda-time "2.8.1"]
                  [com.fasterxml.jackson.core/jackson-core "2.5.3"]
                  [com.fasterxml.jackson.core/jackson-databind "2.5.3"]

--- a/client_tests/clojure/clj-s3/project.clj
+++ b/client_tests/clojure/clj-s3/project.clj
@@ -1,9 +1,16 @@
-(defproject java-s3-tests/java-s3-tests "0.0.1"
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [com.reiddraper/clj-aws-s3 "0.4.2"]
-                 [clj-http "0.7.1"]
+(defproject java-s3-tests/java-s3-tests "0.0.2"
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 ;; aws-sdk-java deps
+                 [com.amazonaws/aws-java-sdk "1.10.8" :exclusions [joda-time]]
+                 [joda-time "2.8.1"]
+                 [com.fasterxml.jackson.core/jackson-core "2.5.3"]
+                 [com.fasterxml.jackson.core/jackson-databind "2.5.3"]
+                 ;; user_creation deps
+                 [clj-http "2.0.0"]
                  [cheshire "5.1.0"]]
-  :profiles {:dev {:dependencies [[midje "1.5.1"]]}}
+  ;; :jvm-opts ["-verbose:class"]
+  :profiles {:dev {:dependencies [[midje "1.7.0"]]}}
   :min-lein-version "2.0.0"
-  :plugins [[lein-midje "3.0.1"]]
+  :plugins [[lein-midje "3.1.3"]]
   :description "integration tests for Riak CS using the offical Java SDK")

--- a/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
+++ b/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
@@ -1,3 +1,8 @@
+;; Copyright (c) 2014 James Reeves
+;; Distributed under the Eclipse Public License, the same as Clojure.
+;;
+;; Original repository is https://github.com/weavejester/clj-aws-s3.
+
 (ns aws.sdk.s3
   "Functions to access the Amazon S3 storage service.
 

--- a/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
+++ b/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
@@ -1,0 +1,647 @@
+(ns aws.sdk.s3
+  "Functions to access the Amazon S3 storage service.
+
+  Each function takes a map of credentials as its first argument. The
+  credentials map should contain an :access-key key and a :secret-key key,
+  optionally an :endpoint key to denote an AWS endpoint and optionally a :proxy
+  key to define a HTTP proxy to go through.
+
+  The :proxy key must contain keys for :host and :port, and may contain keys
+  for :user, :password, :domain and :workstation."
+  (:require [clojure.string :as str]
+            [clj-time.core :as t]
+            [clj-time.coerce :as coerce]
+            [clojure.walk :as walk])
+  (:import com.amazonaws.auth.BasicAWSCredentials
+           com.amazonaws.auth.BasicSessionCredentials
+           com.amazonaws.services.s3.AmazonS3Client
+           com.amazonaws.AmazonServiceException
+           com.amazonaws.ClientConfiguration
+           com.amazonaws.HttpMethod
+           com.amazonaws.services.s3.model.AccessControlList
+           com.amazonaws.services.s3.model.Bucket
+           com.amazonaws.services.s3.model.Grant
+           com.amazonaws.services.s3.model.CanonicalGrantee
+           com.amazonaws.services.s3.model.CopyObjectResult
+           com.amazonaws.services.s3.model.EmailAddressGrantee
+           com.amazonaws.services.s3.model.GetObjectRequest
+           com.amazonaws.services.s3.model.GetObjectMetadataRequest
+           com.amazonaws.services.s3.model.Grant
+           com.amazonaws.services.s3.model.GroupGrantee
+           com.amazonaws.services.s3.model.ListObjectsRequest
+           com.amazonaws.services.s3.model.ListVersionsRequest
+           com.amazonaws.services.s3.model.Owner
+           com.amazonaws.services.s3.model.ObjectMetadata
+           com.amazonaws.services.s3.model.ObjectListing
+           com.amazonaws.services.s3.model.Permission
+           com.amazonaws.services.s3.model.PutObjectRequest
+           com.amazonaws.services.s3.model.S3Object
+           com.amazonaws.services.s3.model.S3ObjectSummary
+           com.amazonaws.services.s3.model.S3VersionSummary
+           com.amazonaws.services.s3.model.VersionListing
+           com.amazonaws.services.s3.model.InitiateMultipartUploadRequest
+           com.amazonaws.services.s3.model.AbortMultipartUploadRequest
+           com.amazonaws.services.s3.model.CompleteMultipartUploadRequest
+           com.amazonaws.services.s3.model.UploadPartRequest
+           java.util.concurrent.Executors
+           java.io.ByteArrayInputStream
+           java.io.File
+           java.io.InputStream
+           java.nio.charset.Charset))
+
+(defn- s3-client*
+  [cred]
+  (let [client-configuration (ClientConfiguration.)]
+    (when-let [conn-timeout (:conn-timeout cred)]
+      (.setConnectionTimeout client-configuration conn-timeout))
+    (when-let [socket-timeout (:socket-timeout cred)]
+      (.setSocketTimeout client-configuration socket-timeout))
+    (when-let [max-retries (:max-retries cred)]
+      (.setMaxErrorRetry client-configuration max-retries))
+    (when-let [max-conns (:max-conns cred)]
+      (.setMaxConnections client-configuration max-conns))
+    (when-let [proxy-host (get-in cred [:proxy :host])]
+      (.setProxyHost client-configuration proxy-host))
+    (when-let [proxy-port (get-in cred [:proxy :port])]
+      (.setProxyPort client-configuration proxy-port))
+    (when-let [proxy-user (get-in cred [:proxy :user])]
+      (.setProxyUsername client-configuration proxy-user))
+    (when-let [proxy-pass (get-in cred [:proxy :password])]
+      (.setProxyPassword client-configuration proxy-pass))
+    (when-let [proxy-domain (get-in cred [:proxy :domain])]
+      (.setProxyDomain client-configuration proxy-domain))
+    (when-let [proxy-workstation (get-in cred [:proxy :workstation])]
+      (.setProxyWorkstation client-configuration proxy-workstation))
+    (let [aws-creds
+          (if (:token cred)
+            (BasicSessionCredentials. (:access-key cred) (:secret-key cred) (:token cred))
+            (BasicAWSCredentials. (:access-key cred) (:secret-key cred)))
+
+          client (AmazonS3Client. aws-creds client-configuration)]
+      (when-let [endpoint (:endpoint cred)]
+        (.setEndpoint client endpoint))
+      client)))
+
+(def ^{:private true :tag AmazonS3Client}
+  s3-client
+  (memoize s3-client*))
+
+(defprotocol ^{:no-doc true} Mappable
+  "Convert a value into a Clojure map."
+  (^{:no-doc true} to-map [x] "Return a map of the value."))
+
+(extend-protocol Mappable
+  Bucket
+  (to-map [bucket]
+    {:name          (.getName bucket)
+     :creation-date (.getCreationDate bucket)
+     :owner         (to-map (.getOwner bucket))})
+  Owner
+  (to-map [owner]
+    {:id           (.getId owner)
+     :display-name (.getDisplayName owner)})
+  nil
+  (to-map [_] nil))
+
+(defn bucket-exists?
+  "Returns true if the supplied bucket name already exists in S3."
+  [cred name]
+  (.doesBucketExist (s3-client cred) name))
+
+(defn create-bucket
+  "Create a new S3 bucket with the supplied name."
+  [cred ^String name]
+  (to-map (.createBucket (s3-client cred) name)))
+
+(defn delete-bucket
+  "Delete the S3 bucket with the supplied name."
+  [cred ^String name]
+  (.deleteBucket (s3-client cred) name))
+
+(defn list-buckets
+  "List all the S3 buckets for the supplied credentials. The buckets will be
+  returned as a seq of maps with the following keys:
+    :name          - the bucket name
+    :creation-date - the date when the bucket was created
+    :owner         - the owner of the bucket"
+  [cred]
+  (map to-map (.listBuckets (s3-client cred))))
+
+(defprotocol ^{:no-doc true} ToPutRequest
+  "A protocol for constructing a map that represents an S3 put request."
+  (^{:no-doc true} put-request [x] "Convert a value into a put request."))
+
+(extend-protocol ToPutRequest
+  InputStream
+  (put-request [is] {:input-stream is})
+  File
+  (put-request [f] {:file f})
+  String
+  (put-request [s]
+    (let [bytes (.getBytes s)]
+      {:input-stream     (ByteArrayInputStream. bytes)
+       :content-length   (count bytes)
+       :content-type     (str "text/plain; charset=" (.name (Charset/defaultCharset)))})))
+
+(defmacro set-attr
+  "Set an attribute on an object if not nil."
+  {:private true}
+  [object setter value]
+  `(if-let [v# ~value]
+     (~setter ~object v#)))
+
+(defn- maybe-int [x]
+  (if x (int x)))
+
+(defn- map->ObjectMetadata
+  "Convert a map of object metadata into a ObjectMetadata instance."
+  [metadata]
+  (doto (ObjectMetadata.)
+    (set-attr .setCacheControl         (:cache-control metadata))
+    (set-attr .setContentDisposition   (:content-disposition metadata))
+    (set-attr .setContentEncoding      (:content-encoding metadata))
+    (set-attr .setContentLength        (:content-length metadata))
+    (set-attr .setContentMD5           (:content-md5 metadata))
+    (set-attr .setContentType          (:content-type metadata))
+    (set-attr .setServerSideEncryption (:server-side-encryption metadata))
+    (set-attr .setUserMetadata
+              (walk/stringify-keys (dissoc metadata
+                                           :cache-control
+                                           :content-disposition
+                                           :content-encoding
+                                           :content-length
+                                           :content-md5
+                                           :content-type
+                                           :server-side-encryption)))))
+
+(defn- ^PutObjectRequest ->PutObjectRequest
+  "Create a PutObjectRequest instance from a bucket name, key and put request
+  map."
+  [^String bucket ^String key request]
+  (cond
+   (:file request)
+     (let [put-obj-req (PutObjectRequest. bucket key ^java.io.File (:file request))]
+       (.setMetadata put-obj-req (map->ObjectMetadata (dissoc request :file)))
+       put-obj-req)
+   (:input-stream request)
+     (PutObjectRequest.
+      bucket key
+      (:input-stream request)
+      (map->ObjectMetadata (dissoc request :input-stream)))))
+
+(declare create-acl) ; used by put-object
+
+(defn put-object
+  "Put a value into an S3 bucket at the specified key. The value can be
+  a String, InputStream or File (or anything that implements the ToPutRequest
+  protocol).
+
+  An optional map of metadata may also be supplied that can include any of the
+  following keys:
+    :cache-control          - the cache-control header (see RFC 2616)
+    :content-disposition    - how the content should be downloaded by browsers
+    :content-encoding       - the encoding of the content (e.g. gzip)
+    :content-length         - the length of the content in bytes
+    :content-md5            - the MD5 sum of the content
+    :content-type           - the mime type of the content
+    :server-side-encryption - set to AES256 if SSE is required
+
+  An optional list of grant functions can be provided after metadata.
+  These functions will be applied to a clear ACL and the result will be
+  the ACL for the newly created object."
+  [cred bucket key value & [metadata & permissions]]
+  (let [req (->> (merge (put-request value) metadata)
+                 (->PutObjectRequest bucket key))]
+    (when permissions
+      (.setAccessControlList req (create-acl permissions)))
+    (.putObject (s3-client cred) req)))
+
+(defn- initiate-multipart-upload
+  [cred bucket key] 
+  (.getUploadId (.initiateMultipartUpload 
+                  (s3-client cred) 
+                  (InitiateMultipartUploadRequest. bucket key))))
+
+(defn- abort-multipart-upload
+  [{cred :cred bucket :bucket key :key upload-id :upload-id}] 
+  (.abortMultipartUpload 
+    (s3-client cred) 
+    (AbortMultipartUploadRequest. bucket key upload-id)))
+
+(defn- complete-multipart-upload
+  [{cred :cred bucket :bucket key :key upload-id :upload-id e-tags :e-tags}] 
+  (.completeMultipartUpload
+    (s3-client cred)
+    (CompleteMultipartUploadRequest. bucket key upload-id e-tags)))
+
+(defn- upload-part
+  [{cred :cred bucket :bucket key :key upload-id :upload-id
+    part-size :part-size offset :offset ^java.io.File file :file}] 
+  (.getPartETag
+   (.uploadPart
+    (s3-client cred)
+    (doto (UploadPartRequest.)
+      (.setBucketName bucket)
+      (.setKey key)
+      (.setUploadId upload-id)
+      (.setPartNumber (+ 1 (/ offset part-size)))
+      (.setFileOffset offset)
+      (.setPartSize ^long (min part-size (- (.length file) offset)))
+      (.setFile file)))))
+
+(defn put-multipart-object
+  "Do a multipart upload of a file into a S3 bucket at the specified key.
+  The value must be a java.io.File object.  The entire file is uploaded 
+  or not at all.  If an exception happens at any time the upload is aborted 
+  and the exception is rethrown. The size of the parts and the number of
+  threads uploading the parts can be configured in the last argument as a
+  map with the following keys:
+    :part-size - the size in bytes of each part of the file.  Must be 5mb
+                 or larger.  Defaults to 5mb
+    :threads   - the number of threads that will upload parts concurrently.
+                 Defaults to 16."
+  [cred bucket key ^java.io.File file & [{:keys [part-size threads]
+                            :or {part-size (* 5 1024 1024) threads 16}}]]
+  (let [upload-id (initiate-multipart-upload cred bucket key)
+        upload    {:upload-id upload-id :cred cred :bucket bucket :key key :file file}
+        pool      (Executors/newFixedThreadPool threads)
+        offsets   (range 0 (.length file) part-size)
+        tasks     (map #(fn [] (upload-part (assoc upload :offset % :part-size part-size)))
+                       offsets)]
+    (try
+      (complete-multipart-upload
+        (assoc upload :e-tags (map #(.get ^java.util.concurrent.Future %)  (.invokeAll pool tasks))))
+      (catch Exception ex 
+        (abort-multipart-upload upload) 
+        (.shutdown pool)
+        (throw ex))
+      (finally (.shutdown pool)))))
+
+(extend-protocol Mappable
+  S3Object
+  (to-map [object]
+    {:content  (.getObjectContent object)
+     :metadata (to-map (.getObjectMetadata object))
+     :bucket   (.getBucketName object)
+     :key      (.getKey object)})
+  ObjectMetadata
+  (to-map [metadata]
+    {:cache-control          (.getCacheControl metadata)
+     :content-disposition    (.getContentDisposition metadata)
+     :content-encoding       (.getContentEncoding metadata)
+     :content-length         (.getContentLength metadata)
+     :content-md5            (.getContentMD5 metadata)
+     :content-type           (.getContentType metadata)
+     :etag                   (.getETag metadata)
+     :last-modified          (.getLastModified metadata)
+     :server-side-encryption (.getServerSideEncryption metadata)
+     :user (walk/keywordize-keys (into {} (.getUserMetadata metadata)))
+     :version-id             (.getVersionId metadata)})
+  ObjectListing
+  (to-map [listing]
+    {:bucket          (.getBucketName listing)
+     :objects         (map to-map (.getObjectSummaries listing))
+     :prefix          (.getPrefix listing)
+     :common-prefixes (seq (.getCommonPrefixes listing))
+     :truncated?      (.isTruncated listing)
+     :max-keys        (.getMaxKeys listing)
+     :marker          (.getMarker listing)
+     :next-marker     (.getNextMarker listing)})
+  S3ObjectSummary
+  (to-map [summary]
+    {:metadata {:content-length (.getSize summary)
+                :etag           (.getETag summary)
+                :last-modified  (.getLastModified summary)}
+     :bucket   (.getBucketName summary)
+     :key      (.getKey summary)})
+  S3VersionSummary
+  (to-map [summary]
+    {:metadata {:content-length (.getSize summary)
+                :etag           (.getETag summary)
+                :last-modified  (.getLastModified summary)}
+     :version-id     (.getVersionId summary)
+     :latest?        (.isLatest summary)
+     :delete-marker? (.isDeleteMarker summary)
+     :bucket         (.getBucketName summary)
+     :key            (.getKey summary)})
+  VersionListing
+  (to-map [listing]
+    {:bucket                 (.getBucketName listing)
+     :versions               (map to-map (.getVersionSummaries listing))
+     :prefix                 (.getPrefix listing)
+     :common-prefixes        (seq (.getCommonPrefixes listing))
+     :delimiter              (.getDelimiter listing)
+     :truncated?             (.isTruncated listing)
+     :max-results            (maybe-int (.getMaxKeys listing)) ; AWS API is inconsistent, should be .getMaxResults
+     :key-marker             (.getKeyMarker listing)
+     :next-key-marker        (.getNextKeyMarker listing)
+     :next-version-id-marker (.getNextVersionIdMarker listing)
+     :version-id-marker      (.getVersionIdMarker listing)})
+  CopyObjectResult
+  (to-map [result]
+    {:etag                    (.getETag result)
+     :expiration-time         (.getExpirationTime result)
+     :expiration-time-rule-id (.getExpirationTimeRuleId result)
+     :last-modified-date      (.getLastModifiedDate result)
+     :server-side-encryption  (.getServerSideEncryption result)}))
+
+(defn get-object
+  "Get an object from an S3 bucket. The object is returned as a map with the
+  following keys:
+    :content  - an InputStream to the content
+    :metadata - a map of the object's metadata
+    :bucket   - the name of the bucket
+    :key      - the object's key
+  Be extremely careful when using this method; the :content value in the returned
+  map contains a direct stream of data from the HTTP connection. The underlying
+  HTTP connection cannot be closed until the user finishes reading the data and
+  closes the stream.
+  Therefore:
+    * Use the data from the :content input stream as soon as possible
+    * Close the :content input stream as soon as possible
+  If these rules are not followed, the client can run out of resources by
+  allocating too many open, but unused, HTTP connections."
+  ([cred ^String bucket ^String key]
+     (to-map (.getObject (s3-client cred) bucket key)))
+  ([cred ^String bucket ^String key ^String version-id]
+     (to-map (.getObject (s3-client cred) (GetObjectRequest. bucket key version-id)))))
+
+(defn- map->GetObjectMetadataRequest
+  "Create a ListObjectsRequest instance from a map of values."
+  [request]
+  (GetObjectMetadataRequest. (:bucket request) (:key request) (:version-id request)))
+
+(defn get-object-metadata
+  "Get an object's metadata from a bucket.  A optional map of options may be supplied.
+   Available options are:
+     :version-id - the version of the object
+   The metadata is a map with the
+   following keys:
+     :cache-control          - the CacheControl HTTP header
+     :content-disposition    - the ContentDisposition HTTP header
+     :content-encoding       - the character encoding of the content
+     :content-length         - the length of the content in bytes
+     :content-md5            - the MD5 hash of the content
+     :content-type           - the mime-type of the content
+     :etag                   - the HTTP ETag header
+     :last-modified          - the last modified date
+     :server-side-encryption - the server-side encryption algorithm"
+  [cred bucket key & [options]]
+  (to-map
+   (.getObjectMetadata
+    (s3-client cred)
+    (map->GetObjectMetadataRequest (merge {:bucket bucket :key key} options)))))
+
+(defn- map->ListObjectsRequest
+  "Create a ListObjectsRequest instance from a map of values."
+  ^ListObjectsRequest
+  [request]
+  (doto (ListObjectsRequest.)
+    (set-attr .setBucketName (:bucket request))
+    (set-attr .setDelimiter  (:delimiter request))
+    (set-attr .setMarker     (:marker request))
+    (set-attr .setMaxKeys    (maybe-int (:max-keys request)))
+    (set-attr .setPrefix     (:prefix request))))
+
+(defn- http-method [method]
+  (-> method name str/upper-case HttpMethod/valueOf))
+
+(defn generate-presigned-url
+  "Return a presigned URL for an S3 object. Accepts the following options:
+    :expires     - the date at which the URL will expire (defaults to 1 day from now)
+    :http-method - the HTTP method for the URL (defaults to :get)"
+  [cred bucket key & [options]]
+  (.toString
+   (.generatePresignedUrl
+    (s3-client cred)
+    bucket
+    key
+    (coerce/to-date (:expires options (-> 1 t/days t/from-now)))
+    (http-method (:http-method options :get)))))
+
+(defn list-objects
+  "List the objects in an S3 bucket. A optional map of options may be supplied.
+  Available options are:
+    :delimiter - read only keys up to the next delimiter (such as a '/')
+    :marker    - read objects after this key
+    :max-keys  - read only this many objects
+    :prefix    - read only objects with this prefix
+
+  The object listing will be returned as a map containing the following keys:
+    :bucket          - the name of the bucket
+    :prefix          - the supplied prefix (or nil if none supplied)
+    :objects         - a list of objects
+    :common-prefixes - the common prefixes of keys omitted by the delimiter
+    :max-keys        - the maximum number of objects to be returned
+    :truncated?      - true if the list of objects was truncated
+    :marker          - the marker of the listing
+    :next-marker     - the next marker of the listing"
+  [cred bucket & [options]]
+  (to-map
+   (.listObjects
+    (s3-client cred)
+    (map->ListObjectsRequest (merge {:bucket bucket} options)))))
+
+(defn delete-object
+  "Delete an object from an S3 bucket."
+  [cred bucket key]
+  (.deleteObject (s3-client cred) bucket key))
+
+(defn object-exists?
+  "Returns true if an object exists in the supplied bucket and key."
+  [cred bucket key]
+  (try
+    (get-object-metadata cred bucket key)
+    true
+    (catch AmazonServiceException e
+      (if (= 404 (.getStatusCode e))
+        false
+        (throw e)))))
+
+(defn copy-object
+  "Copy an existing S3 object to another key. Returns a map containing
+   the data returned from S3"
+  ([cred bucket src-key dest-key]
+     (copy-object cred bucket src-key bucket dest-key))
+  ([cred src-bucket src-key dest-bucket dest-key]
+     (to-map (.copyObject (s3-client cred) src-bucket src-key dest-bucket dest-key))))
+
+(defn- map->ListVersionsRequest
+  "Create a ListVersionsRequest instance from a map of values."
+  [request]
+  (doto (ListVersionsRequest.)
+    (set-attr .setBucketName      (:bucket request))
+    (set-attr .setDelimiter       (:delimiter request))
+    (set-attr .setKeyMarker       (:key-marker request))
+    (set-attr .setMaxResults      (maybe-int (:max-results request)))
+    (set-attr .setPrefix          (:prefix request))
+    (set-attr .setVersionIdMarker (:version-id-marker request))))
+
+(defn list-versions
+ "List the versions in an S3 bucket. A optional map of options may be supplied.
+  Available options are:
+    :delimiter         - the delimiter used in prefix (such as a '/')
+    :key-marker        - read versions from the sorted list of all versions starting
+                         at this marker.
+    :max-results       - read only this many versions
+    :prefix            - read only versions with keys having this prefix
+    :version-id-marker - read objects after this version id
+
+  The version listing will be returned as a map containing the following versions:
+    :bucket                 - the name of the bucket
+    :prefix                 - the supplied prefix (or nil if none supplied)
+    :versions               - a sorted list of versions, newest first, each
+                              version has:
+                              :version-id     - the unique version id
+                              :latest?        - is this the latest version for that key?
+                              :delete-marker? - is this a delete-marker?
+    :common-prefixes        - the common prefixes of keys omitted by the delimiter
+    :max-results            - the maximum number of results to be returned
+    :truncated?             - true if the results were truncated
+    :key-marker             - the key marker of the listing
+    :next-version-id-marker - the version ID marker to use in the next listVersions
+                              request in order to obtain the next page of results.
+    :version-id-marker      - the version id marker of the listing"
+ [cred bucket & [options]]
+ (to-map
+   (.listVersions
+    (s3-client cred)
+    (map->ListVersionsRequest (merge {:bucket bucket} options)))))
+
+(defn delete-version
+  "Deletes a specific version of the specified object in the specified bucket."
+  [cred bucket key version-id]
+  (.deleteVersion (s3-client cred) bucket key version-id))
+
+(defprotocol ^{:no-doc true} ToClojure
+  "Convert an object into an idiomatic Clojure value."
+  (^{:no-doc true} to-clojure [x] "Turn the object into a Clojure value."))
+
+(extend-protocol ToClojure
+  CanonicalGrantee
+  (to-clojure [grantee]
+    {:id           (.getIdentifier grantee)
+     :display-name (.getDisplayName grantee)})
+  EmailAddressGrantee
+  (to-clojure [grantee]
+    {:email (.getIdentifier grantee)})
+  GroupGrantee
+  (to-clojure [grantee]
+    (condp = grantee
+      GroupGrantee/AllUsers           :all-users
+      GroupGrantee/AuthenticatedUsers :authenticated-users
+      GroupGrantee/LogDelivery        :log-delivery))
+  Permission
+  (to-clojure [permission]
+    (condp = permission
+      Permission/FullControl :full-control
+      Permission/Read        :read
+      Permission/ReadAcp     :read-acp
+      Permission/Write       :write
+      Permission/WriteAcp    :write-acp)))
+
+(extend-protocol Mappable
+  Grant
+  (to-map [grant]
+    {:grantee    (to-clojure (.getGrantee grant))
+     :permission (to-clojure (.getPermission grant))})
+  AccessControlList
+  (to-map [acl]
+    {:grants (set (map to-map (.getGrants acl)))
+     :owner  (to-map (.getOwner acl))}))
+
+(defn get-bucket-acl
+  "Get the access control list (ACL) for the supplied bucket. The ACL is a map
+  containing two keys:
+    :owner  - the owner of the ACL
+    :grants - a set of access permissions granted
+
+  The grants themselves are maps with keys:
+    :grantee    - the individual or group being granted access
+    :permission - the type of permission (:read, :write, :read-acp, :write-acp or
+                  :full-control)."
+  [cred ^String bucket]
+  (to-map (.getBucketAcl (s3-client cred) bucket)))
+
+(defn get-object-acl
+  "Get the access control list (ACL) for the supplied object. See get-bucket-acl
+  for a detailed description of the return value."
+  [cred bucket key]
+  (to-map (.getObjectAcl (s3-client cred) bucket key)))
+
+(defn- permission [perm]
+  (case perm
+    :full-control Permission/FullControl
+    :read         Permission/Read
+    :read-acp     Permission/ReadAcp
+    :write        Permission/Write
+    :write-acp    Permission/WriteAcp))
+
+(defn- grantee [grantee]
+  (cond
+   (keyword? grantee)
+     (case grantee
+      :all-users           GroupGrantee/AllUsers
+      :authenticated-users GroupGrantee/AuthenticatedUsers
+      :log-delivery        GroupGrantee/LogDelivery)
+   (:id grantee)
+     (CanonicalGrantee. (:id grantee))
+   (:email grantee)
+     (EmailAddressGrantee. (:email grantee))))
+
+(defn- clear-acl [^AccessControlList acl]
+  (doseq [grantee (->> (.getGrants acl)
+                       (map #(.getGrantee ^Grant %))
+                       (set))]
+    (.revokeAllPermissions acl grantee)))
+
+(defn- add-acl-grants [^AccessControlList acl grants]
+  (doseq [g grants]
+    (.grantPermission acl
+      (grantee (:grantee g))
+      (permission (:permission g)))))
+
+(defn- update-acl [^AccessControlList acl funcs]
+  (let [grants (:grants (to-map acl))
+        update (apply comp (reverse funcs))]
+    (clear-acl acl)
+    (add-acl-grants acl (update grants))))
+
+(defn- create-acl [permissions]
+  (doto (AccessControlList.)
+    (update-acl permissions)))
+
+(defn update-bucket-acl
+  "Update the access control list (ACL) for the named bucket using functions
+  that update a set of grants (see get-bucket-acl).
+
+  This function is often used with the grant and revoke functions, e.g.
+
+    (update-bucket-acl cred bucket
+      (grant :all-users :read)
+      (grant {:email \"foo@example.com\"} :full-control)
+      (revoke {:email \"bar@example.com\"} :write))"
+  [cred ^String bucket & funcs]
+  (let [acl (.getBucketAcl (s3-client cred) bucket)]
+    (update-acl acl funcs)
+    (.setBucketAcl (s3-client cred) bucket acl)))
+
+(defn update-object-acl
+  "Updates the access control list (ACL) for the supplied object using functions
+  that update a set of grants (see update-bucket-acl for more details)."
+  [cred ^String bucket ^String key & funcs]
+  (let [acl (.getObjectAcl (s3-client cred) bucket key)]
+    (update-acl acl funcs)
+    (.setObjectAcl (s3-client cred) bucket key acl)))
+
+(defn grant
+  "Returns a function that adds a new grant map to a set of grants.
+  See update-bucket-acl."
+  [grantee permission]
+  #(conj % {:grantee grantee :permission permission}))
+
+(defn revoke
+  "Returns a function that removes a grant map from a set of grants.
+  See update-bucket-acl."
+  [grantee permission]
+  #(disj % {:grantee grantee :permission permission}))

--- a/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
+++ b/client_tests/clojure/clj-s3/src/aws/sdk/s3.clj
@@ -22,6 +22,7 @@
            com.amazonaws.services.s3.model.Bucket
            com.amazonaws.services.s3.model.Grant
            com.amazonaws.services.s3.model.CanonicalGrantee
+           com.amazonaws.services.s3.model.CreateBucketRequest
            com.amazonaws.services.s3.model.CopyObjectResult
            com.amazonaws.services.s3.model.EmailAddressGrantee
            com.amazonaws.services.s3.model.GetObjectRequest
@@ -108,10 +109,20 @@
   [cred name]
   (.doesBucketExist (s3-client cred) name))
 
+(defn- ^CreateBucketRequest ->CreateBucketRequest
+  "Create a PutBucketRequest instance from a bucket name."
+  [^String bucket ^String key request]
+  (CreateBucketRequest. bucket))
+
+(declare create-acl) ; used by create-bucket and put-object
+
 (defn create-bucket
   "Create a new S3 bucket with the supplied name."
-  [cred ^String name]
-  (to-map (.createBucket (s3-client cred) name)))
+  [cred ^String name & [metadata & permissions]]
+  (let [req (CreateBucketRequest. name)]
+    (when permissions
+      (.setAccessControlList req (create-acl permissions)))
+    (.createBucket (s3-client cred) req)))
 
 (defn delete-bucket
   "Delete the S3 bucket with the supplied name."
@@ -188,8 +199,6 @@
       bucket key
       (:input-stream request)
       (map->ObjectMetadata (dissoc request :input-stream)))))
-
-(declare create-acl) ; used by put-object
 
 (defn put-object
   "Put a value into an S3 bucket at the specified key. The value can be

--- a/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
+++ b/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
@@ -1,4 +1,4 @@
-;; Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+;; Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
 ;;
 ;; This file is provided to you under the Apache License,
 ;; Version 2.0 (the "License"); you may not use this file
@@ -24,12 +24,8 @@
   (:require [clojure.tools.logging :as log])
   (:use midje.sweet))
 
-(def ^:internal riak-cs-host-with-protocol "http://localhost")
-(def ^:internal riak-cs-host "localhost")
-
-(defn input-stream-from-string
-  [s]
-  (java.io.ByteArrayInputStream. (.getBytes s "UTF-8")))
+(def ^:internal riak-cs-host "127.0.0.1")
+(def ^:internal riak-cs-host-with-protocol (str "http://" riak-cs-host))
 
 (defn get-riak-cs-port-str
   "Try to get a TCP port number from the OS environment"
@@ -58,25 +54,31 @@
    :proxy {:host riak-cs-host
            :port (get-riak-cs-port)}})
 
+(defn random-user
+  []
+  (user-creation/create-random-user riak-cs-host-with-protocol (get-riak-cs-port)))
+
+(defmacro with-random-user
+  "Execute `body` in implicit do with a random-user bound to `var-name`"
+  [var-name & body]
+  `(let [~var-name (random-user)]
+     (do ~@body)))
+
 (defn random-cred
   []
-  (let [new-cred (user-creation/create-random-user
-                   riak-cs-host-with-protocol
-                   (get-riak-cs-port))]
-    (user-to-cred new-cred)))
+  (user-to-cred (random-user)))
 
 (defmacro with-random-cred
-  "Execute `form` with a random-cred
-  bound to `var-name`"
-  [var-name form]
+  "Execute `body` in implicit do with a random-cred bound to `var-name`"
+  [var-name & body]
   `(let [~var-name (random-cred)]
-     ~form))
+     (do ~@body)))
 
 (defn random-string []
   (str (java.util.UUID/randomUUID)))
 
 (defn write-file [filename content]
-  (with-open [w (clojure.java.io/writer  filename :append false)]
+  (with-open [w (clojure.java.io/writer filename :append false)]
     (.write w content)))
 
 (defn etag-suffix [etag]
@@ -99,32 +101,30 @@
       => [])
 
 (let [bucket-name (random-string)]
-  (fact "creating a bucket should list
-        one bucket in list buckets"
+  (fact "creating a bucket should list one bucket in list buckets"
         (with-random-cred c
-          (do (s3/create-bucket c bucket-name)
-              ((comp :name first) (s3/list-buckets c))))
-        => bucket-name))
+          (s3/create-bucket c bucket-name)
+          (map :name (s3/list-buckets c))
+        => [bucket-name])))
 
 (let [bucket-name (random-string)
       object-name (random-string)]
   (fact "simple put works"
         (with-random-cred cred
-          (do (s3/create-bucket cred bucket-name)
-              (s3/put-object cred bucket-name object-name
-                             "contents")))
+          (s3/create-bucket cred bucket-name)
+          (s3/put-object cred bucket-name object-name
+                         "contents"))
         => truthy))
 
 (let [bucket-name (random-string)
       object-name (random-string)
       value "this is the value!"]
   (fact "the value received during GET is the same
-        as the object that was PUT"
+         as the object that was PUT"
         (with-random-cred c
-          (do (s3/create-bucket c bucket-name)
-              (s3/put-object c bucket-name object-name
-                             value)
-              ((comp slurp :content) (s3/get-object c bucket-name object-name))))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value)
+          ((comp slurp :content) (s3/get-object c bucket-name object-name)))
         => value))
 
 (let [bucket-name (random-string)
@@ -132,33 +132,31 @@
       value "this is the value!"
       as-bytes (.getBytes value "UTF-8")
       md5-sum (md5-string as-bytes)]
-  (fact "check that the etag of the response
-        is the same as the md5 of the original
-        object"
+  (fact "check that the etag of the response is the same as the md5
+         of the original object"
         (with-random-cred c
-          (do (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name
-                           value)
-            ((comp :etag :metadata)
-               (s3/get-object
-                 c bucket-name object-name))))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value)
+          ((comp :etag :metadata)
+           (s3/get-object
+            c bucket-name object-name)))
         => md5-sum))
 
 (let [bucket-name (random-string)
       object-name (random-string)
-      value (str "aaaaaaaaaa" "bbbbbbbbbb")
+      value "aaaaaaaaaabbbbbbbbbb"
       file-name "./clj-mp-test.txt"]
   (fact "multipart upload works"
         (with-random-cred c
-          (do
-            (s3/create-bucket c bucket-name)
-            (write-file file-name value)
-            (upload-file c bucket-name object-name file-name 10)
-            (let [fetched-object (s3/get-object
-                                  c bucket-name object-name)]
-              [((comp slurp :content) fetched-object)
-               ((comp etag-suffix :etag :metadata) fetched-object)])))
-        => [value, "-2"]))
+          (s3/create-bucket c bucket-name)
+          (write-file file-name value)
+          (upload-file c bucket-name object-name file-name 10)
+          (let [fetched-object (s3/get-object
+                                c bucket-name object-name)]
+            ((comp slurp :content) fetched-object)
+            => value
+            ((comp etag-suffix :etag :metadata) fetched-object)
+            => "-2"))))
 
 (let [bucket-name (random-string)
       object-name (random-string)
@@ -166,10 +164,9 @@
       wrong-md5 "2945d7de2f70de5b8c0cb3fbcba4fe92"]
   (fact "Bad content md5 throws an exception"
         (with-random-cred c
-          (do
-            (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name value
-                           {:content-md5 wrong-md5})))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value
+                         {:content-md5 wrong-md5}))
         => (throws AmazonS3Exception)))
 
 (def bad-canonical-id
@@ -181,11 +178,9 @@
   (fact "Nonexistent canonical-id grant header returns HTTP 400 on
         a put object request (not just an ACL subresource request)"
         (with-random-cred c
-          (do
-            ;; create a bucket
-            (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name value-string {}
-                           (s3/grant {:id bad-canonical-id} :full-control))))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value-string {}
+                         (s3/grant {:id bad-canonical-id} :full-control)))
         => (throws AmazonS3Exception)))
 
 (let [bucket-name (random-string)
@@ -195,15 +190,11 @@
   (fact "Creating an object with an ACL returns the same ACL when you read
         the ACL"
         (with-random-cred c
-          (do
-            ;; create a bucket
-            (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name value-string {}
-                           (s3/grant :all-users :read))
-            (contains?
-             (:grants (s3/get-object-acl c bucket-name object-name))
-             public-read-grant)))
-        => truthy))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value-string {}
+                         (s3/grant :all-users :read))
+          (:grants (s3/get-object-acl c bucket-name object-name)))
+        => (contains (just public-read-grant))))
 
 (let [bucket-name (random-string)
       object-name (random-string)
@@ -212,68 +203,47 @@
   (fact "Creating an object with an ACL returns the same ACL when you read
         the ACL"
         (with-random-cred c
-          (do
-            ;; create a bucket
-            (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name value-string {}
-                           (s3/grant :all-users :read))
-            (contains?
-             (:grants (s3/get-object-acl c bucket-name object-name))
-             public-read-grant)))
-        => truthy))
+          (s3/create-bucket c bucket-name)
+          (s3/put-object c bucket-name object-name value-string {}
+                         (s3/grant :all-users :read))
+          (:grants (s3/get-object-acl c bucket-name object-name)))
+        => (contains (just public-read-grant))))
 
 (let [bucket-name (random-string)
       object-name (random-string)
       value-string "this is the real value"]
-  (fact "Creating an object with an (non-canned) ACL returns the same ACL
-        when you read the ACL"
-        (with-random-cred c
-          (do
+  (with-random-cred c
+    (with-random-user u2
+      (fact "Creating an object with an (non-canned) ACL returns the same ACL
+             when you read the ACL"
             (s3/create-bucket c bucket-name)
-            (let [user-two (user-creation/create-random-user
-                            riak-cs-host-with-protocol
-                            (get-riak-cs-port))
-                  user-two-id (:id user-two)
-                  user-two-name (:display_name user-two)
-                  acl-grant {:grantee {:id user-two-id, :display-name user-two-name},
-                             :permission :read}]
-              (s3/put-object c bucket-name object-name value-string {}
-                             (s3/grant {:id user-two-id} :read))
-              (contains?
-                (:grants (s3/get-object-acl c bucket-name object-name))
-                acl-grant))))
-        => truthy))
+            (s3/put-object c bucket-name object-name value-string {}
+                           (s3/grant {:id (:id u2)} :read))
+            (:grants (s3/get-object-acl c bucket-name object-name))
+            => (contains (just {:grantee {:id (:id u2),
+                                          :display-name (:display_name u2)},
+                                :permission :read}))))))
 
 (let [bucket-name (random-string)
-      object-name (random-string)
-      public-read-grant {:grantee :all-users, :permission :read}]
+      object-name (random-string)]
   (fact "Creating a bucket with an ACL returns the same ACL when you read
         the ACL"
         (with-random-cred c
           (do
             (s3/create-bucket c bucket-name {}
                               (s3/grant :all-users :read))
-            (contains?
-             (:grants (s3/get-bucket-acl c bucket-name))
-             public-read-grant)))
-        => truthy))
+            (:grants (s3/get-bucket-acl c bucket-name))))
+        => (contains (just {:grantee :all-users, :permission :read}))))
 
 (let [bucket-name (random-string)
       object-name (random-string)]
-  (fact "Creating a bucket with an (non-canned) ACL returns the same ACL
-        when you read the ACL"
-        (with-random-cred c
-          (do
-            (let [user-two (user-creation/create-random-user
-                            riak-cs-host-with-protocol
-                            (get-riak-cs-port))
-                  user-two-id (:id user-two)
-                  user-two-name (:display_name user-two)
-                  acl-grant {:grantee {:id user-two-id, :display-name user-two-name},
-                             :permission :write}]
-              (s3/create-bucket c bucket-name {}
-                                (s3/grant {:id user-two-id} :write))
-              (contains?
+  (with-random-cred c
+    (with-random-user u2
+        (fact "Creating a bucket with an (non-canned) ACL returns the same ACL
+               when you read the ACL"
+               (s3/create-bucket c bucket-name {}
+                                 (s3/grant {:id (:id u2)} :write))
                (:grants (s3/get-bucket-acl c bucket-name))
-               acl-grant))))
-        => truthy))
+               => (contains (just {:grantee {:id (:id u2),
+                                             :display-name (:display_name u2)},
+                                   :permission :write}))))))

--- a/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
+++ b/client_tests/clojure/clj-s3/test/java_s3_tests/test/client.clj
@@ -17,20 +17,11 @@
 (ns java-s3-tests.test.client
   (:import java.security.MessageDigest
            org.apache.commons.codec.binary.Hex
-           com.amazonaws.services.s3.model.AmazonS3Exception
-           com.amazonaws.services.s3.model.AccessControlList
-           com.amazonaws.services.s3.model.CanonicalGrantee
-           com.amazonaws.services.s3.model.GroupGrantee
-           com.amazonaws.services.s3.model.Grant
-           com.amazonaws.services.s3.model.Permission
-           com.amazonaws.services.s3.model.PutObjectRequest
-           com.amazonaws.services.s3.model.CreateBucketRequest
-           com.amazonaws.services.s3.model.ObjectMetadata
-           com.amazonaws.services.s3.transfer.TransferManager
-           com.amazonaws.services.s3.transfer.TransferManagerConfiguration)
+           com.amazonaws.services.s3.model.AmazonS3Exception)
 
   (:require [aws.sdk.s3 :as s3])
   (:require [java-s3-tests.user-creation :as user-creation])
+  (:require [clojure.tools.logging :as log])
   (:use midje.sweet))
 
 (def ^:internal riak-cs-host-with-protocol "http://localhost")
@@ -59,22 +50,22 @@
   (let [b (md5-byte-array input-byte-array)]
     (String. (Hex/encodeHex b))))
 
-(defn random-client
+(defn random-cred
   []
   (let [new-creds (user-creation/create-random-user
-                    riak-cs-host-with-protocol
-                    (get-riak-cs-port))]
-    (s3/client (:key_id new-creds)
-               (:key_secret new-creds)
-               {:proxy-host riak-cs-host
-                :proxy-port (get-riak-cs-port)
-                :protocol :http})))
+                   riak-cs-host-with-protocol
+                   (get-riak-cs-port))]
+    {:endpoint "http://s3.amazonaws.com"
+     :access-key (:key_id new-creds)
+     :secret-key (:key_secret new-creds)
+     :proxy {:host riak-cs-host
+             :port (get-riak-cs-port)}}))
 
-(defmacro with-random-client
-  "Execute `form` with a random-client
+(defmacro with-random-cred
+  "Execute `form` with a random-cred
   bound to `var-name`"
   [var-name form]
-  `(let [~var-name (random-client)]
+  `(let [~var-name (random-cred)]
      ~form))
 
 (defn random-string []
@@ -87,55 +78,41 @@
 (defn etag-suffix [etag]
   (subs etag (- (count etag) 2)))
 
-(defn create-manager [c]
-  (TransferManager. c))
-
-(defn configure-manager [tm]
-  (let [tm-config (.getConfiguration tm)]
-    (.setMultipartUploadThreshold tm-config 19)
-    (.setMinimumUploadPartSize tm-config 10)
-    (.setConfiguration tm tm-config)))
-
-(defn create-and-configure-manager [c]
-  (let [tm (create-manager c)]
-    (configure-manager tm)
-    tm))
-
-(defn upload-file [tm bucket-name object-name file-name]
-  (let [f (clojure.java.io/file file-name)
-        u (.upload tm bucket-name object-name f)]
-    (.waitForCompletion u)
+(defn upload-file [cred bucket key file-name part-size]
+  (let [f (clojure.java.io/file file-name)]
+    (s3/put-multipart-object cred bucket key f {:part-size part-size :threads 2})
     (.delete f)))
 
 (fact "bogus creds raises an exception"
-      (let [bogus-client
-            (s3/client "foo"
-                       "bar"
-                       {:endpoint (str "http://localhost:"
-                                       (get-riak-cs-port-str))})]
-        (s3/list-buckets bogus-client))
+      (let [bogus-cred
+            {:endpoint "http://s3.amazonaws.com"
+             :access-key "goo"
+             :secret-key "bar"
+             :proxy {:host riak-cs-host
+                     :port (get-riak-cs-port)}}]
+        (s3/list-buckets bogus-cred))
       => (throws AmazonS3Exception))
 
 (fact "new users have no buckets"
-        (with-random-client c
-          (s3/list-buckets c))
-        => [])
+      (with-random-cred c
+        (s3/list-buckets c))
+      => [])
 
 (let [bucket-name (random-string)]
   (fact "creating a bucket should list
         one bucket in list buckets"
-        (with-random-client c
+        (with-random-cred c
           (do (s3/create-bucket c bucket-name)
-            ((comp :name first) (s3/list-buckets c))))
+              ((comp :name first) (s3/list-buckets c))))
         => bucket-name))
 
 (let [bucket-name (random-string)
       object-name (random-string)]
   (fact "simple put works"
-        (with-random-client c
-          (do (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name
-                           "contents")))
+        (with-random-cred cred
+          (do (s3/create-bucket cred bucket-name)
+              (s3/put-object cred bucket-name object-name
+                             "contents")))
         => truthy))
 
 (let [bucket-name (random-string)
@@ -143,11 +120,11 @@
       value "this is the value!"]
   (fact "the value received during GET is the same
         as the object that was PUT"
-        (with-random-client c
+        (with-random-cred c
           (do (s3/create-bucket c bucket-name)
-            (s3/put-object c bucket-name object-name
-                           value)
-            ((comp slurp :content) (s3/get-object c bucket-name object-name))))
+              (s3/put-object c bucket-name object-name
+                             value)
+              ((comp slurp :content) (s3/get-object c bucket-name object-name))))
         => value))
 
 (let [bucket-name (random-string)
@@ -158,7 +135,7 @@
   (fact "check that the etag of the response
         is the same as the md5 of the original
         object"
-        (with-random-client c
+        (with-random-cred c
           (do (s3/create-bucket c bucket-name)
             (s3/put-object c bucket-name object-name
                            value)
@@ -171,17 +148,16 @@
       object-name (random-string)
       value (str "aaaaaaaaaa" "bbbbbbbbbb")
       file-name "./clj-mp-test.txt"]
-  (fact "mulitpart upload works"
-        (with-random-client c
+  (fact "multipart upload works"
+        (with-random-cred c
           (do
             (s3/create-bucket c bucket-name)
-            (let [tm (create-and-configure-manager c)]
-              (write-file file-name value)
-              (upload-file tm bucket-name object-name file-name)
-              (let [fetched-object (s3/get-object
-                                      c bucket-name object-name)]
-                  [((comp slurp :content) fetched-object)
-                   ((comp etag-suffix :etag :metadata) fetched-object)]))))
+            (write-file file-name value)
+            (upload-file c bucket-name object-name file-name 10)
+            (let [fetched-object (s3/get-object
+                                  c bucket-name object-name)]
+              [((comp slurp :content) fetched-object)
+               ((comp etag-suffix :etag :metadata) fetched-object)])))
         => [value, "-2"]))
 
 (let [bucket-name (random-string)
@@ -189,7 +165,7 @@
       value "this is the real value"
       wrong-md5 "2945d7de2f70de5b8c0cb3fbcba4fe92"]
   (fact "Bad content md5 throws an exception"
-        (with-random-client c
+        (with-random-cred c
           (do
             (s3/create-bucket c bucket-name)
             (s3/put-object c bucket-name object-name value
@@ -199,61 +175,51 @@
 (def bad-canonical-id
   "0f80b2d002a3d018faaa4a956ce8aa243332a30e878f5dc94f82749984ebb30b")
 
-(def full-control
-  (Permission/FullControl))
-
-(def read-grant
-  (Permission/Read))
-
-(def write-grant
-  (Permission/Write))
-
 (let [bucket-name (random-string)
       object-name (random-string)
       value-string "this is the real value"]
   (fact "Nonexistent canonical-id grant header returns HTTP 400 on
         a put object request (not just an ACL subresource request)"
-        (with-random-client c
+        (with-random-cred c
           (do
             ;; create a bucket
             (s3/create-bucket c bucket-name)
-
-            (let [value (input-stream-from-string value-string)
-                  bad-id-grantee (CanonicalGrantee. bad-canonical-id)
-                  metadata (ObjectMetadata.)
-                  req (PutObjectRequest. bucket-name object-name value metadata)
-                  acl (AccessControlList.)]
-
-              ;; grant permission to the nonexistent-user
-              (.grantPermission acl bad-id-grantee full-control)
-
-              (.setAccessControlList req acl)
-              (.putObject c req))))
+            (s3/put-object c bucket-name object-name value-string {}
+                           (s3/grant {:id bad-canonical-id} :full-control))))
         => (throws AmazonS3Exception)))
-
-(def all-users (GroupGrantee/AllUsers))
 
 (let [bucket-name (random-string)
       object-name (random-string)
       value-string "this is the real value"
-      grant (Grant. all-users read-grant)]
+      public-read-grant {:grantee :all-users, :permission :read}]
   (fact "Creating an object with an ACL returns the same ACL when you read
         the ACL"
-        (with-random-client c
+        (with-random-cred c
           (do
             ;; create a bucket
             (s3/create-bucket c bucket-name)
+            (s3/put-object c bucket-name object-name value-string {}
+                           (s3/grant :all-users :read))
+            (contains?
+             (:grants (s3/get-object-acl c bucket-name object-name))
+             public-read-grant)))
+        => truthy))
 
-            (let [value (input-stream-from-string value-string)
-                  metadata (ObjectMetadata.)
-                  acl (AccessControlList.)
-                  req (PutObjectRequest. bucket-name object-name value metadata)]
-              (.grantPermission acl all-users read-grant)
-              (.setAccessControlList req acl)
-              (.putObject c req)
-              (contains?
-                (.getGrants (.getObjectAcl c bucket-name object-name))
-                grant))))
+(let [bucket-name (random-string)
+      object-name (random-string)
+      value-string "this is the real value"
+      public-read-grant {:grantee :all-users, :permission :read}]
+  (fact "Creating an object with an ACL returns the same ACL when you read
+        the ACL"
+        (with-random-cred c
+          (do
+            ;; create a bucket
+            (s3/create-bucket c bucket-name)
+            (s3/put-object c bucket-name object-name value-string {}
+                           (s3/grant :all-users :read))
+            (contains?
+             (:grants (s3/get-object-acl c bucket-name object-name))
+             public-read-grant)))
         => truthy))
 
 (let [bucket-name (random-string)
@@ -261,59 +227,56 @@
       value-string "this is the real value"]
   (fact "Creating an object with an (non-canned) ACL returns the same ACL
         when you read the ACL"
-        (with-random-client c
+        (with-random-cred c
           (do
-            ;; create a bucket
             (s3/create-bucket c bucket-name)
-
-            (let [value (input-stream-from-string value-string)
-                  metadata (ObjectMetadata.)
-                  user-two-id (:id (user-creation/create-random-user
-                                     riak-cs-host-with-protocol
-                                     (get-riak-cs-port)))
-                  id-grantee (CanonicalGrantee. user-two-id)
-                  grant (Grant. id-grantee read-grant)
-                  acl (AccessControlList.)
-                  req (PutObjectRequest. bucket-name object-name value metadata)]
-              (.grantPermission acl id-grantee read-grant)
-              (.setAccessControlList req acl)
-              (.putObject c req)
+            (let [user-two (user-creation/create-random-user
+                            riak-cs-host-with-protocol
+                            (get-riak-cs-port))
+                  user-two-id (:id user-two)
+                  user-two-name (:display_name user-two)
+                  acl-grant {:grantee {:id user-two-id, :display-name user-two-name},
+                             :permission :read}]
+              (s3/put-object c bucket-name object-name value-string {}
+                             (s3/grant {:id user-two-id} :read))
               (contains?
-                (.getGrants (.getObjectAcl c bucket-name object-name))
-                grant))))
+                (:grants (s3/get-object-acl c bucket-name object-name))
+                acl-grant))))
         => truthy))
 
 (let [bucket-name (random-string)
       object-name (random-string)
-      grant (Grant. all-users read-grant)]
+      public-read-grant {:grantee :all-users, :permission :read}]
   (fact "Creating a bucket with an ACL returns the same ACL when you read
         the ACL"
-        (with-random-client c
-            (let [acl (AccessControlList.)
-                  req (CreateBucketRequest. bucket-name)]
-              (.grantPermission acl all-users read-grant)
-              (.setAccessControlList req acl)
-              (.createBucket c req)
-              (contains?
-                (.getGrants (.getBucketAcl c bucket-name))
-                grant)))
+        (with-random-cred c
+          (do
+            ;; TODO: not created with ACL, should extend s3/create-bucket
+            (s3/create-bucket c bucket-name)
+            (s3/update-bucket-acl c bucket-name
+                                  (s3/grant :all-users :read))
+            (contains?
+             (:grants (s3/get-bucket-acl c bucket-name))
+             public-read-grant)))
         => truthy))
 
 (let [bucket-name (random-string)]
   (fact "Creating a bucket with an (non-canned) ACL returns the same ACL
         when you read the ACL"
-        (with-random-client c
-          (let [user-two-id (:id (user-creation/create-random-user
-                                   riak-cs-host-with-protocol
-                                   (get-riak-cs-port)))
-                id-grantee (CanonicalGrantee. user-two-id)
-                grant (Grant. id-grantee write-grant)
-                acl (AccessControlList.)
-                req (CreateBucketRequest. bucket-name)]
-            (.grantPermission acl id-grantee write-grant)
-            (.setAccessControlList req acl)
-            (.createBucket c req)
-            (contains?
-              (.getGrants (.getBucketAcl c bucket-name))
-              grant)))
+        (with-random-cred c
+          (do
+            (let [user-two (user-creation/create-random-user
+                            riak-cs-host-with-protocol
+                            (get-riak-cs-port))
+                  user-two-id (:id user-two)
+                  user-two-name (:display_name user-two)
+                  acl-grant {:grantee {:id user-two-id, :display-name user-two-name},
+                             :permission :write}]
+              ;; TODO: not created with ACL, should extend s3/create-bucket
+              (s3/create-bucket c bucket-name)
+              (s3/update-bucket-acl c bucket-name
+                                    (s3/grant {:id user-two-id} :write))
+              (contains?
+               (:grants (s3/get-bucket-acl c bucket-name))
+               acl-grant))))
         => truthy))


### PR DESCRIPTION
This PR's main purpose is to update version of aws-sdk-java in client tests to latest `1.10.8`.

As side effects...
- Use proxy settings in upstream master https://github.com/weavejester/clj-aws-s3
  instead of proxy support by forked one
- Include `s3.clj` from clj-aws-s3 repository (at commit `b01c0f1`)
  because it is single file thin wrapper, no test and to make updating easier.
- Update other dependent library versions
