### PR TITLE
Verify realtime sync complete on rt [JIRA: RCS-276]

### DIFF
--- a/riak_test/src/repl_helpers.erl
+++ b/riak_test/src/repl_helpers.erl
@@ -342,6 +342,21 @@ wait_until_no_connection13(Node) ->
                 end
         end). %% 40 seconds is enough for repl
 
+wait_until_realtime_sync_complete(Nodes) ->
+    [wait_until_rtq_drained(Node)||Node <- Nodes].
+
+wait_until_rtq_drained(Node) ->
+    rt:wait_until(Node,
+        fun(_) ->
+                case rpc:call(Node, riak_repl2_rtq, dumpq, []) of
+                    [] ->
+                        true;
+                    _ ->
+                        false
+                end
+        end),
+    lager:info("Realtime sync on ~p complete", [Node]).
+
 connect_cluster13(Node, IP, Port) ->
     Res = rpc:call(Node, riak_repl_console, connect,
         [[IP, integer_to_list(Port)]]),

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -262,7 +262,7 @@ confirm() ->
 
     Object6 = crypto:rand_bytes(4194304),
     erlcloud_s3:put_object(?TEST_BUCKET, "object_six", Object6, U1C1Config),
-    timer:sleep(1000), % Sorry, but could you please wait for a while
+    repl_helpers:wait_until_realtime_sync_complete(ANodes),
     lager:info("The object can be downloaded from sink cluster"),
     Obj16 = erlcloud_s3:get_object(?TEST_BUCKET, "object_six", U1C2Config),
     ?assertEqual(Object6, proplists:get_value(content, Obj16)),


### PR DESCRIPTION
I added the rt code to wait until all RTQs get empty for ensuring realtime sync completion instead sleep 1sec. Since somehow my dev box seems poor performance, 1 sec is not enough to me. :jack_o_lantern: 
