### PR TITLE
[WIP] Change ceph/s3-tests branch to updated one for Riak CS 2.1 release

### DIFF
--- a/client_tests/python/ceph_tests/Makefile
+++ b/client_tests/python/ceph_tests/Makefile
@@ -7,7 +7,7 @@ BIN = env/bin
 all: test
 
 s3-tests:
-	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-2.0
+	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-2.1
 
 env:
 	@cd s3-tests && virtualenv env


### PR DESCRIPTION
Update ceph's s3-tests for Riak CS 2.1 release.

For reviewer, please review with https://github.com/basho/s3-tests/pull/3
