### PR TITLE
Update ceph s3 tests for Riak CS 2.1.0 with bug fixes

### DIFF
--- a/client_tests/python/boto_tests/boto_test.py
+++ b/client_tests/python/boto_tests/boto_test.py
@@ -568,7 +568,7 @@ class BucketPolicyTest(S3ApiVerificationTestBase):
             self.fail()
         except S3ResponseError as e:
             self.assertEqual(e.status, 404)
-            self.assertEqual(e.reason, 'Object Not Found')
+            self.assertEqual(e.reason, 'Not Found')
 
         policy = '''
 {"Version":"2008-10-17","Statement":[{"Sid":"Stmtaaa","Effect":"Allow","Principal":"*","Action":["s3:GetObject"],"Resource":"arn:aws:s3:::%s/*","Condition":{"IpAddress":{"aws:SourceIp":"%s"}}}]}
@@ -877,7 +877,7 @@ class SimpleCopyTest(S3ApiVerificationTestBase):
         except S3ResponseError as e:
             print e
             self.assertEqual(e.status, 404)
-            self.assertEqual(e.reason, 'Object Not Found')
+            self.assertEqual(e.reason, 'Not Found')
     
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/client_tests/python/ceph_tests/Makefile
+++ b/client_tests/python/ceph_tests/Makefile
@@ -3,11 +3,20 @@
 
 DEPS = env/lib/python2.7/site-packages
 BIN = env/bin
+NOSE_ARGS = s3tests.functional.test_s3 -A
+NOSE_ATTR = (method != "post")
+NOSE_ATTR += and (resource != "bucket.log")
+NOSE_ATTR += and (not versioning)
+NOSE_ATTR += and (not cors)
+NOSE_ATTR += and (not fails_on_aws)
+NOSE_ATTR += and (not fails_with_subdomain)
+NOSE_ATTR += and (not fails_on_rcs)
 
 all: test
 
 s3-tests:
-	@git clone --quiet https://github.com/basho/s3-tests -b riakcs-2.0
+	@git clone --quiet https://github.com/basho/s3-tests \
+		-b riakcs-2.1
 
 env:
 	@cd s3-tests && virtualenv env
@@ -18,7 +27,8 @@ $(DEPS) $(BIN): s3-tests env
 test: $(DEPS) $(BIN)
 	@echo $(CS_HTTP_PORT)
 	@./s3_conf.sh > s3-tests/s3test.conf
-	@cd s3-tests && S3TEST_CONF=s3test.conf env/bin/nosetests s3tests.functional.test_s3
+	cd s3-tests && \
+	    S3TEST_CONF=s3test.conf env/bin/nosetests $(NOSE_ARGS) '$(NOSE_ATTR)'
 
 clean:
 	@rm -rf s3-tests

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -27,6 +27,7 @@
 -include("riak_cs.hrl").
 
 -export([test_condition_and_permission/4,
+         malformed_request/1,
          new_metadata/2,
          get_copy_source/1,
          start_put_fsm/7,
@@ -102,6 +103,17 @@ authorize_on_src(RcPid, SrcManifest, RD,
     _ = riak_cs_wm_utils:object_access_authorize_helper(object, false,
                                                         OtherRD, OtherCtx).
 
+-spec malformed_request(#wm_reqdata{}) ->
+                               false |
+                               {true, {invalid_argument, string(), string()}}.
+malformed_request(RD) ->
+    MDDirectiveKey = "x-amz-metadata-directive",
+    case wrq:get_req_header(MDDirectiveKey, RD) of
+        undefined -> false;
+        "REPLACE" -> false;
+        "COPY"    -> false;
+        Value     -> {true, {invalid_argument, MDDirectiveKey, Value}}
+    end.
 
 %% @doc just kicks up put fsm
 -spec new_metadata(lfs_manifest(), #wm_reqdata{}) -> {binary(), [{string(), string()}]}.

--- a/src/riak_cs_oos_response.erl
+++ b/src/riak_cs_oos_response.erl
@@ -154,6 +154,7 @@ error_message(invalid_argument) -> "Invalid Argument";
 error_message(unresolved_grant_email) -> "The e-mail address you provided does not match any account on record.";
 error_message(invalid_range) -> "The requested range is not satisfiable";
 error_message(invalid_bucket_name) -> "The specified bucket is not valid.";
+error_message(not_implemented) -> "A request you provided implies functionality that is not implemented";
 error_message(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "Please reduce your request rate.".
@@ -189,6 +190,7 @@ error_code(invalid_argument) -> "InvalidArgument";
 error_code(invalid_range) -> "InvalidRange";
 error_code(invalid_bucket_name) -> "InvalidBucketName";
 error_code(unresolved_grant_email) -> "UnresolvableGrantByEmailAddress";
+error_code(not_implemented) -> "NotImplemented";
 error_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "ServiceUnavailable".
@@ -230,6 +232,7 @@ status_code(invalid_argument) -> 400;
 status_code(unresolved_grant_email) -> 400;
 status_code(invalid_range) -> 416;
 status_code(invalid_bucket_name) -> 400;
+status_code(not_implemented) -> 501;
 status_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     503.

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -222,6 +222,8 @@ respond({ok, ?LORESP{}=Response}, RD, Ctx) ->
 respond({error, _}=Error, RD, Ctx) ->
     api_error(Error, RD, Ctx).
 
+respond(404 = _StatusCode, Body, ReqData, Ctx) ->
+    respond({404, "Not Found"}, Body, ReqData, Ctx);
 respond(StatusCode, Body, ReqData, Ctx) ->
      UpdReqData = wrq:set_resp_body(Body,
                                     wrq:set_resp_header("Content-Type",

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -106,6 +106,7 @@ error_message(unexpected_content) -> "This request does not support content";
 error_message(canned_acl_and_header_grant) -> "Specifying both Canned ACLs and Header Grants is not allowed";
 error_message(malformed_xml) -> "The XML you provided was not well-formed or did not validate against our published schema";
 error_message(remaining_multipart_upload) -> "Concurrent multipart upload initiation detected. Please stop it to delete bucket.";
+error_message(not_implemented) -> "A request you provided implies functionality that is not implemented";
 error_message(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "Please reduce your request rate.".
@@ -154,6 +155,7 @@ error_code(canned_acl_and_header_grant) -> "InvalidRequest";
 error_code(malformed_acl_error) -> "MalformedACLError";
 error_code(malformed_xml) -> "MalformedXML";
 error_code(remaining_multipart_upload) -> "MultipartUploadRemaining";
+error_code(not_implemented) -> "NotImplemented";
 error_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     "ServiceUnavailable".
@@ -209,6 +211,7 @@ status_code(canned_acl_and_header_grant) -> 400;
 status_code(malformed_acl_error) -> 400;
 status_code(malformed_xml) -> 400;
 status_code(remaining_multipart_upload) -> 409;
+status_code(not_implemented) -> 501;
 status_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     503.

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -304,12 +304,16 @@ copy_response(Manifest, TagName, RD, Ctx) ->
     respond(200, riak_cs_xml:to_xml(XmlDoc), RD, Ctx).
 
 
-no_such_upload_response(UploadId, RD, Ctx) ->
+no_such_upload_response(InternalUploadId, RD, Ctx) ->
+    UploadId = case InternalUploadId of
+                   {raw, ReqUploadId} -> ReqUploadId;
+                   _ -> base64url:encode(InternalUploadId)
+               end,
     XmlDoc = {'Error',
               [
                {'Code', [error_code(no_such_upload)]},
                {'Message', [error_message(no_such_upload)]},
-               {'UploadId', [base64url:encode(UploadId)]},
+               {'UploadId', [UploadId]},
                {'HostId', ["host-id"]}
               ]},
     Body = riak_cs_xml:to_xml([XmlDoc]),

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -45,7 +45,6 @@
                       | {'riak_connect_failed', term()}
                       | {'malformed_policy_version', string()}
                       | {'invalid_argument', string()}.
-
 -spec error_message(error_reason()) -> string().
 error_message(invalid_access_key_id) ->
     "The AWS Access Key Id you provided does not exist in our records.";
@@ -167,54 +166,54 @@ error_code(ErrorName) ->
 %% http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 
 -spec status_code(error_reason()) -> pos_integer().
-status_code(invalid_access_key_id) -> 403;
-status_code(invalid_email_address) -> 400;
-status_code(access_denied) ->  403;
-status_code(copy_source_access_denied) ->  403;
-status_code(reqtime_tooskewed) -> 403;
-status_code(bucket_not_empty) ->  409;
-status_code(bucket_already_exists) -> 409;
-status_code(user_already_exists) -> 409;
-status_code(toomanybuckets) -> 400;
+status_code(invalid_access_key_id)         -> 403;
+status_code(invalid_email_address)         -> 400;
+status_code(access_denied)                 -> 403;
+status_code(copy_source_access_denied)     -> 403;
+status_code(reqtime_tooskewed)             -> 403;
+status_code(bucket_not_empty)              -> 409;
+status_code(bucket_already_exists)         -> 409;
+status_code(user_already_exists)           -> 409;
+status_code(toomanybuckets)                -> 400;
 %% yes, 400, really, not 413
-status_code(entity_too_large) -> 400;
-status_code(entity_too_small) -> 400;
-status_code(bad_etag) -> 400;
-status_code(bad_etag_order) -> 400;
-status_code(invalid_user_update) -> 400;
-status_code(no_such_bucket) -> 404;
-status_code(no_such_key) -> 404;
-status_code(no_copy_source_key) -> 404;
-status_code({riak_connect_failed, _}) -> 503;
-status_code(admin_key_undefined) -> 503;
-status_code(admin_secret_undefined) -> 503;
-status_code(bucket_owner_unavailable) -> 503;
-status_code(multiple_bucket_owners) -> 503;
-status_code(econnrefused) -> 503;
-status_code(unsatisfied_constraint) -> 503;
-status_code(malformed_policy_json) -> 400;
+status_code(entity_too_large)              -> 400;
+status_code(entity_too_small)              -> 400;
+status_code(bad_etag)                      -> 400;
+status_code(bad_etag_order)                -> 400;
+status_code(invalid_user_update)           -> 400;
+status_code(no_such_bucket)                -> 404;
+status_code(no_such_key)                   -> 404;
+status_code(no_copy_source_key)            -> 404;
+status_code({riak_connect_failed, _})      -> 503;
+status_code(admin_key_undefined)           -> 503;
+status_code(admin_secret_undefined)        -> 503;
+status_code(bucket_owner_unavailable)      -> 503;
+status_code(multiple_bucket_owners)        -> 503;
+status_code(econnrefused)                  -> 503;
+status_code(unsatisfied_constraint)        -> 503;
+status_code(malformed_policy_json)         -> 400;
 status_code({malformed_policy_version, _}) -> 400;
-status_code(malformed_policy_missing) -> 400;
-status_code(malformed_policy_resource) -> 400;
-status_code(malformed_policy_principal) -> 400;
-status_code(malformed_policy_action) -> 400;
-status_code(malformed_policy_condition) -> 400;
-status_code({auth_not_supported, _}) -> 400;
-status_code(no_such_bucket_policy) -> 404;
-status_code(no_such_upload) -> 404;
-status_code(invalid_digest) -> 400;
-status_code(bad_request) -> 400;
-status_code(invalid_argument) -> 400;
-status_code(unresolved_grant_email) -> 400;
-status_code(invalid_range) -> 416;
-status_code(invalid_bucket_name) -> 400;
-status_code(invalid_part_number) -> 400;
-status_code(unexpected_content) -> 400;
-status_code(canned_acl_and_header_grant) -> 400;
-status_code(malformed_acl_error) -> 400;
-status_code(malformed_xml) -> 400;
-status_code(remaining_multipart_upload) -> 409;
-status_code(not_implemented) -> 501;
+status_code(malformed_policy_missing)      -> 400;
+status_code(malformed_policy_resource)     -> 400;
+status_code(malformed_policy_principal)    -> 400;
+status_code(malformed_policy_action)       -> 400;
+status_code(malformed_policy_condition)    -> 400;
+status_code({auth_not_supported, _})       -> 400;
+status_code(no_such_bucket_policy)         -> 404;
+status_code(no_such_upload)                -> 404;
+status_code(invalid_digest)                -> 400;
+status_code(bad_request)                   -> 400;
+status_code(invalid_argument)              -> 400;
+status_code(unresolved_grant_email)        -> 400;
+status_code(invalid_range)                 -> 416;
+status_code(invalid_bucket_name)           -> 400;
+status_code(invalid_part_number)           -> 400;
+status_code(unexpected_content)            -> 400;
+status_code(canned_acl_and_header_grant)   -> 400;
+status_code(malformed_acl_error)           -> 400;
+status_code(malformed_xml)                 -> 400;
+status_code(remaining_multipart_upload)    -> 409;
+status_code(not_implemented)               -> 501;
 status_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
     503.
@@ -283,7 +282,7 @@ error_resource(_Tag, RD) ->
     {OrigResource, _} = riak_cs_s3_rewrite:original_resource(RD),
     OrigResource.
 
-toomanybuckets_response(Current,BucketLimit,RD,Ctx) ->
+toomanybuckets_response(Current, BucketLimit, RD, Ctx) ->
     XmlDoc = {'Error',
               [
                {'Code', [error_code(toomanybuckets)]},
@@ -394,5 +393,3 @@ process_xml_error([HeadElement | RestElements]) ->
         _ ->
             process_xml_error(RestElements)
     end.
-
-

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -98,6 +98,8 @@ error_message(invalid_digest) ->
     "The Content-MD5 you specified was invalid.";
 error_message(bad_request) -> "Bad Request";
 error_message(invalid_argument) -> "Invalid Argument";
+error_message({invalid_argument, "x-amz-metadata-directive"}) ->
+    "Unknown metadata directive.";
 error_message(unresolved_grant_email) -> "The e-mail address you provided does not match any account on record.";
 error_message(invalid_range) -> "The requested range is not satisfiable";
 error_message(invalid_bucket_name) -> "The specified bucket is not valid.";
@@ -253,6 +255,8 @@ api_error({Tag, _}=Error, RD, Ctx)
                    Ctx);
 api_error({toomanybuckets, Current, BucketLimit}, RD, Ctx) ->
     toomanybuckets_response(Current, BucketLimit, RD, Ctx);
+api_error({invalid_argument, Name, Value}, RD, Ctx) ->
+    invalid_argument_response(Name, Value, RD, Ctx);
 api_error({error, Reason}, RD, Ctx) ->
     api_error(Reason, RD, Ctx).
 
@@ -288,6 +292,18 @@ toomanybuckets_response(Current,BucketLimit,RD,Ctx) ->
               ]},
     Body = riak_cs_xml:to_xml([XmlDoc]),
     respond(status_code(toomanybuckets), Body, RD, Ctx).
+
+invalid_argument_response(Name, Value, RD, Ctx) ->
+    XmlDoc = {'Error',
+              [
+               {'Code', [error_code(invalid_argument)]},
+               {'Message', [error_message({invalid_argument, Name})]},
+               {'ArgumentName', [Name]},
+               {'ArgumentValue', [Value]},
+               {'RequestId', [""]}
+              ]},
+    Body = riak_cs_xml:to_xml([XmlDoc]),
+    respond(status_code(invalid_argument), Body, RD, Ctx).
 
 copy_object_response(Manifest, RD, Ctx) ->
     copy_response(Manifest, 'CopyObjectResult', RD, Ctx).

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -43,7 +43,8 @@
 
 -type error_reason() :: atom()
                       | {'riak_connect_failed', term()}
-                      | {'malformed_policy_version', string()}.
+                      | {'malformed_policy_version', string()}
+                      | {'invalid_argument', string()}.
 
 -spec error_message(error_reason()) -> string().
 error_message(invalid_access_key_id) ->

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -73,6 +73,7 @@ base_resources() ->
      {["buckets", bucket, "acl"], riak_cs_wm_common, props(riak_cs_wm_bucket_acl)},
      {["buckets", bucket, "location"], riak_cs_wm_common, props(riak_cs_wm_bucket_location)},
      {["buckets", bucket, "versioning"], riak_cs_wm_common, props(riak_cs_wm_bucket_versioning)},
+     {["buckets", bucket, "versions"], riak_cs_wm_common, props(riak_cs_wm_not_implemented)},
      %% Object resources
      {["buckets", bucket, "objects", object], riak_cs_wm_common, props(riak_cs_wm_object)},
      {["buckets", bucket, "objects", object, "acl"], riak_cs_wm_common, props(riak_cs_wm_object_acl)}

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -506,6 +506,8 @@ post_authentication({error, Reason}, RD, Ctx, _, _) ->
 
 update_stats_inflow(_RD, undefined = _StatsPrefix) ->
     ok;
+update_stats_inflow(_RD, no_stats = _StatsPrefix) ->
+    ok;
 update_stats_inflow(RD, StatsPrefix) ->
     Method = riak_cs_wm_utils:lower_case_method(wrq:method(RD)),
     Key = [StatsPrefix, Method],

--- a/src/riak_cs_wm_error_handler.erl
+++ b/src/riak_cs_wm_error_handler.erl
@@ -41,6 +41,15 @@ render_error(405, Req, Reason) ->
     {Path,_} = Req:path(),
     error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, {error, {error, Reason, erlang:get_stacktrace()}}]),
     {xml_error_body(Path, <<"MethodNotAllowed">>, <<"The specified method is not allowed against this resource.">>, <<"12345">>), ReqState};
+render_error(412, Req, Reason) ->
+    riak_cs_dtrace:dt_wm_entry(?MODULE, <<"render_error">>),
+    {ok, ReqState} = Req:add_response_header("Content-Type", "application/xml"),
+    {Path,_} = Req:path(),
+    error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, {error, {error, Reason, erlang:get_stacktrace()}}]),
+    {xml_error_body(Path,
+                    <<"PreconditionFailed">>,
+                    <<"At least one of the pre-conditions you specified did not hold">>,
+                    <<"12345">>), ReqState};
 render_error(_Code, Req, _Reason) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"render_error">>),
     Req:response_body().

--- a/src/riak_cs_wm_error_handler.erl
+++ b/src/riak_cs_wm_error_handler.erl
@@ -35,17 +35,15 @@ render_error(500, Req, Reason) ->
     ErrorFour = <<"this request</body></html>">>,
     IOList = [ErrorOne, ErrorTwo, ErrorThree, ErrorFour],
     {erlang:iolist_to_binary(IOList), ReqState};
-render_error(405, Req, Reason) ->
+render_error(405, Req, _Reason) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"render_error">>),
     {ok, ReqState} = Req:add_response_header("Content-Type", "application/xml"),
     {Path,_} = Req:path(),
-    error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, {error, {error, Reason, erlang:get_stacktrace()}}]),
     {xml_error_body(Path, <<"MethodNotAllowed">>, <<"The specified method is not allowed against this resource.">>, <<"12345">>), ReqState};
-render_error(412, Req, Reason) ->
+render_error(412, Req, _Reason) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"render_error">>),
     {ok, ReqState} = Req:add_response_header("Content-Type", "application/xml"),
     {Path,_} = Req:path(),
-    error_logger:error_msg("webmachine error: path=~p~n~p~n", [Path, {error, {error, Reason, erlang:get_stacktrace()}}]),
     {xml_error_body(Path,
                     <<"PreconditionFailed">>,
                     <<"At least one of the pre-conditions you specified did not hold">>,

--- a/src/riak_cs_wm_not_implemented.erl
+++ b/src/riak_cs_wm_not_implemented.erl
@@ -1,0 +1,38 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+%% @doc This resource allows all HTTP 1.1 methods, however, responds
+%%      with error by `malformed_request/2'.
+-module(riak_cs_wm_not_implemented).
+
+-export([allowed_methods/0,
+         malformed_request/2]).
+
+-include("riak_cs.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-spec allowed_methods() -> [atom()].
+allowed_methods() ->
+    ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE', 'CONNECT', 'OPTIONS'].
+
+-spec malformed_request(#wm_reqdata{}, #context{}) ->
+                               {false | {halt, _}, #wm_reqdata{}, #context{}}.
+malformed_request(RD, Ctx) ->
+    riak_cs_s3_response:api_error(not_implemented, RD, Ctx).

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -370,10 +370,12 @@ handle_copy_put(RD, Ctx, SrcBucket, SrcKey) ->
                         _ = lager:debug("copying! > ~s ~s => ~s ~s via ~p",
                                         [SrcBucket, SrcKey, Bucket, Key, ReadRcPid]),
 
-                        Metadata = riak_cs_wm_utils:extract_user_metadata(RD),
+                        {ContentType, Metadata} =
+                            riak_cs_copy_object:new_metadata(SrcManifest, RD),
                         NewAcl = Acl?ACL{creation_time=os:timestamp()},
-                        {ok, PutFsmPid} = riak_cs_copy_object:start_put_fsm(Bucket, Key, SrcManifest,
-                                                                            Metadata, NewAcl, RcPid),
+                        {ok, PutFsmPid} = riak_cs_copy_object:start_put_fsm(
+                                            Bucket, Key, SrcManifest?MANIFEST.content_length,
+                                            ContentType, Metadata, NewAcl, RcPid),
 
                         %% Prepare for connection loss or client close
                         FDWatcher = riak_cs_copy_object:connection_checker((RD#wm_reqdata.wm_state)#wm_reqstate.socket),

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -46,14 +46,19 @@ init(Ctx) ->
 stats_prefix() -> object.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
-malformed_request(RD, Ctx) ->
+malformed_request(RD, #context{response_module=ResponseMod} = Ctx) ->
     ContextWithKey = riak_cs_wm_utils:extract_key(RD, Ctx),
     case riak_cs_wm_utils:has_canned_acl_and_header_grant(RD) of
         true ->
-            riak_cs_s3_response:api_error(canned_acl_and_header_grant,
-                                          RD, ContextWithKey);
+            ResponseMod:api_error(canned_acl_and_header_grant,
+                                  RD, ContextWithKey);
         false ->
-            {false, RD, ContextWithKey}
+            case riak_cs_copy_object:malformed_request(RD) of
+                {true, Reason} ->
+                    ResponseMod:api_error(Reason, RD, ContextWithKey);
+                false ->
+                    {false, RD, ContextWithKey}
+            end
     end.
 
 %% @doc Get the type of access requested and the manifest with the

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -149,9 +149,10 @@ valid_entity_length(RD, Ctx) ->
                              {boolean() | {'halt', term()}, #wm_reqdata{}, #context{}}.
 delete_resource(RD, Ctx=#context{local_context=LocalCtx,
                                  riak_client=RcPid}) ->
-    case (catch base64url:decode(wrq:path_info('uploadId', RD))) of
+    ReqUploadId = wrq:path_info('uploadId', RD),
+    case (catch base64url:decode(ReqUploadId)) of
         {'EXIT', _Reason} ->
-            {{halt, 404}, RD, Ctx};
+            riak_cs_s3_response:no_such_upload_response({raw, ReqUploadId}, RD, Ctx);
         UploadId ->
             #key_context{bucket=Bucket, key=KeyStr} = LocalCtx,
             Key = list_to_binary(KeyStr),

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -947,7 +947,7 @@ actor_is_owner_but_denied_policy(User, RD, Ctx, Method, Deletable)
 actor_is_owner_but_denied_policy(User, RD, Ctx, Method, Deletable)
   when Method =:= 'GET' orelse
        (Deletable andalso Method =:= 'HEAD') ->
-    {{halt, 404}, riak_cs_access_log_handler:set_user(User, RD), Ctx}.
+    {{halt, {404, "Not Found"}}, riak_cs_access_log_handler:set_user(User, RD), Ctx}.
 
 -spec actor_is_owner_and_allowed_policy(User :: rcs_user(),
                                         RD :: term(),
@@ -975,7 +975,7 @@ actor_is_not_owner_and_denied_policy(OwnerId, RD, Ctx, Method, Deletable)
 actor_is_not_owner_and_denied_policy(_OwnerId, RD, Ctx, Method, Deletable)
   when Method =:= 'GET' orelse
        (Deletable andalso Method =:= 'HEAD') ->
-    {{halt, 404}, RD, Ctx}.
+    {{halt, {404, "Not Found"}}, RD, Ctx}.
 
 -spec actor_is_not_owner_but_allowed_policy(User :: rcs_user(),
                                             OwnerId :: string(),

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -155,7 +155,8 @@ list_objects_response_to_xml(Resp) ->
                 %% the `NextMarker' element if it's not `undefined'
                [make_external_node('NextMarker', NextMarker) ||
                 NextMarker <- [Resp?LORESP.next_marker],
-                NextMarker =/= undefined] ++
+                NextMarker =/= undefined,
+                Resp?LORESP.is_truncated] ++
                [make_external_node('MaxKeys', Resp?LORESP.max_keys),
                 make_external_node('Delimiter', Resp?LORESP.delimiter),
                 make_external_node('IsTruncated', Resp?LORESP.is_truncated)] ++


### PR DESCRIPTION
Main purpose of this PR is to update ceph/s3-tests to latest commit at upstream because upstream has many updates / additions to s3 test suite.

To integrate s3-tests, now nosetest attribute filter is used to minimize changes to s3-tests fork for riak cs.
The filter is implemented in `Makefile` under ceph_test/ directory.

Also, it includes a few bug fixes:
- Add XML message for 412 that WM generates
- Include UploadId in requests for cetain errors for MP requests
- Add handling of x-amz-metadata directive in PUT Object Copy
- Fix untracked parts that have to be deleted
- Don't include NextMarker element when not truncated
- Remove logging with error severity in 4xx response (not a bug strictly,
  but severity with error+ may produce big load to disk)

Following commits are niether bug fix nor refactoring, they make integration
to s3-tests somewhat easier.
- Use "Not Found" reason phrase for 404, instead of "Object Not Found"
- Add list versioned object endpoint WM callback to respond with NotImplemented
  errors

This PR requires https://github.com/basho/s3-tests/pull/4
