### PR TITLE
Cuttlefishy rt

### DIFF
--- a/riak_test/README.md
+++ b/riak_test/README.md
@@ -76,13 +76,13 @@ $ git commit -m "Add 1.4 series Riak EE"
                       ]}
         ]}.
 
-{rt_cs_dev, [
+{rtcs_dev, [
   {rt_project, "riak_cs"},
      {rt_deps, [
                 "/home/kuenishi/cs-2.0/riak_cs/deps"
                ]},
      {rt_retry_delay, 500},
-     {rt_harness, rt_cs_dev},
+     {rt_harness, rtcs_dev},
      {build_paths, [{root,              "/home/kuenishi/rt/riak_ee"},
                     {current,           "/home/kuenishi/rt/riak_ee/current"},
                     {ee_root,           "/home/kuenishi/rt/riak_ee"},
@@ -108,7 +108,7 @@ $ git commit -m "Add 1.4 series Riak EE"
 ```
 
 Running the RiakCS tests for `riak_test` use a different test harness
-(`rt_cs_dev`) than running the Riak tests and so requires a separate
+(`rtcs_dev`) than running the Riak tests and so requires a separate
 configuration section. Notice the extra `riak_cs/deps` in the
 `rt_deps` section. `RT_DEST_DIR` should be replaced by the path used
 when setting up `riak_test` builds for Riak (by default
@@ -174,5 +174,5 @@ commands `make clean-client-test` and then `make compile-client-test`.
 1. To execute a test, run the following from the `riak_test` repo:
 
     ```shell
-    ./riak_test -c rt_cs_dev -t TEST_NAME
+    ./riak_test -c rtcs_dev -t TEST_NAME
     ```

--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -502,7 +502,7 @@ bitcask_data_root() -> "./data/bitcask".
 -spec bitcask_vnode_names(atom(), previous | current) -> [string()].
 bitcask_vnode_names(Node, Vsn) ->
     Prefix = rtcs_config:devpath(riak, Vsn),
-    BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rt_cs_dev:node_id(Node)),
+    BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rtcs_dev:node_id(Node)),
     {ok, VnodeDirNames} = file:list_dir(BitcaskAbsRoot),
     VnodeDirNames.
 
@@ -514,7 +514,7 @@ bitcask_vnode_names(Node, Vsn) ->
                                 [string()].
 bitcask_data_files(Node, Vsn, VnodeName, AbsOrRel) ->
     Prefix = rtcs_config:devpath(riak, Vsn),
-    BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rt_cs_dev:node_id(Node)),
+    BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rtcs_dev:node_id(Node)),
     VnodeAbsPath = filename:join(BitcaskAbsRoot, VnodeName),
     {ok, Fs0} = file:list_dir(VnodeAbsPath),
     [case AbsOrRel of

--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -171,7 +171,7 @@ init_circle(Tag, #state{admin_config=AdminConfig, riak_nodes = [RiakNode|_]} = _
     Name = concat("user-", Tag),
     Email = concat(Name, "@example.com"),
     {AccessKeyId, SecretAccessKey, _Id} =
-        rtcs:create_user(Port, AdminConfig, Email, Name),
+        rtcs_admin:create_user(Port, AdminConfig, Email, Name),
     UserConfig = rtcs_config:config(AccessKeyId, SecretAccessKey, Port),
     #circle{tag = Tag, user_config = UserConfig}.
 

--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -501,7 +501,7 @@ bitcask_data_root() -> "./data/bitcask".
 %% For example: "548063113999088594326381812268606132370974703616"
 -spec bitcask_vnode_names(atom(), previous | current) -> [string()].
 bitcask_vnode_names(Node, Vsn) ->
-    Prefix = rtcs_config:get_rt_config(riak, Vsn),
+    Prefix = rtcs_config:devpath(riak, Vsn),
     BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rt_cs_dev:node_id(Node)),
     {ok, VnodeDirNames} = file:list_dir(BitcaskAbsRoot),
     VnodeDirNames.
@@ -513,7 +513,7 @@ bitcask_vnode_names(Node, Vsn) ->
 -spec bitcask_data_files(node(), previous | current, string(), abs | rel) ->
                                 [string()].
 bitcask_data_files(Node, Vsn, VnodeName, AbsOrRel) ->
-    Prefix = rtcs_config:get_rt_config(riak, Vsn),
+    Prefix = rtcs_config:devpath(riak, Vsn),
     BitcaskAbsRoot = rtcs_config:riak_bitcaskroot(Prefix, rt_cs_dev:node_id(Node)),
     VnodeAbsPath = filename:join(BitcaskAbsRoot, VnodeName),
     {ok, Fs0} = file:list_dir(VnodeAbsPath),

--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -170,9 +170,8 @@ init_circle(Tag, #state{admin_config=AdminConfig, riak_nodes = [RiakNode|_]} = _
     Port = rtcs_config:cs_port(RiakNode),
     Name = concat("user-", Tag),
     Email = concat(Name, "@example.com"),
-    {AccessKeyId, SecretAccessKey, _Id} =
+    {UserConfig, _Id} =
         rtcs_admin:create_user(Port, AdminConfig, Email, Name),
-    UserConfig = rtcs_config:config(AccessKeyId, SecretAccessKey, Port),
     #circle{tag = Tag, user_config = UserConfig}.
 
 -spec apply_operations(circle(), state(), [op()]) -> {ok, state()}.

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -188,7 +188,7 @@ set_advanced_conf(Node, NameValuePairs) when is_atom(Node) ->
     update_app_config_file(get_app_config(Node), NameValuePairs),
     ok;
 set_advanced_conf(DevPath, NameValuePairs) ->
-    AdvancedConfs = case all_the_files(DevPath, "etc/advanced.config") of
+    AdvancedConfs = case all_the_files(DevPath, "etc/a*.config") of
                         [] ->
                             %% no advanced conf? But we _need_ them, so make 'em
                             rtdev:make_advanced_confs(DevPath);

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -538,7 +538,7 @@ all_the_files(DevPath, File) ->
     end.
 
 devpath(Name, Vsn) ->
-    rtcs_config:get_rt_config(Name, Vsn).
+    rtcs_config:devpath(Name, Vsn).
 
 versions() ->
     proplists:get_keys(rt_config:get(build_paths)) -- [root].

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -23,8 +23,6 @@
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
--define(DEVS(N), lists:concat(["dev", N, "@127.0.0.1"])).
--define(DEV(N), list_to_atom(?DEVS(N))).
 -define(BUILD_PATHS, (rt_config:get(build_paths))).
 -define(SRC_PATHS, (rt_config:get(src_paths))).
 

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -154,6 +154,10 @@ set_conf({Name, Vsn}, NameValuePairs) ->
     lager:info("rt_cs_dev:set_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
     set_conf(devpath(Name, Vsn), NameValuePairs),
     ok;
+set_conf({Name, Vsn, N}, NameValuePairs) ->
+    lager:info("rt_cs_dev:set_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
+    rtdev:append_to_conf_file(get_conf(devpath(Name, Vsn), N), NameValuePairs),
+    ok;
 set_conf(Node, NameValuePairs) when is_atom(Node) ->
     rtdev:append_to_conf_file(get_conf(Node), NameValuePairs),
     ok;
@@ -176,8 +180,12 @@ set_advanced_conf({Name, Vsn}, NameValuePairs) ->
     lager:info("rt_cs_dev:set_advanced_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
     set_advanced_conf(devpath(Name, Vsn), NameValuePairs),
     ok;
+set_advanced_conf({Name, Vsn, N}, NameValuePairs) ->
+    lager:info("rt_cs_dev:set_advanced_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
+    update_app_config_file(get_app_config(devpath(Name, Vsn), N), NameValuePairs),
+    ok;
 set_advanced_conf(Node, NameValuePairs) when is_atom(Node) ->
-    rtdev:append_to_conf_file(get_conf(Node), NameValuePairs),
+    update_app_config_file(get_app_config(Node), NameValuePairs),
     ok;
 set_advanced_conf(DevPath, NameValuePairs) ->
     AdvancedConfs = case all_the_files(DevPath, "etc/advanced.config") of
@@ -194,7 +202,20 @@ set_advanced_conf(DevPath, NameValuePairs) ->
 get_conf(Node) ->
     N = node_id(Node),
     Path = relpath(node_version(N)),
-    WildCard = io_lib:format("~s/dev/dev~b/etc/*.conf", [Path, N]),
+    get_conf(Path, N).
+
+get_conf(DevPath, N) ->
+    WildCard = io_lib:format("~s/dev/dev~b/etc/*.conf", [DevPath, N]),
+    [Conf] = filelib:wildcard(WildCard),
+    Conf.
+
+get_app_config(Node) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    get_conf(Path, N).
+
+get_app_config(DevPath, N) ->
+    WildCard = io_lib:format("~s/dev/dev~b/etc/a*.config", [DevPath, N]),
     [Conf] = filelib:wildcard(WildCard),
     Conf.
 

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -1,0 +1,511 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @private
+-module(rt_cs_dev).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DEVS(N), lists:concat(["dev", N, "@127.0.0.1"])).
+-define(DEV(N), list_to_atom(?DEVS(N))).
+-define(BUILD_PATHS, (rt_config:get(build_paths))).
+-define(SRC_PATHS, (rt_config:get(src_paths))).
+
+get_deps() ->
+    lists:flatten(io_lib:format("~s/dev/dev1/lib", [relpath(current)])).
+
+setup_harness(_Test, _Args) ->
+    confirm_build_type(rt_config:get(build_type, oss)),
+    Path = relpath(root),
+    %% Stop all discoverable nodes, not just nodes we'll be using for this test.
+    rt:pmap(fun(X) -> stop_all(X ++ "/dev") end, devpaths()),
+
+    %% Reset nodes to base state
+    lager:info("Resetting nodes to fresh state"),
+    rtdev:run_git(Path, "reset HEAD --hard"),
+    rtdev:run_git(Path, "clean -fd"),
+
+    lager:info("Cleaning up lingering pipe directories"),
+    rt:pmap(fun(Dir) ->
+                    %% when joining two absolute paths, filename:join intentionally
+                    %% throws away the first one. ++ gets us around that, while
+                    %% keeping some of the security of filename:join.
+                    %% the extra slashes will be pruned by filename:join, but this
+                    %% ensures that there will be at least one between "/tmp" and Dir
+                    PipeDir = filename:join(["/tmp//" ++ Dir, "dev"]),
+                    %% when using filelib:wildcard/2, there must be a wildchar char
+                    %% before the first '/'.
+                    Files = filelib:wildcard("dev?/*.{r,w}", PipeDir),
+                    [ file:delete(filename:join(PipeDir, File)) || File <- Files],
+                    file:del_dir(PipeDir)
+            end, devpaths()),
+    ok.
+
+confirm_build_type(BuildType) ->
+    [ok = confirm_build_type(BuildType, Vsn) || Vsn <- [cs_current, cs_previous]].
+
+confirm_build_type(BuildType, Vsn) ->
+    ReplPB = filename:join([relpath(Vsn), "dev/dev1/lib/riak_repl_pb_api*"]),
+    case {BuildType, filelib:wildcard(ReplPB)} of
+        {oss, []} -> ok;
+        {ee,  [_|_]} -> ok;
+        _ ->
+            lager:error("Build type of ~p is not ~p",
+                        [Vsn, BuildType]),
+            {error, {build_type_mismatch, Vsn}}
+    end.
+
+relpath(Vsn) ->
+    Path = ?BUILD_PATHS,
+    path(Vsn, Path).
+
+srcpath(Vsn) ->
+    Path = ?SRC_PATHS,
+    path(Vsn, Path).
+
+path(Vsn, Paths=[{_,_}|_]) ->
+    orddict:fetch(Vsn, orddict:from_list(Paths));
+path(current, Path) ->
+    Path;
+path(root, Path) ->
+    Path;
+path(_, _) ->
+    throw("Version requested but only one path provided").
+
+upgrade(Node, NewVersion) ->
+    N = node_id(Node),
+    Version = node_version(N),
+    lager:info("Upgrading ~p : ~p -> ~p", [Node, Version, NewVersion]),
+    catch stop(Node),
+    rt:wait_until_unpingable(Node),
+    OldPath = relpath(Version),
+    NewPath = relpath(NewVersion),
+
+    Commands = [
+        io_lib:format("cp -p -P -R \"~s/dev/dev~b/data\" \"~s/dev/dev~b\"",
+                       [OldPath, N, NewPath, N]),
+        io_lib:format("rm -rf ~s/dev/dev~b/data/*",
+                       [OldPath, N]),
+        io_lib:format("cp -p -P -R \"~s/dev/dev~b/etc\" \"~s/dev/dev~b\"",
+                       [OldPath, N, NewPath, N])
+    ],
+    [ begin
+        lager:info("Running: ~s", [Cmd]),
+        os:cmd(Cmd)
+    end || Cmd <- Commands],
+    VersionMap = orddict:store(N, NewVersion, rt_config:get(rt_versions)),
+    rt_config:set(rt_versions, VersionMap),
+    start(Node),
+    rt:wait_until_pingable(Node),
+    ok.
+
+all_the_app_configs(DevPath) ->
+    lager:error("The dev path is ~p", [DevPath]),
+    case filelib:is_dir(DevPath) of
+        true ->
+            Devs = filelib:wildcard(DevPath ++ "/dev/dev*"),
+            [ Dev ++ "/etc/app.config" || Dev <- Devs];
+        _ ->
+            lager:debug("~s is not a directory.", [DevPath]),
+            []
+    end.
+
+update_app_config(all, Config) ->
+    lager:info("rtdev:update_app_config(all, ~p)", [Config]),
+    [ update_app_config(DevPath, Config) || DevPath <- devpaths()];
+update_app_config(Node, Config) when is_atom(Node) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    FileFormatString = "~s/dev/dev~b/etc/~s.config",
+
+    AppConfigFile = io_lib:format(FileFormatString, [Path, N, "app"]),
+    AdvConfigFile = io_lib:format(FileFormatString, [Path, N, "advanced"]),
+    %% If there's an app.config, do it old style
+    %% if not, use cuttlefish's adavnced.config
+    case filelib:is_file(AppConfigFile) of
+        true ->
+            update_app_config_file(AppConfigFile, Config);
+        _ ->
+            update_app_config_file(AdvConfigFile, Config)
+    end;
+update_app_config(DevPath, Config) ->
+    [update_app_config_file(AppConfig, Config) || AppConfig <- all_the_app_configs(DevPath)].
+
+update_app_config_file(ConfigFile, Config) ->
+    lager:info("rtdev:update_app_config_file(~s, ~p)", [ConfigFile, Config]),
+
+    BaseConfig = case file:consult(ConfigFile) of
+        {ok, [ValidConfig]} ->
+            ValidConfig;
+        {error, enoent} ->
+            []
+    end,
+    MergeA = orddict:from_list(Config),
+    MergeB = orddict:from_list(BaseConfig),
+    NewConfig =
+        orddict:merge(fun(_, VarsA, VarsB) ->
+                              MergeC = orddict:from_list(VarsA),
+                              MergeD = orddict:from_list(VarsB),
+                              orddict:merge(fun(_, ValA, _ValB) ->
+                                                    ValA
+                                            end, MergeC, MergeD)
+                      end, MergeA, MergeB),
+    NewConfigOut = io_lib:format("~p.", [NewConfig]),
+    ?assertEqual(ok, file:write_file(ConfigFile, NewConfigOut)),
+    ok.
+
+%% Appropriate backend will be set by rtcs later.
+get_backends() ->
+    cs_multi_backend.
+
+node_path(Node) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    lists:flatten(io_lib:format("~s/dev/dev~b", [Path, N])).
+
+create_dirs(Nodes) ->
+    Snmp = [node_path(Node) ++ "/data/snmp/agent/db" || Node <- Nodes],
+    [?assertCmd("mkdir -p " ++ Dir) || Dir <- Snmp].
+
+clean_data_dir(Nodes, SubDir) when is_list(Nodes) ->
+    DataDirs = [node_path(Node) ++ "/data/" ++ SubDir || Node <- Nodes],
+    lists:foreach(fun rm_dir/1, DataDirs).
+
+rm_dir(Dir) ->
+    lager:info("Removing directory ~s", [Dir]),
+    ?assertCmd("rm -rf " ++ Dir),
+    ?assertEqual(false, filelib:is_dir(Dir)).
+
+add_default_node_config(Nodes) ->
+    case rt_config:get(rt_default_config, undefined) of
+        undefined -> ok;
+        Defaults when is_list(Defaults) ->
+            rt:pmap(fun(Node) ->
+                            update_app_config(Node, Defaults)
+                    end, Nodes),
+            ok;
+        BadValue ->
+            lager:error("Invalid value for rt_default_config : ~p", [BadValue]),
+            throw({invalid_config, {rt_default_config, BadValue}})
+    end.
+
+deploy_nodes(NodeConfig) ->
+    Path = relpath(root),
+    lager:info("Riak path: ~p", [Path]),
+    NumNodes = length(NodeConfig),
+    NodesN = lists:seq(1, NumNodes),
+    Nodes = [?DEV(N) || N <- NodesN],
+    NodeMap = orddict:from_list(lists:zip(Nodes, NodesN)),
+    {Versions, Configs} = lists:unzip(NodeConfig),
+    VersionMap = lists:zip(NodesN, Versions),
+
+    %% Check that you have the right versions available
+    [ check_node(Version) || Version <- VersionMap ],
+    rt_config:set(rt_nodes, NodeMap),
+    rt_config:set(rt_versions, VersionMap),
+
+    create_dirs(Nodes),
+
+    %% Set initial config
+    add_default_node_config(Nodes),
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({Node, Config}) ->
+                    update_app_config(Node, Config)
+            end,
+            lists:zip(Nodes, Configs)),
+
+    %% create snmp dirs, for EE
+    create_dirs(Nodes),
+
+    %% Start nodes
+    %%[run_riak(N, relpath(node_version(N)), "start") || N <- Nodes],
+    rt:pmap(fun(N) -> rtdev:run_riak(N, relpath(node_version(N)), "start") end, NodesN),
+
+    %% Ensure nodes started
+    [ok = rt:wait_until_pingable(N) || N <- Nodes],
+
+    %% %% Enable debug logging
+    %% [rpc:call(N, lager, set_loglevel, [lager_console_backend, debug]) || N <- Nodes],
+
+    %% We have to make sure that riak_core_ring_manager is running before we can go on.
+    [ok = rt:wait_until_registered(N, riak_core_ring_manager) || N <- Nodes],
+
+    %% Ensure nodes are singleton clusters
+    [ok = rt:check_singleton_node(?DEV(N)) || {N, Version} <- VersionMap,
+                                              Version /= "0.14.2"],
+
+    lager:info("Deployed nodes: ~p", [Nodes]),
+    Nodes.
+
+stop_all(DevPath) ->
+    case filelib:is_dir(DevPath) of
+        true ->
+            Devs = filelib:wildcard(DevPath ++ "/{dev,stanchion}*"),
+
+            %% Works, but I'd like it to brag a little more about it.
+            Stop = fun(C) ->
+                Cmd = stop_command(C),
+                [Output | _Tail] = string:tokens(os:cmd(Cmd), "\n"),
+                Status = case Output of
+                    "ok" -> "ok";
+                    _ -> "wasn't running"
+                end,
+                lager:info("Stopping Node... ~s ~~ ~s.", [Cmd, Status])
+            end,
+            [Stop(D) || D <- Devs];
+        _ -> lager:info("~s is not a directory.", [DevPath])
+    end,
+    ok.
+
+stop_command(C) ->
+    IsRiakCS = string:str(C, "riak_cs"),
+    IsStanchion = string:str(C, "stanchion"),
+    if
+        IsRiakCS > 0 ->
+            C ++ "/bin/riak-cs stop";
+        IsStanchion > 0 ->
+            C ++ "/bin/stanchion stop";
+        true ->
+            C ++ "/bin/riak stop"
+    end.
+
+stop(Node) ->
+    RiakPid = rpc:call(Node, os, getpid, []),
+    N = node_id(Node),
+    rtdev:run_riak(N, relpath(node_version(N)), "stop"),
+    F = fun(_N) ->
+            os:cmd("kill -0 " ++ RiakPid) =/= []
+    end,
+    ?assertEqual(ok, rt:wait_until(Node, F)),
+    ok.
+
+start(Node) ->
+    N = node_id(Node),
+    rtdev:run_riak(N, relpath(node_version(N)), "start"),
+    ok.
+
+attach(Node, Expected) ->
+    interactive(Node, "attach", Expected).
+
+attach_direct(Node, Expected) ->
+    interactive(Node, "attach-direct", Expected).
+
+console(Node, Expected) ->
+    interactive(Node, "console", Expected).
+
+interactive(Node, Command, Exp) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    Cmd = rtdev:riakcmd(Path, N, Command),
+    lager:info("Opening a port for riak ~s.", [Command]),
+    lager:debug("Calling open_port with cmd ~s", [binary_to_list(iolist_to_binary(Cmd))]),
+    P = open_port({spawn, binary_to_list(iolist_to_binary(Cmd))},
+                  [stream, use_stdio, exit_status, binary, stderr_to_stdout]),
+    interactive_loop(P, Exp).
+
+interactive_loop(Port, Expected) ->
+    receive
+        {Port, {data, Data}} ->
+            %% We've gotten some data, so the port isn't done executing
+            %% Let's break it up by newline and display it.
+            Tokens = string:tokens(binary_to_list(Data), "\n"),
+            [lager:debug("~s", [Text]) || Text <- Tokens],
+
+            %% Now we're going to take hd(Expected) which is either {expect, X}
+            %% or {send, X}. If it's {expect, X}, we foldl through the Tokenized
+            %% data looking for a partial match via rt:str/2. If we find one,
+            %% we pop hd off the stack and continue iterating through the list
+            %% with the next hd until we run out of input. Once hd is a tuple
+            %% {send, X}, we send that test to the port. The assumption is that
+            %% once we send data, anything else we still have in the buffer is
+            %% meaningless, so we skip it. That's what that {sent, sent} thing
+            %% is about. If there were a way to abort mid-foldl, I'd have done
+            %% that. {sent, _} -> is just a pass through to get out of the fold.
+
+            NewExpected = lists:foldl(fun(X, Expect) ->
+                    [{Type, Text}|RemainingExpect] = case Expect of
+                        [] -> [{done, "done"}|[]];
+                        E -> E
+                    end,
+                    case {Type, rt:str(X, Text)} of
+                        {expect, true} ->
+                            RemainingExpect;
+                        {expect, false} ->
+                            [{Type, Text}|RemainingExpect];
+                        {send, _} ->
+                            port_command(Port, list_to_binary(Text ++ "\n")),
+                            [{sent, "sent"}|RemainingExpect];
+                        {sent, _} ->
+                            Expect;
+                        {done, _} ->
+                            []
+                    end
+                end, Expected, Tokens),
+            %% Now that the fold is over, we should remove {sent, sent} if it's there.
+            %% The fold might have ended not matching anything or not sending anything
+            %% so it's possible we don't have to remove {sent, sent}. This will be passed
+            %% to interactive_loop's next iteration.
+            NewerExpected = case NewExpected of
+                [{sent, "sent"}|E] -> E;
+                E -> E
+            end,
+            %% If NewerExpected is empty, we've met all expected criteria and in order to boot
+            %% Otherwise, loop.
+            case NewerExpected of
+                [] -> ?assert(true);
+                _ -> interactive_loop(Port, NewerExpected)
+            end;
+        {Port, {exit_status,_}} ->
+            %% This port has exited. Maybe the last thing we did was {send, [4]} which
+            %% as Ctrl-D would have exited the console. If Expected is empty, then
+            %% We've met every expectation. Yay! If not, it means we've exited before
+            %% something expected happened.
+            ?assertEqual([], Expected)
+        after rt_config:get(rt_max_wait_time) ->
+            %% interactive_loop is going to wait until it matches expected behavior
+            %% If it doesn't, the test should fail; however, without a timeout it
+            %% will just hang forever in search of expected behavior. See also: Parenting
+            ?assertEqual([], Expected)
+    end.
+
+admin(Node, Args, Options) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    Cmd = rtdev:riak_admin_cmd(Path, N, Args),
+    lager:info("Running: ~s", [Cmd]),
+    Result = execute_admin_cmd(Cmd, Options),
+    lager:info("~s", [Result]),
+    {ok, Result}.
+
+execute_admin_cmd(Cmd, Options) ->
+    {_ExitCode, Result} = FullResult = wait_for_cmd(spawn_cmd(Cmd)),
+    case lists:member(return_exit_code, Options) of
+        true ->
+            FullResult;
+        false ->
+            Result
+    end.
+
+riak(Node, Args) ->
+    N = node_id(Node),
+    Path = relpath(node_version(N)),
+    Result = rtdev:run_riak(N, Path, Args),
+    lager:info("~s", [Result]),
+    {ok, Result}.
+
+node_id(Node) ->
+    NodeMap = rt_config:get(rt_nodes),
+    orddict:fetch(Node, NodeMap).
+
+node_version(N) ->
+    VersionMap = rt_config:get(rt_versions),
+    orddict:fetch(N, VersionMap).
+
+spawn_cmd(Cmd) ->
+    spawn_cmd(Cmd, []).
+spawn_cmd(Cmd, Opts) ->
+    Port = open_port({spawn, Cmd}, [stream, in, exit_status, stderr_to_stdout] ++ Opts),
+    Port.
+
+wait_for_cmd(Port) ->
+    rt:wait_until(node(),
+                  fun(_) ->
+                          receive
+                              {Port, Msg={data, _}} ->
+                                  self() ! {Port, Msg},
+                                  false;
+                              {Port, Msg={exit_status, _}} ->
+                                  catch port_close(Port),
+                                  self() ! {Port, Msg},
+                                  true
+                          after 0 ->
+                                  false
+                          end
+                  end),
+    get_cmd_result(Port, []).
+
+cmd(Cmd) ->
+    cmd(Cmd, []).
+
+cmd(Cmd, Opts) ->
+    wait_for_cmd(spawn_cmd(Cmd, Opts)).
+
+get_cmd_result(Port, Acc) ->
+    receive
+        {Port, {data, Bytes}} ->
+            get_cmd_result(Port, [Bytes|Acc]);
+        {Port, {exit_status, Status}} ->
+            Output = lists:flatten(lists:reverse(Acc)),
+            {Status, Output}
+    after 0 ->
+            timeout
+    end.
+
+check_node({_N, Version}) ->
+    case proplists:is_defined(Version, rt_config:get(build_paths)) of
+        true -> ok;
+        _ ->
+            lager:error("You don't have Riak ~s installed or configured", [Version]),
+            erlang:error("You don't have Riak " ++ atom_to_list(Version) ++ " installed or configured")
+    end.
+
+set_backend(Backend) ->
+    lager:info("rtdev:set_backend(~p)", [Backend]),
+    update_app_config(all, [{riak_kv, [{storage_backend, Backend}]}]),
+    get_backends().
+
+get_version() ->
+    case file:read_file(relpath(cs_current) ++ "/VERSION") of
+        {error, enoent} -> unknown;
+        {ok, Version} -> Version
+    end.
+
+teardown() ->
+    %% Stop all discoverable nodes, not just nodes we'll be using for this test.
+    rt:pmap(fun(X) -> stop_all(X ++ "/dev") end,
+            devpaths()).
+
+whats_up() ->
+    io:format("Here's what's running...~n"),
+
+    Up = [rpc:call(Node, os, cmd, ["pwd"]) || Node <- nodes()],
+    [io:format("  ~s~n",[string:substr(Dir, 1, length(Dir)-1)]) || Dir <- Up].
+
+devpaths() ->
+    lists:usort([ DevPath || {Name, DevPath} <- rt_config:get(build_paths),
+                             not lists:member(Name, [root, ee_root, cs_root, stanchion_root])
+                ]).
+
+versions() ->
+    proplists:get_keys(rt_config:get(build_paths)) -- [root].
+
+get_node_logs() ->
+    lists:flatmap(fun get_node_logs/1, [root, ee_root, cs_root, stanchion_root]).
+
+get_node_logs(Base) ->
+    Root = filename:absname(proplists:get_value(Base, ?BUILD_PATHS)),
+    %% Unlike Riak, Riak CS has multiple things in the root and so we need
+    %% to distinguish between them.
+    RootLen = length(filename:dirname(Root)) + 1, %% Remove the leading slash
+    [ begin
+          {ok, Port} = file:open(Filename, [read, binary]),
+          {lists:nthtail(RootLen, Filename), Port}
+      end || Filename <- filelib:wildcard(Root ++ "/*/dev/dev*/log/*") ].

--- a/riak_test/src/rt_cs_dev.erl
+++ b/riak_test/src/rt_cs_dev.erl
@@ -178,7 +178,7 @@ set_advanced_conf({Name, Vsn}, NameValuePairs) ->
     set_advanced_conf(devpath(Name, Vsn), NameValuePairs),
     ok;
 set_advanced_conf(Node, NameValuePairs) when is_atom(Node) ->
-    rtdev:append_to_conf_file(rtdev:get_advanced_riak_conf(Node), NameValuePairs),
+    rtdev:append_to_conf_file(get_conf(Node), NameValuePairs),
     ok;
 set_advanced_conf(DevPath, NameValuePairs) ->
     AdvancedConfs = case rtdev:all_the_files(DevPath, "etc/advanced.config") of
@@ -578,7 +578,7 @@ devpaths() ->
                 ]).
 
 devpath(Name, Vsn) ->
-    rt_config:get(rtcs_config:get_rt_config(Name, Vsn)).
+    rtcs_config:get_rt_config(Name, Vsn).
 
 versions() ->
     proplists:get_keys(rt_config:get(build_paths)) -- [root].

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -92,7 +92,7 @@ setup_clusters(Configs, JoinFun, NumNodes, Vsn) ->
     ?assertEqual(ok, wait_until_nodes_ready(RiakNodes)),
     ?assertEqual(ok, wait_until_no_pending_changes(RiakNodes)),
     rt:wait_until_ring_converged(RiakNodes),
-    {AdminKeyId, AdminSecretKey} = setup_admin_user(NumNodes, Configs, Vsn),
+    {AdminKeyId, AdminSecretKey} = setup_admin_user(NumNodes, rtcs_config:configs(Configs), Vsn),
     AdminConfig = rtcs_config:config(AdminKeyId,
                                      AdminSecretKey,
                                      rtcs_config:cs_port(hd(RiakNodes))),

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -289,7 +289,7 @@ assert_error_log_empty(N) ->
     assert_error_log_empty(current, N).
 
 assert_error_log_empty(Vsn, N) ->
-    ErrorLog = rtcs_config:riakcs_logpath(rtcs_config:get_rt_config(cs, Vsn), N, "error.log"),
+    ErrorLog = rtcs_config:riakcs_logpath(rtcs_config:devpath(cs, Vsn), N, "error.log"),
     case file:read_file(ErrorLog) of
         {error, enoent} -> ok;
         {ok, <<>>} -> ok;

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -32,31 +32,8 @@
 -define(CSDEVS(N), lists:concat(["rcs-dev", N, "@127.0.0.1"])).
 -define(CSDEV(N), list_to_atom(?CSDEVS(N))).
 
--define(RIAK_CURRENT, <<"build_paths.current">>).
--define(RIAK_PREVIOUS, <<"build_paths.previous">>).
--define(EE_CURRENT, <<"build_paths.ee_current">>).
--define(EE_PREVIOUS, <<"build_paths.ee_previous">>).
--define(CS_CURRENT, <<"build_paths.cs_current">>).
--define(CS_PREVIOUS, <<"build_paths.cs_previous">>).
--define(STANCHION_CURRENT, <<"build_paths.stanchion_current">>).
--define(STANCHION_PREVIOUS, <<"build_paths.stanchion_previous">>).
-
--define(PROXY_HOST, "localhost").
--define(S3_HOST, "s3.amazonaws.com").
--define(S3_PORT, 80).
--define(DEFAULT_PROTO, "http").
-
--define(REQUEST_POOL_SIZE, 8).
--define(BUCKET_LIST_POOL_SIZE, 2).
-
-request_pool_size() ->
-    ?REQUEST_POOL_SIZE.
-
-bucket_list_pool_size() ->
-    ?BUCKET_LIST_POOL_SIZE.
-
 setup(NumNodes) ->
-    setup(NumNodes, default_configs(), current).
+    setup(NumNodes, rtcs_config:default_configs(), current).
 
 setup(NumNodes, Configs) ->
     setup(NumNodes, Configs, current).
@@ -67,7 +44,7 @@ setup(NumNodes, Configs, Vsn) ->
     flavored_setup(NumNodes, Flavor, Configs, Vsn).
 
 setup2x2() ->
-    setup2x2(default_configs()).
+    setup2x2(rtcs_config:default_configs()).
 
 setup2x2(Configs) ->
     JoinFun = fun(Nodes) ->
@@ -79,7 +56,7 @@ setup2x2(Configs) ->
 
 %% 1 cluster with N nodes + M cluster with 1 node
 setupNxMsingles(N, M) ->
-    setupNxMsingles(N, M, default_configs(), current).
+    setupNxMsingles(N, M, rtcs_config:default_configs(), current).
 
 setupNxMsingles(N, M, Configs, Vsn)
   when Vsn =:= current orelse Vsn =:= previous ->
@@ -111,7 +88,7 @@ setup_clusters(Configs, ConfigFun, JoinFun, NumNodes, Vsn) ->
     application:load(sasl),
     application:set_env(sasl, sasl_error_logger, false),
 
-    Cfgs = configs(Configs),
+    Cfgs = rtcs_config:configs(Configs),
     lager:info("Configs = ~p", [ Cfgs]),
     {RiakNodes, _CSNodes, _Stanchion} = Nodes =
         deploy_nodes(NumNodes, Cfgs, ConfigFun, Vsn),
@@ -122,9 +99,9 @@ setup_clusters(Configs, ConfigFun, JoinFun, NumNodes, Vsn) ->
     ?assertEqual(ok, wait_until_no_pending_changes(RiakNodes)),
     rt:wait_until_ring_converged(RiakNodes),
     {AdminKeyId, AdminSecretKey} = setup_admin_user(NumNodes, Cfgs, ConfigFun, Vsn),
-    AdminConfig = rtcs:config(AdminKeyId,
-                              AdminSecretKey,
-                              rtcs:cs_port(hd(RiakNodes))),
+    AdminConfig = rtcs_config:config(AdminKeyId,
+                                     AdminSecretKey,
+                                     rtcs_config:cs_port(hd(RiakNodes))),
     {AdminConfig, Nodes}.
 
 
@@ -136,37 +113,6 @@ teardown() ->
     %% catch application:stop(sasl),
     catch application:stop(erlcloud),
     catch application:stop(ibrowse).
-
-configs(CustomConfigs) ->
-    [{riak, proplists:get_value(riak, CustomConfigs, riak_config())},
-     {cs, proplists:get_value(cs, CustomConfigs, cs_config())},
-     {stanchion, proplists:get_value(stanchion,
-                                     CustomConfigs,
-                                     stanchion_config())}].
-
-previous_configs() ->
-    previous_configs([]).
-
-previous_configs(CustomConfigs) ->
-    [{riak, proplists:get_value(riak, CustomConfigs, previous_riak_config())},
-     {cs, proplists:get_value(cs, CustomConfigs, previous_cs_config())},
-     {stanchion, proplists:get_value(stanchion, CustomConfigs,
-                                     previous_stanchion_config())}].
-
-default_configs() ->
-    [{riak, riak_config()},
-     {stanchion, stanchion_config()},
-     {cs, cs_config()}].
-
-config(Key, Secret, Port) ->
-    erlcloud_s3:new(Key,
-                    Secret,
-                    ?S3_HOST,
-                    Port, % inets issue precludes using ?S3_PORT
-                    ?DEFAULT_PROTO,
-                    ?PROXY_HOST,
-                    Port,
-                    []).
 
 %% Return Riak node IDs, one per cluster.
 %% For example, in basic single cluster case, just return [1].
@@ -180,298 +126,28 @@ riak_id_per_cluster(NumNodes) ->
 deploy_stanchion(Config) ->
     %% Set initial config
     ConfigFun = fun(_, Config0, _) -> Config0 end,
-    update_stanchion_config(rt_config:get(?STANCHION_CURRENT), Config, ConfigFun),
+    rtcs_config:update_stanchion_config(rt_config:get(rtcs_config:stanchion_current()), Config, ConfigFun),
 
-    start_stanchion(),
+    rtcs_exec:start_stanchion(),
     lager:info("Stanchion started").
 
 create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),
     User = "Test User" ++ integer_to_list(UserIndex),
     Email = lists:flatten(io_lib:format("~p~p~p@basho.com", [A, B, C])),
-    {KeyId, Secret, _Id} = create_user(cs_port(Node), Email, User),
+    {KeyId, Secret, _Id} = create_user(rtcs_config:cs_port(Node), Email, User),
     lager:info("Created user ~p with keys ~p ~p", [Email, KeyId, Secret]),
     {KeyId, Secret}.
 
 create_admin_user(Node) ->
     User = "admin",
     Email = "admin@me.com",
-    {KeyId, Secret, Id} = create_user(cs_port(Node), Email, User),
+    {KeyId, Secret, Id} = create_user(rtcs_config:cs_port(Node), Email, User),
     lager:info("Riak CS Admin account created with ~p",[Email]),
     lager:info("KeyId = ~p",[KeyId]),
     lager:info("KeySecret = ~p",[Secret]),
     lager:info("Id = ~p",[Id]),
     {KeyId, Secret}.
-
-pb_port(N) when is_integer(N) ->
-    10000 + (N * 10) + 7;
-pb_port(Node) ->
-    pb_port(rt_cs_dev:node_id(Node)).
-
-cs_port(N) when is_integer(N) ->
-    15008 + 10 * N;
-cs_port(Node) ->
-    cs_port(rt_cs_dev:node_id(Node)).
-
-stanchion_port() -> 9095.
-
-riak_config(CustomConfig) ->
-    orddict:merge(fun(_, LHS, RHS) -> LHS ++ RHS end,
-                  orddict:from_list(lists:sort(CustomConfig)),
-                  orddict:from_list(lists:sort(riak_config()))).
-
-riak_config() ->
-    riak_config(
-      ?CS_CURRENT,
-      rt_config:get(build_type, oss),
-      rt_config:get(backend, {multi_backend, bitcask})).
-
-
-riak_config(CsVsn, oss, Backend) ->
-    riak_oss_config(CsVsn, Backend);
-riak_config(CsVsn, ee, Backend) ->
-    riak_ee_config(CsVsn, Backend).
-
-riak_oss_config(CsVsn, Backend) ->
-    CSPath = rt_config:get(CsVsn),
-    AddPaths = filelib:wildcard(CSPath ++ "/dev/dev1/lib/riak_cs*/ebin"),
-    [
-     lager_config(),
-     {riak_core,
-      [{default_bucket_props, [{allow_mult, true}]},
-       {ring_creation_size, 8}]
-     },
-     {riak_api,
-      [{pb_backlog, 256}]},
-     {riak_kv,
-      [{add_paths, AddPaths}] ++
-          backend_config(CsVsn, Backend)
-      }
-    ].
-
-backend_config(_CsVsn, memory) ->
-    [{storage_backend, riak_kv_memory_backend}];
-backend_config(_CsVsn, {multi_backend, BlocksBackend}) ->
-    [
-     {storage_backend, riak_cs_kv_multi_backend},
-     {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
-     {multi_backend_default, be_default},
-     {multi_backend,
-      [{be_default, riak_kv_eleveldb_backend,
-        [
-         {max_open_files, 20},
-         {data_root, "./data/leveldb"}
-        ]},
-       blocks_backend_config(BlocksBackend)
-      ]}
-    ];
-backend_config(?CS_CURRENT, prefix_multi) ->
-    [
-     {storage_backend, riak_kv_multi_prefix_backend},
-     {riak_cs_version, 20000}
-    ];
-backend_config(OlderCsVsn, prefix_multi) ->
-    backend_config(OlderCsVsn, {multi_backend, bitcask}).
-
-blocks_backend_config(fs) ->
-    {be_blocks, riak_kv_fs2_backend, [{data_root, "./data/fs2"},
-                                      {block_size, 1050000}]};
-blocks_backend_config(_) ->
-    {be_blocks, riak_kv_bitcask_backend, [{data_root, "./data/bitcask"}]}.
-
-riak_ee_config(CsVsn, Backend) ->
-    [repl_config() | riak_oss_config(CsVsn, Backend)].
-
-repl_config() ->
-    {riak_repl,
-     [
-      {fullsync_on_connect, false},
-      {fullsync_interval, disabled},
-      {proxy_get, enabled}
-     ]}.
-
-previous_riak_config() ->
-    riak_config(
-      ?CS_PREVIOUS,
-      rt_config:get(build_type, oss),
-      rt_config:get(backend, {multi_backend, bitcask})).
-
-previous_riak_config(CustomConfig) ->
-    orddict:merge(fun(_, LHS, RHS) -> LHS ++ RHS end,
-                  orddict:from_list(lists:sort(CustomConfig)),
-                  orddict:from_list(lists:sort(previous_riak_config()))).
-
-previous_riak_config(oss, Backend) ->
-    riak_oss_config(?CS_PREVIOUS, Backend);
-previous_riak_config(ee, Backend) ->
-    riak_ee_config(?CS_PREVIOUS, Backend).
-
-previous_cs_config() ->
-    previous_cs_config([], []).
-
-previous_cs_config(UserExtra) ->
-    previous_cs_config(UserExtra, []).
-
-previous_cs_config(UserExtra, OtherApps) ->
-    [
-     lager_config(),
-     {riak_cs,
-      UserExtra ++
-          [
-           {connection_pools,
-            [
-             {request_pool, {request_pool_size(), 0} },
-             {bucket_list_pool, {bucket_list_pool_size(), 0} }
-            ]},
-           {block_get_max_retries, 1},
-           {proxy_get, enabled},
-           {anonymous_user_creation, true},
-           {riak_pb_port, 10017},
-           {stanchion_port, stanchion_port()},
-           {cs_version, 010300}
-          ]
-     }] ++ OtherApps.
-
-cs_config() ->
-    cs_config([], []).
-
-cs_config(UserExtra) ->
-    cs_config(UserExtra, []).
-
-cs_config(UserExtra, OtherApps) ->
-    [
-     lager_config(),
-     {riak_cs,
-      UserExtra ++
-          [
-           {connection_pools,
-            [
-             {request_pool, {request_pool_size(), 0} },
-             {bucket_list_pool, {bucket_list_pool_size(), 0} }
-            ]},
-           {block_get_max_retries, 1},
-           {proxy_get, enabled},
-           {anonymous_user_creation, true},
-           {stanchion_host, {"127.0.0.1", stanchion_port()}},
-           {riak_host, {"127.0.0.1", 10017}},
-           {cs_version, 010300}
-          ]
-     }] ++ OtherApps.
-
-replace_cs_config(Key, Value, Config) ->
-    CSConfig0 = proplists:get_value(riak_cs, Config),
-    CSConfig = replace(Key, Value, CSConfig0),
-    replace(riak_cs, CSConfig, Config).
-
-replace(Key, Value, Config0) ->
-    Config1 = proplists:delete(Key, Config0),
-    [proplists:property(Key, Value)|Config1].
-
-replace_stanchion_config(Key, Value, Config) ->
-    CSConfig0 = proplists:get_value(stanchion, Config),
-    CSConfig = replace(Key, Value, CSConfig0),
-    replace(stanchion, CSConfig, Config).
-
-previous_stanchion_config() ->
-    [
-     lager_config(),
-     {stanchion,
-      [
-       {stanchion_port, stanchion_port()},
-       {riak_pb_port, 10017}
-      ]
-     }].
-
-previous_stanchion_config(UserExtra) ->
-    lists:foldl(fun({Key,Value}, Config0) ->
-                        replace_stanchion_config(Key,Value,Config0)
-                end, previous_stanchion_config(), UserExtra).
-
-stanchion_config() ->
-    [
-     lager_config(),
-     {stanchion,
-      [
-       {host, {"127.0.0.1", stanchion_port()}},
-       {riak_host, {"127.0.0.1", 10017}}
-      ]
-     }].
-
-stanchion_config(UserExtra) ->
-    lists:foldl(fun({Key,Value}, Config0) ->
-                        replace_stanchion_config(Key,Value,Config0)
-                end, stanchion_config(), UserExtra).
-
-lager_config() ->
-    {lager,
-     [
-      {handlers,
-       [
-        {lager_file_backend,
-         [
-          {"./log/error.log", error, 10485760, "$D0",5},
-          {"./log/console.log", rt_config:get(console_log_level, debug),
-           10485760, "$D0", 5}
-         ]}
-       ]}
-     ]}.
-
-riak_bitcaskroot(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/data/bitcask", [Prefix, N]).
-
-riak_binpath(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/bin/riak", [Prefix, N]).
-
-riakcmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s ~s", [riak_binpath(Path, N), Cmd])).
-
-riakcs_home(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/", [Prefix, N]).
-
-riakcs_binpath(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/bin/riak-cs", [Prefix, N]).
-
-riakcs_etcpath(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/etc", [Prefix, N]).
-
-riakcs_libpath(Prefix, N) ->
-    io_lib:format("~s/dev/dev~b/lib", [Prefix, N]).
-
-riakcs_logpath(Prefix, N, File) ->
-    io_lib:format("~s/dev/dev~b/log/~s", [Prefix, N, File]).
-
-riakcscmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
-
-riakcs_statuscmd(Path, N) ->
-    lists:flatten(io_lib:format("~s-admin status", [riakcs_binpath(Path, N)])).
-
-riakcs_switchcmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s-admin stanchion ~s", [riakcs_binpath(Path, N), Cmd])).
-
-riakcs_gccmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s-admin gc ~s", [riakcs_binpath(Path, N), Cmd])).
-
-riakcs_accesscmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s-admin access ~s", [riakcs_binpath(Path, N), Cmd])).
-
-riakcs_storagecmd(Path, N, Cmd) ->
-    lists:flatten(io_lib:format("~s-admin storage ~s", [riakcs_binpath(Path, N), Cmd])).
-
-stanchion_binpath(Prefix) ->
-    io_lib:format("~s/dev/stanchion/bin/stanchion", [Prefix]).
-
-stanchion_etcpath(Prefix) ->
-    io_lib:format("~s/dev/stanchion/etc", [Prefix]).
-
-stanchioncmd(Path, Cmd) ->
-    lists:flatten(io_lib:format("~s ~s", [stanchion_binpath(Path), Cmd])).
-
-stanchion_statuscmd(Path) ->
-    lists:flatten(io_lib:format("~s-admin status", [stanchion_binpath(Path)])).
-
-cs_current() ->
-    ?CS_CURRENT.
 
 -spec deploy_nodes(list(), list(), fun(), current|previous) -> any().
 deploy_nodes(NumNodes, InitialConfig, ConfigFun, Vsn)
@@ -502,15 +178,15 @@ deploy_nodes(NumNodes, InitialConfig, ConfigFun, Vsn)
     NodeList = [{CS1, R1, StanchionNode} | tl(NL0)],
     lager:info("NodeList: ~p", [NodeList]),
 
-    stop_all_nodes(NodeList, Vsn),
+    rtcs_exec:stop_all_nodes(NodeList, Vsn),
 
     rt_cs_dev:create_dirs(RiakNodes),
 
     {_Versions, Configs} = lists:unzip(NodeConfig),
 
     %% Set initial config
-    set_configs(NodeList, Configs, ConfigFun, Vsn),
-    start_all_nodes(NodeList, Vsn),
+    rtcs_config:set_configs(NodeList, Configs, ConfigFun, Vsn),
+    rtcs_exec:start_all_nodes(NodeList, Vsn),
 
     Nodes = {RiakNodes, CSNodes, StanchionNode},
     [ok = rt:wait_until_pingable(N) || N <- RiakNodes ++ CSNodes ++ [StanchionNode]],
@@ -552,7 +228,7 @@ setup_admin_user(NumNodes, InitialConfig, ConfigFun, Vsn)
     %% Create admin user and set in cs and stanchion configs
     {KeyID, KeySecret} = AdminCreds = create_admin_user(hd(RiakNodes)),
 
-    set_admin_creds_in_configs(NodeList, Configs, ConfigFun, AdminCreds, Vsn),
+    rtcs_config:set_admin_creds_in_configs(NodeList, Configs, ConfigFun, AdminCreds, Vsn),
 
     UpdateFun = fun({Node, App}) ->
                         ok = rpc:call(Node, application, set_env,
@@ -576,323 +252,6 @@ setup_admin_user(NumNodes, InitialConfig, ConfigFun, Vsn)
 
     AdminCreds.
 
-
-start_cs_and_stanchion_nodes(NodeList, Vsn) ->
-    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    start_stanchion(Vsn),
-                    start_cs(N, Vsn);
-               ({_CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    start_cs(N, Vsn)
-            end, NodeList).
-
-stop_cs_and_stanchion_nodes(NodeList, Vsn) ->
-    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    stop_cs(N, Vsn),
-                    stop_stanchion(Vsn),
-                    rt:wait_until_unpingable(CSNode),
-                    rt:wait_until_unpingable(Stanchion);
-               ({CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    stop_cs(N, Vsn),
-                    rt:wait_until_unpingable(CSNode)
-            end, NodeList).
-
-start_all_nodes(NodeList, Vsn) ->
-    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    NodeVersion = rt_cs_dev:node_version(N),
-                    lager:debug("starting riak #~p > ~p => ~p",
-                                [N,  NodeVersion,
-                                 rt_cs_dev:relpath(NodeVersion)]),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(NodeVersion), "start"),
-                    rt:wait_for_service(RiakNode, riak_kv),
-                    spawn(fun() -> start_stanchion(Vsn) end),
-                    spawn(fun() -> start_cs(N, Vsn) end);
-               ({_CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "start"),
-                    rt:wait_for_service(RiakNode, riak_kv),
-                    spawn(fun() -> start_cs(N, Vsn) end)
-            end, NodeList).
-
-stop_all_nodes(NodeList, Vsn) ->
-    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    stop_cs(N, Vsn),
-                    stop_stanchion(Vsn),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
-                    rt:wait_until_unpingable(CSNode),
-                    rt:wait_until_unpingable(Stanchion),
-                    rt:wait_until_unpingable(RiakNode);
-               ({CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    stop_cs(N, Vsn),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
-                    rt:wait_until_unpingable(CSNode),
-                    rt:wait_until_unpingable(RiakNode)
-            end, NodeList).
-
-get_rt_config(riak, current) ->
-    case rt_config:get(build_type, oss) of
-        oss -> rt_config:get(?RIAK_CURRENT);
-        ee  -> rt_config:get(?EE_CURRENT)
-    end;
-get_rt_config(riak, previous) ->
-    case rt_config:get(build_type, oss) of
-        oss -> rt_config:get(?RIAK_PREVIOUS);
-        ee  -> rt_config:get(?EE_PREVIOUS)
-    end;
-get_rt_config(cs, current) -> rt_config:get(?CS_CURRENT);
-get_rt_config(cs, previous) -> rt_config:get(?CS_PREVIOUS);
-get_rt_config(stanchion, current) -> rt_config:get(?STANCHION_CURRENT);
-get_rt_config(stanchion, previous) -> rt_config:get(?STANCHION_PREVIOUS).
-
-set_configs(NodeList, Configs, ConfigFun, Vsn) ->
-    rt:pmap(fun({_, default}) ->
-                    ok;
-               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    rt_cs_dev:update_app_config(RiakNode, proplists:get_value(riak,
-                                                                              Config)),
-                    update_cs_config(get_rt_config(cs, Vsn), N,
-                                     proplists:get_value(cs, Config), ConfigFun),
-                    update_stanchion_config(get_rt_config(stanchion, Vsn),
-                                            proplists:get_value(stanchion, Config),
-                                            ConfigFun);
-               ({{_CSNode, RiakNode}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    rt_cs_dev:update_app_config(RiakNode,
-                                                proplists:get_value(riak, Config)),
-                    update_cs_config(get_rt_config(cs, Vsn), N,
-                                     proplists:get_value(cs, Config), ConfigFun)
-            end,
-            lists:zip(NodeList, Configs)),
-    enable_zdbbl(Vsn).
-
-set_admin_creds_in_configs(NodeList, Configs, ConfigFun, AdminCreds, Vsn) ->
-    rt:pmap(fun({_, default}) ->
-                    ok;
-               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    update_cs_config(get_rt_config(cs, Vsn),
-                                     N,
-                                     proplists:get_value(cs, Config),
-                                     ConfigFun,
-                                     AdminCreds),
-                    update_stanchion_config(get_rt_config(stanchion, Vsn),
-                                            proplists:get_value(stanchion, Config),
-                                            ConfigFun, AdminCreds);
-               ({{_CSNode, RiakNode}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    update_cs_config(get_rt_config(cs, Vsn),
-                                     N,
-                                     proplists:get_value(cs, Config),
-                                     ConfigFun,
-                                     AdminCreds)
-            end,
-            lists:zip(NodeList, Configs)).
-
-start_cs(N) -> start_cs(N, current).
-
-start_cs(N, Vsn) ->
-    NodePath = get_rt_config(cs, Vsn),
-    Cmd = riakcscmd(NodePath, N, "start"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-stop_cs(N) -> stop_cs(N, current).
-
-stop_cs(N, Vsn) ->
-    Cmd = riakcscmd(get_rt_config(cs, Vsn), N, "stop"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-repair_gc_bucket(N, Options) -> repair_gc_bucket(N, Options, current).
-
-repair_gc_bucket(N, Options, Vsn) ->
-    Prefix = get_rt_config(cs, Vsn),
-    RepairScriptWild = string:join([riakcs_libpath(Prefix, N), "riak_cs*",
-                                    "priv/tools/repair_gc_bucket.erl"] , "/"),
-    [RepairScript] = filelib:wildcard(RepairScriptWild),
-    Cmd = riakcscmd(Prefix, N, "escript " ++ RepairScript ++
-                        " " ++ Options),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-exec_priv_escript(N, Command, Options) ->
-    exec_priv_escript(N, Command, Options, cs).
-
-exec_priv_escript(N, Command, Options, ByWhom) ->
-    CsPrefix = get_rt_config(cs, current),
-    ExecuterPrefix = get_rt_config(ByWhom, current),
-    ScriptWild = string:join([riakcs_libpath(CsPrefix, N), "riak_cs*",
-                              "priv/tools/"] , "/"),
-    [ToolsDir] = filelib:wildcard(ScriptWild),
-    Cmd = case ByWhom of
-              cs ->
-                  riakcscmd(ExecuterPrefix, N, "escript " ++ ToolsDir ++
-                                "/" ++ Command ++
-                                " " ++ Options);
-              riak ->
-                  riakcmd(ExecuterPrefix, N, "escript " ++ ToolsDir ++
-                              "/" ++ Command ++
-                              " " ++ Options)
-          end,
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-switch_stanchion_cs(N, Host, Port) -> switch_stanchion_cs(N, Host, Port, current).
-
-switch_stanchion_cs(N, Host, Port, Vsn) ->
-    SubCmd = io_lib:format("switch ~s ~p", [Host, Port]),
-    Cmd = riakcs_switchcmd(get_rt_config(cs, Vsn), N, SubCmd),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-show_stanchion_cs(N) -> show_stanchion_cs(N, current).
-
-show_stanchion_cs(N, Vsn) ->
-    Cmd = riakcs_switchcmd(get_rt_config(cs, Vsn), N, "show"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-start_stanchion() -> start_stanchion(current).
-
-start_stanchion(Vsn) ->
-    Cmd = stanchioncmd(get_rt_config(stanchion, Vsn), "start"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-stop_stanchion() -> stop_stanchion(current).
-
-stop_stanchion(Vsn) ->
-    Cmd = stanchioncmd(get_rt_config(stanchion, Vsn), "stop"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-flush_access(N) -> flush_access(N, current).
-
-flush_access(N, Vsn) ->
-    Cmd = riakcs_accesscmd(get_rt_config(cs, Vsn), N, "flush"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-gc(N, SubCmd) -> gc(N, SubCmd, current).
-
-gc(N, SubCmd, Vsn) ->
-    Cmd = riakcs_gccmd(get_rt_config(cs, Vsn), N, SubCmd),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-calculate_storage(N) -> calculate_storage(N, current).
-
-calculate_storage(N, Vsn) ->
-    Cmd = riakcs_storagecmd(get_rt_config(cs, Vsn), N, "batch -r"),
-    lager:info("Running ~p", [Cmd]),
-    os:cmd(Cmd).
-
-enable_proxy_get(SrcN, Vsn, SinkCluster) ->
-    rtdev:run_riak_repl(SrcN, get_rt_config(riak, Vsn),
-                        "proxy_get enable " ++ SinkCluster).
-
-disable_proxy_get(SrcN, Vsn, SinkCluster) ->
-    rtdev:run_riak_repl(SrcN, get_rt_config(riak, Vsn),
-                        "proxy_get disable " ++ SinkCluster).
-
-read_config(Vsn, N, Who) ->
-    Prefix = get_rt_config(Who, Vsn),
-    EtcPath = case Who of
-                  cs -> riakcs_etcpath(Prefix, N);
-                  stanchion -> stanchion_etcpath(Prefix)
-              end,
-    case file:consult(EtcPath ++ "/advanced.config") of
-         {ok, [Config]} ->
-             Config;
-         {error, enoent}->
-             {ok, [Config]} = file:consult(EtcPath ++ "/app.config"),
-             Config
-     end.
-
-update_cs_config(Prefix, N, Config, {_,_} = AdminCred) ->
-    update_cs_config(Prefix, N, Config, fun(_,Config0,_) -> Config0 end, AdminCred);
-update_cs_config(Prefix, N, Config, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
-    update_cs_config1(Prefix, N, Config, ConfigUpdateFun).
-
-update_cs_config(Prefix, N, Config, ConfigUpdateFun, {AdminKey, AdminSecret}) ->
-    CSSection = proplists:get_value(riak_cs, Config),
-    UpdConfig = [{riak_cs, update_admin_creds(CSSection, AdminKey, AdminSecret)} |
-                 proplists:delete(riak_cs, Config)],
-    update_cs_config1(Prefix, N, UpdConfig, ConfigUpdateFun).
-
-update_cs_config1(Prefix, N, Config, ConfigUpdateFun) ->
-    CSSection = proplists:get_value(riak_cs, Config),
-    UpdConfig0 = [{riak_cs, update_cs_port(CSSection, N)} |
-                  proplists:delete(riak_cs, Config)],
-    UpdConfig = ConfigUpdateFun(cs, UpdConfig0, N),
-    update_app_config(riakcs_etcpath(Prefix, N), UpdConfig).
-
-update_admin_creds(Config, AdminKey, AdminSecret) ->
-    [{admin_key, AdminKey}, {admin_secret, AdminSecret} |
-     proplists:delete(admin_secret,
-                      proplists:delete(admin_key, Config))].
-
-update_cs_port(Config, N) ->
-    Config2 = [{riak_host, {"127.0.0.1", pb_port(N)}} | proplists:delete(riak_host, Config)],
-    [{listener, {"127.0.0.1", cs_port(N)}} | proplists:delete(listener, Config2)].
-
-update_stanchion_config(Prefix, Config, {_,_} = AdminCreds) ->
-    update_stanchion_config(Prefix, Config, fun(_,Config0,_) -> Config0 end, AdminCreds);
-update_stanchion_config(Prefix, Config, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
-    update_stanchion_config1(Prefix, Config, ConfigUpdateFun).
-
-update_stanchion_config(Prefix, Config, ConfigUpdateFun, {AdminKey, AdminSecret}) ->
-    StanchionSection = proplists:get_value(stanchion, Config),
-    UpdConfig = [{stanchion, update_admin_creds(StanchionSection, AdminKey, AdminSecret)} |
-                 proplists:delete(stanchion, Config)],
-    update_stanchion_config1(Prefix, UpdConfig, ConfigUpdateFun).
-
-update_stanchion_config1(Prefix, Config0, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
-    Config = ConfigUpdateFun(stanchion, Config0, undefined),
-    update_app_config(stanchion_etcpath(Prefix), Config).
-
-update_app_config(Path, Config) ->
-    lager:debug("rtcs:update_app_config(~s,~p)", [Path, Config]),
-    FileFormatString = "~s/~s.config",
-    AppConfigFile = io_lib:format(FileFormatString, [Path, "app"]),
-    AdvConfigFile = io_lib:format(FileFormatString, [Path, "advanced"]),
-
-    {BaseConfig, ConfigFile} = case file:consult(AppConfigFile) of
-        {ok, [ValidConfig]} ->
-            {ValidConfig, AppConfigFile};
-        {error, enoent} ->
-            {ok, [ValidConfig]} = file:consult(AdvConfigFile),
-            {ValidConfig, AdvConfigFile}
-    end,
-    lager:debug("updating ~s", [ConfigFile]),
-
-    MergeA = orddict:from_list(Config),
-    MergeB = orddict:from_list(BaseConfig),
-    NewConfig =
-        orddict:merge(fun(_, VarsA, VarsB) ->
-                              MergeC = orddict:from_list(VarsA),
-                              MergeD = orddict:from_list(VarsB),
-                              orddict:merge(fun(_, ValA, _ValB) ->
-                                                    ValA
-                                            end, MergeC, MergeD)
-                      end, MergeA, MergeB),
-    NewConfigOut = io_lib:format("~p.", [NewConfig]),
-    ?assertEqual(ok, file:write_file(ConfigFile, NewConfigOut)),
-    ok.
-
-enable_zdbbl(Vsn) ->
-    Fs = filelib:wildcard(filename:join([get_rt_config(riak, Vsn),
-                                         "dev", "dev*", "etc", "vm.args"])),
-    lager:info("rtcs:enable_zdbbl for vm.args : ~p~n", [Fs]),
-    [os:cmd("sed -i -e 's/##+zdbbl /+zdbbl /g' " ++ F) || F <- Fs],
-    ok.
 
 create_user(Port, EmailAddr, Name) ->
     create_user(Port, undefined, EmailAddr, Name).
@@ -967,7 +326,7 @@ assert_error_log_empty(N) ->
     assert_error_log_empty(current, N).
 
 assert_error_log_empty(Vsn, N) ->
-    ErrorLog = riakcs_logpath(get_rt_config(cs, Vsn), N, "error.log"),
+    ErrorLog = rtcs_config:riakcs_logpath(rtcs_config:get_rt_config(cs, Vsn), N, "error.log"),
     case file:read_file(ErrorLog) of
         {error, enoent} -> ok;
         {ok, <<>>} -> ok;
@@ -982,8 +341,8 @@ assert_error_log_empty(Vsn, N) ->
 
 truncate_error_log(N) ->
     Cmd = os:find_executable("rm"),
-    ErrorLog = riakcs_logpath(rt_config:get(?CS_CURRENT), N, "error.log"),
-    ok = rtcs:cmd(Cmd, [{args, ["-f", ErrorLog]}]).
+    ErrorLog = rtcs_config:riakcs_logpath(rt_config:get(rtcs_config:cs_current()), N, "error.log"),
+    ok = rtcs_exec:cmd(Cmd, [{args, ["-f", ErrorLog]}]).
 
 wait_until(_, _, 0, _) ->
     fail;
@@ -1080,135 +439,6 @@ assert_versions(App, Nodes, Regexp) ->
      end ||
         N <- Nodes].
 
-%% @doc update current app.config, assuming CS is already stopped
-upgrade_cs(N, AdminCreds) ->
-    migrate_cs(previous, current, N, AdminCreds).
-
-%% @doc update config file from `From' to `To' version.
-migrate_cs(From, To, N, AdminCreds) ->
-    migrate(From, To, N, AdminCreds, cs).
-
-migrate(From, To, N, AdminCreds, Who) when
-      (From =:= current andalso To =:= previous)
-      orelse ( From =:= previous andalso To =:= current) ->
-    Config0 = read_config(From, N, Who),
-    Config1 = migrate_config(From, To, Config0, Who),
-    Prefix = get_rt_config(Who, To),
-    lager:debug("migrating ~s => ~s", [get_rt_config(Who, From), Prefix]),
-    case Who of
-        cs -> update_cs_config(Prefix, N, Config1, AdminCreds);
-        stanchion -> update_stanchion_config(Prefix, Config1, AdminCreds)
-    end.
-
-migrate_stanchion(From, To, AdminCreds) ->
-    migrate(From, To, -1, AdminCreds, stanchion).
-
-migrate_config(previous, current, Conf, stanchion) ->
-    {AddList, RemoveList} = diff_config(stanchion_config(),
-                                        previous_stanchion_config()),
-    migrate_config(Conf, AddList, RemoveList);
-migrate_config(current, previous, Conf, stanchion) ->
-    {AddList, RemoveList} = diff_config(previous_stanchion_config(),
-                                        stanchion_config()),
-    migrate_config(Conf, AddList, RemoveList);
-migrate_config(previous, current, Conf, cs) ->
-    {AddList, RemoveList} = diff_config(cs_config([{anonymous_user_creation, false}]),
-                                        previous_cs_config()),
-    migrate_config(Conf, AddList, RemoveList);
-migrate_config(current, previous, Conf, cs) ->
-    {AddList, RemoveList} = diff_config(previous_cs_config(), cs_config()),
-    migrate_config(Conf, AddList, RemoveList).
-
-migrate_config(Conf0, AddList, RemoveList) ->
-    RemoveFun = fun(Key, Config) ->
-                  InnerConf0 = proplists:get_value(Key, Config),
-                  InnerRemoveList = proplists:get_value(Key, RemoveList),
-                  InnerConf1 = lists:foldl(fun proplists:delete/2,
-                                           InnerConf0,
-                                           proplists:get_keys(InnerRemoveList)),
-                  replace(Key, InnerConf1, Config)
-          end,
-    Conf1 = lists:foldl(RemoveFun, Conf0, proplists:get_keys(RemoveList)),
-
-    AddFun = fun(Key, Config) ->
-                  InnerConf = proplists:get_value(Key, Config)
-                              ++ proplists:get_value(Key, AddList),
-                  replace(Key, InnerConf, Config)
-             end,
-    lists:foldl(AddFun, Conf1, proplists:get_keys(AddList)).
-
-diff_config(Conf, BaseConf)->
-    Keys = lists:umerge(proplists:get_keys(Conf),
-                        proplists:get_keys(BaseConf)),
-
-    Fun = fun(Key, {AddList, RemoveList}) ->
-                  {Add, Remove} = diff_props(proplists:get_value(Key,Conf),
-                                             proplists:get_value(Key, BaseConf)),
-                  case {Add, Remove} of
-                      {[], []} ->
-                          {AddList, RemoveList};
-                      {{}, Remove} ->
-                          {AddList, RemoveList++[{Key, Remove}]};
-                      {Add, []} ->
-                          {AddList++[{Key, Add}], RemoveList};
-                      {Add, Remove} ->
-                          {AddList++[{Key, Add}], RemoveList++[{Key, Remove}]}
-                  end
-          end,
-    lists:foldl(Fun, {[], []}, Keys).
-
-diff_props(undefined, BaseProps) ->
-    {[], BaseProps};
-diff_props(Props, undefined) ->
-    {Props, []};
-diff_props(Props, BaseProps) ->
-    Keys = lists:umerge(proplists:get_keys(Props),
-                        proplists:get_keys(BaseProps)),
-    Fun = fun(Key, {Add, Remove}) ->
-                  Values = {proplists:get_value(Key, Props),
-                            proplists:get_value(Key, BaseProps)},
-                  case Values of
-                      {undefined, V2} ->
-                          {Add, Remove++[{Key, V2}]};
-                      {V1, undefined} ->
-                          {Add++[{Key, V1}], Remove};
-                      {V, V} ->
-                          {Add, Remove};
-                      {V1, V2} ->
-                          {Add++[{Key, V1}], Remove++[{Key, V2}]}
-                  end
-          end,
-    lists:foldl(Fun, {[], []}, Keys).
-
-%% TODO: this is added as riak-1.4 branch of riak_test/src/rt_cs_dev.erl
-%% throws out the return value. Let's get rid of these functions when
-%% we entered to Riak CS 2.0 dev, updating to riak_test master branch
-cmd(Cmd, Opts) ->
-    cmd(Cmd, Opts, rt_config:get(rt_max_wait_time)).
-
-cmd(Cmd, Opts, WaitTime) ->
-    lager:info("Command: ~s", [Cmd]),
-    lager:info("Options: ~p", [Opts]),
-    Port = open_port({spawn_executable, Cmd},
-                     [in, exit_status, binary,
-                      stream, stderr_to_stdout,{line, 200} | Opts]),
-    get_cmd_result(Port, WaitTime).
-
-get_cmd_result(Port, WaitTime) ->
-    receive
-        {Port, {data, {Flag, Line}}} when Flag =:= eol orelse Flag =:= noeol ->
-            lager:info(Line),
-            get_cmd_result(Port, WaitTime);
-        {Port, {exit_status, 0}} ->
-            ok;
-        {Port, {exit_status, Status}} ->
-            {error, {exit_status, Status}};
-        {Port, Other} ->
-            lager:warning("Other data from port: ~p", [Other]),
-            get_cmd_result(Port, WaitTime)
-    after WaitTime ->
-            {error, timeout}
-    end.
 
 %% Copy from rts:iso8601/1
 iso8601(Timestamp) when is_integer(Timestamp) ->

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -88,10 +88,8 @@ setup_clusters(Configs, ConfigFun, JoinFun, NumNodes, Vsn) ->
     application:load(sasl),
     application:set_env(sasl, sasl_error_logger, false),
 
-    Cfgs = rtcs_config:configs(Configs),
-    lager:info("Configs = ~p", [ Cfgs]),
     {RiakNodes, _CSNodes, _Stanchion} = Nodes =
-        deploy_nodes(NumNodes, Cfgs, ConfigFun, Vsn),
+        deploy_nodes(NumNodes, rtcs_config:configs(Configs), ConfigFun, Vsn),
     rt:wait_until_nodes_ready(RiakNodes),
     lager:info("Make cluster"),
     JoinFun(RiakNodes),

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -148,7 +148,7 @@ deploy_nodes(NumNodes, InitialConfig, Vsn)
     CSNodeMap = orddict:from_list(lists:zip(CSNodes, lists:seq(1, NumNodes))),
     rt_config:set(rt_cs_nodes, CSNodeMap),
 
-    {_RiakRoot, RiakVsn} = rt_cs_dev:riak_root_and_vsn(Vsn, rt_config:get(build_type, oss)),
+    {_RiakRoot, RiakVsn} = rtcs_dev:riak_root_and_vsn(Vsn, rt_config:get(build_type, oss)),
     lager:debug("setting rt_versions> ~p =>", [Vsn]),
 
     VersionMap = lists:zip(lists:seq(1, NumNodes), lists:duplicate(NumNodes, RiakVsn)),
@@ -156,7 +156,7 @@ deploy_nodes(NumNodes, InitialConfig, Vsn)
 
     rtcs_exec:stop_all_nodes(node_list(NumNodes), Vsn),
 
-    rt_cs_dev:create_dirs(RiakNodes),
+    rtcs_dev:create_dirs(RiakNodes),
 
     %% Set initial config
     rtcs_config:set_configs(NumNodes,
@@ -186,9 +186,9 @@ setup_admin_user(NumNodes, Vsn)
 
     AdminConf = [{admin_key, KeyID}, {admin_secret, KeySecret}],
     rt:pmap(fun(N) ->
-                    rt_cs_dev:set_advanced_conf({cs, Vsn, N}, [{riak_cs, AdminConf}])
+                    rtcs_dev:set_advanced_conf({cs, Vsn, N}, [{riak_cs, AdminConf}])
             end, lists:seq(1, NumNodes)),
-    rt_cs_dev:set_advanced_conf({stanchion, Vsn}, [{stanchion, AdminConf}]),
+    rtcs_dev:set_advanced_conf({stanchion, Vsn}, [{stanchion, AdminConf}]),
 
     UpdateFun = fun({Node, App}) ->
                         ok = rpc:call(Node, application, set_env,

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -121,14 +121,6 @@ riak_id_per_cluster(NumNodes) ->
         {multibag, _} = Flavor -> rtcs_bag:riak_id_per_cluster(NumNodes, Flavor)
     end.
 
-deploy_stanchion(Config) ->
-    %% Set initial config
-    ConfigFun = fun(_, Config0, _) -> Config0 end,
-    rtcs_config:update_stanchion_config(rt_config:get(rtcs_config:stanchion_current()), Config, ConfigFun),
-
-    rtcs_exec:start_stanchion(),
-    lager:info("Stanchion started").
-
 create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),
     User = "Test User" ++ integer_to_list(UserIndex),

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -92,10 +92,7 @@ setup_clusters(Configs, JoinFun, NumNodes, Vsn) ->
     ?assertEqual(ok, wait_until_nodes_ready(RiakNodes)),
     ?assertEqual(ok, wait_until_no_pending_changes(RiakNodes)),
     rt:wait_until_ring_converged(RiakNodes),
-    {AdminKeyId, AdminSecretKey} = setup_admin_user(NumNodes, Vsn),
-    AdminConfig = rtcs_config:config(AdminKeyId,
-                                     AdminSecretKey,
-                                     rtcs_config:cs_port(hd(RiakNodes))),
+    AdminConfig = setup_admin_user(NumNodes, Vsn),
     {AdminConfig, Nodes}.
 
 
@@ -164,7 +161,9 @@ setup_admin_user(NumNodes, Vsn)
   when Vsn =:= current orelse Vsn =:= previous ->
 
     %% Create admin user and set in cs and stanchion configs
-    {KeyID, KeySecret} = AdminCreds = rtcs_admin:create_admin_user(1),
+    AdminCreds = rtcs_admin:create_admin_user(1),
+    #aws_config{access_key_id=KeyID,
+                secret_access_key=KeySecret} = AdminCreds,
 
     AdminConf = [{admin_key, KeyID}, {admin_secret, KeySecret}],
     rt:pmap(fun(N) ->

--- a/riak_test/src/rtcs_admin.erl
+++ b/riak_test/src/rtcs_admin.erl
@@ -26,11 +26,20 @@
          create_user/4,
          create_admin_user/1,
          update_user/5,
-         list_users/4]).
+         list_users/4,
+         make_authorization/5,
+         make_authorization/6,
+         make_authorization/7,
+         aws_config/2,
+         aws_config/3]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
+
+-define(S3_HOST, "s3.amazonaws.com").
+-define(DEFAULT_PROTO, "http").
+-define(PROXY_HOST, "localhost").
 
 -spec storage_stats_json_request(#aws_config{}, #aws_config{}, string(), string()) ->
                                         [{string(), {non_neg_integer(), non_neg_integer()}}].
@@ -40,31 +49,33 @@ storage_stats_json_request(AdminConfig, UserConfig, Begin, End) ->
     {struct, Slice} = latest(Samples, undefined),
     by_bucket_list(Slice, []).
 
--spec(create_admin_user(atom()) -> {string(), string()}).
+-spec(create_admin_user(atom()) -> #aws_config{}).
 create_admin_user(Node) ->
     User = "admin",
     Email = "admin@me.com",
-    {KeyId, Secret, Id} = create_user(rtcs_config:cs_port(Node), Email, User),
+    {UserConfig, Id} = create_user(rtcs_config:cs_port(Node), Email, User),
     lager:info("Riak CS Admin account created with ~p",[Email]),
-    lager:info("KeyId = ~p",[KeyId]),
-    lager:info("KeySecret = ~p",[Secret]),
+    lager:info("KeyId = ~p",[UserConfig#aws_config.access_key_id]),
+    lager:info("KeySecret = ~p",[UserConfig#aws_config.secret_access_key]),
     lager:info("Id = ~p",[Id]),
-    {KeyId, Secret}.
+    UserConfig.
 
--spec(create_user(atom(), non_neg_integer()) -> {string(), string()}).
+-spec(create_user(atom(), non_neg_integer()) -> #aws_config{}).
 create_user(Node, UserIndex) ->
     {A, B, C} = erlang:now(),
     User = "Test User" ++ integer_to_list(UserIndex),
     Email = lists:flatten(io_lib:format("~p~p~p@basho.com", [A, B, C])),
-    {KeyId, Secret, _Id} = create_user(rtcs_config:cs_port(Node), Email, User),
-    lager:info("Created user ~p with keys ~p ~p", [Email, KeyId, Secret]),
-    {KeyId, Secret}.
+    {UserConfig, _Id} = create_user(rtcs_config:cs_port(Node), Email, User),
+    lager:info("Created user ~p with keys ~p ~p", [Email,
+                                                   UserConfig#aws_config.access_key_id,
+                                                   UserConfig#aws_config.secret_access_key]),
+    UserConfig.
 
--spec(create_user(non_neg_integer(), string(), string()) -> {string(), string(), string()}).
+-spec(create_user(non_neg_integer(), string(), string()) -> {#aws_config{}, string()}).
 create_user(Port, EmailAddr, Name) ->
     create_user(Port, undefined, EmailAddr, Name).
 
--spec(create_user(non_neg_integer(), string(), string(), string()) -> {string(), string(), string()}).
+-spec(create_user(non_neg_integer(), string(), string(), string()) -> {#aws_config{}, string()}).
 create_user(Port, UserConfig, EmailAddr, Name) ->
     lager:debug("Trying to create user ~p", [EmailAddr]),
     Resource = "/riak-cs/user",
@@ -97,7 +108,7 @@ create_user(Port, UserConfig, EmailAddr, Name) ->
     KeyId = binary_to_list(proplists:get_value(<<"key_id">>, JsonData)),
     KeySecret = binary_to_list(proplists:get_value(<<"key_secret">>, JsonData)),
     Id = binary_to_list(proplists:get_value(<<"id">>, JsonData)),
-    {KeyId, KeySecret, Id}.
+    {aws_config(KeyId, KeySecret, Port), Id}.
 
 -spec(update_user(#aws_config{}, non_neg_integer(), string(), string(), string()) -> string()).
 update_user(UserConfig, Port, Resource, ContentType, UpdateDoc) ->
@@ -133,7 +144,75 @@ list_users(UserConfig, Port, Resource, AcceptContentType) ->
     lager:debug("List users output=~p~n",[Output]),
     Output.
 
+-spec(make_authorization(string(), string(), string(), #aws_config{}, string()) -> string()).
+make_authorization(Method, Resource, ContentType, Config, Date) ->
+    make_authorization(Method, Resource, ContentType, Config, Date, []).
+
+-spec(make_authorization(string(), string(), string(), #aws_config{}, string(), [{string(), string()}]) -> string()).
+make_authorization(Method, Resource, ContentType, Config, Date, AmzHeaders) ->
+    make_authorization(s3, Method, Resource, ContentType, Config, Date, AmzHeaders).
+
+-spec(make_authorization(atom(), string(), string(), string(), #aws_config{}, string(), [{string(), string()}]) -> string()).
+make_authorization(Type, Method, Resource, ContentType, Config, Date, AmzHeaders) ->
+    Prefix = case Type of
+                 s3 -> "AWS";
+                 velvet -> "MOSS"
+             end,
+    StsAmzHeaderPart = [[K, $:, V, $\n] || {K, V} <- AmzHeaders],
+    StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n,
+                    StsAmzHeaderPart, Resource],
+    lager:debug("StringToSign~n~s~n", [StringToSign]),
+    Signature =
+        base64:encode_to_string(rtcs:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    lists:flatten([Prefix, " ", Config#aws_config.access_key_id, $:, Signature]).
+
+-spec(aws_config(string(), string(), non_neg_integer()) -> #aws_config{}).
+aws_config(Key, Secret, Port) ->
+    erlcloud_s3:new(Key,
+                    Secret,
+                    ?S3_HOST,
+                    Port, % inets issue precludes using ?S3_PORT
+                    ?DEFAULT_PROTO,
+                    ?PROXY_HOST,
+                    Port,
+                    []).
+
+-spec(aws_config(#aws_config{}, [{atom(), term()}]) -> #aws_config{}).
+aws_config(UserConfig, []) ->
+    UserConfig;
+aws_config(UserConfig, [{port, Port}|Props]) ->
+    UpdConfig = erlcloud_s3:new(UserConfig#aws_config.access_key_id,
+                                UserConfig#aws_config.secret_access_key,
+                                ?S3_HOST,
+                                Port, % inets issue precludes using ?S3_PORT
+                                ?DEFAULT_PROTO,
+                                ?PROXY_HOST,
+                                Port,
+                                []),
+    aws_config(UpdConfig, Props);
+aws_config(UserConfig, [{key, KeyId}|Props]) ->
+    UpdConfig = erlcloud_s3:new(KeyId,
+                                UserConfig#aws_config.secret_access_key,
+                                ?S3_HOST,
+                                UserConfig#aws_config.s3_port, % inets issue precludes using ?S3_PORT
+                                ?DEFAULT_PROTO,
+                                ?PROXY_HOST,
+                                UserConfig#aws_config.s3_port,
+                                []),
+    aws_config(UpdConfig, Props);
+aws_config(UserConfig, [{secret, Secret}|Props]) ->
+    UpdConfig = erlcloud_s3:new(UserConfig#aws_config.access_key_id,
+                                Secret,
+                                ?S3_HOST,
+                                UserConfig#aws_config.s3_port, % inets issue precludes using ?S3_PORT
+                                ?DEFAULT_PROTO,
+                                ?PROXY_HOST,
+                                UserConfig#aws_config.s3_port,
+                                []),
+    aws_config(UpdConfig, Props).
+
 %% private
+
 
 latest([], {_, Candidate}) ->
     Candidate;
@@ -166,21 +245,3 @@ samples_from_json_request(AdminConfig, UserConfig, {Begin, End}) ->
     Usage = mochijson2:decode(proplists:get_value(content, GetResult)),
     rtcs:json_get([<<"Storage">>, <<"Samples">>], Usage).
 
-make_authorization(Method, Resource, ContentType, Config, Date) ->
-    make_authorization(Method, Resource, ContentType, Config, Date, []).
-
-make_authorization(Method, Resource, ContentType, Config, Date, AmzHeaders) ->
-    make_authorization(s3, Method, Resource, ContentType, Config, Date, AmzHeaders).
-
-make_authorization(Type, Method, Resource, ContentType, Config, Date, AmzHeaders) ->
-    Prefix = case Type of
-                 s3 -> "AWS";
-                 velvet -> "MOSS"
-             end,
-    StsAmzHeaderPart = [[K, $:, V, $\n] || {K, V} <- AmzHeaders],
-    StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n,
-                    StsAmzHeaderPart, Resource],
-    lager:debug("StringToSign~n~s~n", [StringToSign]),
-    Signature =
-        base64:encode_to_string(rtcs:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
-    lists:flatten([Prefix, " ", Config#aws_config.access_key_id, $:, Signature]).

--- a/riak_test/src/rtcs_admin.erl
+++ b/riak_test/src/rtcs_admin.erl
@@ -20,7 +20,13 @@
 
 -module(rtcs_admin).
 
--export([storage_stats_json_request/4]).
+-export([storage_stats_json_request/4,
+         create_user/2,
+         create_user/3,
+         create_user/4,
+         create_admin_user/1,
+         update_user/5,
+         list_users/4]).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
@@ -33,6 +39,101 @@ storage_stats_json_request(AdminConfig, UserConfig, Begin, End) ->
     lager:debug("Storage samples[json]: ~p", [Samples]),
     {struct, Slice} = latest(Samples, undefined),
     by_bucket_list(Slice, []).
+
+-spec(create_admin_user(atom()) -> {string(), string()}).
+create_admin_user(Node) ->
+    User = "admin",
+    Email = "admin@me.com",
+    {KeyId, Secret, Id} = create_user(rtcs_config:cs_port(Node), Email, User),
+    lager:info("Riak CS Admin account created with ~p",[Email]),
+    lager:info("KeyId = ~p",[KeyId]),
+    lager:info("KeySecret = ~p",[Secret]),
+    lager:info("Id = ~p",[Id]),
+    {KeyId, Secret}.
+
+-spec(create_user(atom(), non_neg_integer()) -> {string(), string()}).
+create_user(Node, UserIndex) ->
+    {A, B, C} = erlang:now(),
+    User = "Test User" ++ integer_to_list(UserIndex),
+    Email = lists:flatten(io_lib:format("~p~p~p@basho.com", [A, B, C])),
+    {KeyId, Secret, _Id} = create_user(rtcs_config:cs_port(Node), Email, User),
+    lager:info("Created user ~p with keys ~p ~p", [Email, KeyId, Secret]),
+    {KeyId, Secret}.
+
+-spec(create_user(non_neg_integer(), string(), string()) -> {string(), string(), string()}).
+create_user(Port, EmailAddr, Name) ->
+    create_user(Port, undefined, EmailAddr, Name).
+
+-spec(create_user(non_neg_integer(), string(), string(), string()) -> {string(), string(), string()}).
+create_user(Port, UserConfig, EmailAddr, Name) ->
+    lager:debug("Trying to create user ~p", [EmailAddr]),
+    Resource = "/riak-cs/user",
+    Date = httpd_util:rfc1123_date(),
+    Cmd="curl -s -H 'Content-Type: application/json' " ++
+        "-H 'Date: " ++ Date ++ "' " ++
+        case UserConfig of
+            undefined -> "";
+            _ ->
+                "-H 'Authorization: " ++
+                    make_authorization("POST", Resource, "application/json",
+                                       UserConfig, Date) ++
+                    "' "
+        end ++
+        "http://localhost:" ++
+        integer_to_list(Port) ++
+        Resource ++
+        " --data '{\"email\":\"" ++ EmailAddr ++  "\", \"name\":\"" ++ Name ++"\"}'",
+    lager:debug("Cmd: ~p", [Cmd]),
+    Delay = rt_config:get(rt_retry_delay),
+    Retries = rt_config:get(rt_max_wait_time) div Delay,
+    OutputFun = fun() -> rt:cmd(Cmd) end,
+    Condition = fun({Status, Res}) ->
+                        lager:debug("Return (~p), Res: ~p", [Status, Res]),
+                        Status =:= 0 andalso Res /= []
+                end,
+    {_Status, Output} = rtcs:wait_until(OutputFun, Condition, Retries, Delay),
+    lager:debug("Create user output=~p~n",[Output]),
+    {struct, JsonData} = mochijson2:decode(Output),
+    KeyId = binary_to_list(proplists:get_value(<<"key_id">>, JsonData)),
+    KeySecret = binary_to_list(proplists:get_value(<<"key_secret">>, JsonData)),
+    Id = binary_to_list(proplists:get_value(<<"id">>, JsonData)),
+    {KeyId, KeySecret, Id}.
+
+-spec(update_user(#aws_config{}, non_neg_integer(), string(), string(), string()) -> string()).
+update_user(UserConfig, Port, Resource, ContentType, UpdateDoc) ->
+    Date = httpd_util:rfc1123_date(),
+    Cmd="curl -s -X PUT -H 'Date: " ++ Date ++
+        "' -H 'Content-Type: " ++ ContentType ++
+        "' -H 'Authorization: " ++
+        make_authorization("PUT", Resource, ContentType, UserConfig, Date) ++
+        "' http://localhost:" ++ integer_to_list(Port) ++
+        Resource ++ " --data-binary " ++ UpdateDoc,
+    Delay = rt_config:get(rt_retry_delay),
+    Retries = rt_config:get(rt_max_wait_time) div Delay,
+    OutputFun = fun() -> os:cmd(Cmd) end,
+    Condition = fun(Res) -> Res /= [] end,
+    Output = rtcs:wait_until(OutputFun, Condition, Retries, Delay),
+    lager:debug("Update user output=~p~n",[Output]),
+    Output.
+
+-spec(list_users(#aws_config{}, non_neg_integer(), string(), string()) -> string()).
+list_users(UserConfig, Port, Resource, AcceptContentType) ->
+    Date = httpd_util:rfc1123_date(),
+    Cmd="curl -s -H 'Date: " ++ Date ++
+        "' -H 'Accept: " ++ AcceptContentType ++
+        "' -H 'Authorization: " ++
+        make_authorization("GET", Resource, "", UserConfig, Date) ++
+        "' http://localhost:" ++ integer_to_list(Port) ++
+        Resource,
+    Delay = rt_config:get(rt_retry_delay),
+    Retries = rt_config:get(rt_max_wait_time) div Delay,
+    OutputFun = fun() -> os:cmd(Cmd) end,
+    Condition = fun(Res) -> Res /= [] end,
+    Output = rtcs:wait_until(OutputFun, Condition, Retries, Delay),
+    lager:debug("List users output=~p~n",[Output]),
+    Output.
+
+%% private
 
 latest([], {_, Candidate}) ->
     Candidate;
@@ -64,3 +165,22 @@ samples_from_json_request(AdminConfig, UserConfig, {Begin, End}) ->
     GetResult = erlcloud_s3:get_object("riak-cs", StatsKey, AdminConfig),
     Usage = mochijson2:decode(proplists:get_value(content, GetResult)),
     rtcs:json_get([<<"Storage">>, <<"Samples">>], Usage).
+
+make_authorization(Method, Resource, ContentType, Config, Date) ->
+    make_authorization(Method, Resource, ContentType, Config, Date, []).
+
+make_authorization(Method, Resource, ContentType, Config, Date, AmzHeaders) ->
+    make_authorization(s3, Method, Resource, ContentType, Config, Date, AmzHeaders).
+
+make_authorization(Type, Method, Resource, ContentType, Config, Date, AmzHeaders) ->
+    Prefix = case Type of
+                 s3 -> "AWS";
+                 velvet -> "MOSS"
+             end,
+    StsAmzHeaderPart = [[K, $:, V, $\n] || {K, V} <- AmzHeaders],
+    StringToSign = [Method, $\n, [], $\n, ContentType, $\n, Date, $\n,
+                    StsAmzHeaderPart, Resource],
+    lager:debug("StringToSign~n~s~n", [StringToSign]),
+    Signature =
+        base64:encode_to_string(rtcs:sha_mac(Config#aws_config.secret_access_key, StringToSign)),
+    lists:flatten([Prefix, " ", Config#aws_config.access_key_id, $:, Signature]).

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -78,12 +78,12 @@ config(Key, Secret, Port) ->
 pb_port(N) when is_integer(N) ->
     10000 + (N * 10) + 7;
 pb_port(Node) ->
-    pb_port(rt_cs_dev:node_id(Node)).
+    pb_port(rtcs_dev:node_id(Node)).
 
 cs_port(N) when is_integer(N) ->
     15008 + 10 * N;
 cs_port(Node) ->
-    cs_port(rt_cs_dev:node_id(Node)).
+    cs_port(rtcs_dev:node_id(Node)).
 
 stanchion_port() -> 9095.
 
@@ -364,7 +364,7 @@ devpath(stanchion, previous) -> rt_config:get(?STANCHION_PREVIOUS).
 
 set_configs(NumNodes, Config, Vsn) ->
     rt:pmap(fun(N) ->
-                    rt_cs_dev:update_app_config(rtcs:riak_node(N),
+                    rtcs_dev:update_app_config(rtcs:riak_node(N),
                                                 proplists:get_value(riak, Config)),
                     update_cs_config(devpath(cs, Vsn), N,
                                      proplists:get_value(cs, Config))
@@ -427,9 +427,9 @@ update_app_config(Path, Config) ->
     %% if not, use cuttlefish's adavnced.config
     case filelib:is_file(AppConfigFile) of
         true ->
-            rt_cs_dev:update_app_config_file(AppConfigFile, Config);
+            rtcs_dev:update_app_config_file(AppConfigFile, Config);
         _ ->
-            rt_cs_dev:update_app_config_file(AdvConfigFile, Config)
+            rtcs_dev:update_app_config_file(AdvConfigFile, Config)
     end.
 
 enable_zdbbl(Vsn) ->

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -364,17 +364,15 @@ devpath(stanchion, previous) -> rt_config:get(?STANCHION_PREVIOUS).
 
 set_configs(NumNodes, Config, ConfigFun, Vsn) ->
     rt:pmap(fun(N) ->
-                    rt_cs_dev:update_app_config(rtcs:riak_node(N), proplists:get_value(riak, Config)),
+                    rt_cs_dev:update_app_config(rtcs:riak_node(N),
+                                                proplists:get_value(riak, Config)),
                     update_cs_config(devpath(cs, Vsn), N,
-                                     proplists:get_value(cs, Config), ConfigFun),
-                    case N of
-                        1 -> update_stanchion_config(devpath(stanchion, Vsn),
-                                                     proplists:get_value(stanchion, Config),
-                                                     ConfigFun);
-                        _ -> ok
-                    end
+                                     proplists:get_value(cs, Config), ConfigFun)
             end,
             lists:seq(1, NumNodes)),
+    update_stanchion_config(devpath(stanchion, Vsn),
+                            proplists:get_value(stanchion, Config),
+                            ConfigFun),
     enable_zdbbl(Vsn).
 
 set_admin_creds_in_configs(NodeList, Configs, ConfigFun, AdminCreds, Vsn) ->

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -374,28 +374,6 @@ set_configs(NumNodes, Config, Vsn) ->
                             proplists:get_value(stanchion, Config)),
     enable_zdbbl(Vsn).
 
-set_admin_creds_in_configs(NodeList, Configs, AdminCreds, Vsn) ->
-    rt:pmap(fun({_, default}) ->
-                    ok;
-               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    update_cs_config(devpath(cs, Vsn),
-                                     N,
-                                     proplists:get_value(cs, Config),
-                                     AdminCreds),
-                    update_stanchion_config(devpath(stanchion, Vsn),
-                                            proplists:get_value(stanchion, Config),
-                                            AdminCreds);
-               ({{_CSNode, RiakNode}, Config}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    update_cs_config(devpath(cs, Vsn),
-                                     N,
-                                     proplists:get_value(cs, Config),
-                                     AdminCreds)
-            end,
-            lists:zip(NodeList, Configs)).
-
-
 read_config(Vsn, N, Who) ->
     Prefix = devpath(Who, Vsn),
     EtcPath = case Who of

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -30,10 +30,7 @@
 -define(STANCHION_CURRENT, <<"build_paths.stanchion_current">>).
 -define(STANCHION_PREVIOUS, <<"build_paths.stanchion_previous">>).
 
--define(PROXY_HOST, "localhost").
--define(S3_HOST, "s3.amazonaws.com").
 -define(S3_PORT, 80).
--define(DEFAULT_PROTO, "http").
 
 -define(REQUEST_POOL_SIZE, 8).
 -define(BUCKET_LIST_POOL_SIZE, 2).
@@ -64,16 +61,6 @@ default_configs() ->
     [{riak, riak_config()},
      {stanchion, stanchion_config()},
      {cs, cs_config()}].
-
-config(Key, Secret, Port) ->
-    erlcloud_s3:new(Key,
-                    Secret,
-                    ?S3_HOST,
-                    Port, % inets issue precludes using ?S3_PORT
-                    ?DEFAULT_PROTO,
-                    ?PROXY_HOST,
-                    Port,
-                    []).
 
 pb_port(N) when is_integer(N) ->
     10000 + (N * 10) + 7;

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -1,0 +1,602 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+-module(rtcs_config).
+-compile(export_all).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(RIAK_CURRENT, <<"build_paths.current">>).
+-define(RIAK_PREVIOUS, <<"build_paths.previous">>).
+-define(EE_CURRENT, <<"build_paths.ee_current">>).
+-define(EE_PREVIOUS, <<"build_paths.ee_previous">>).
+-define(CS_CURRENT, <<"build_paths.cs_current">>).
+-define(CS_PREVIOUS, <<"build_paths.cs_previous">>).
+-define(STANCHION_CURRENT, <<"build_paths.stanchion_current">>).
+-define(STANCHION_PREVIOUS, <<"build_paths.stanchion_previous">>).
+
+-define(PROXY_HOST, "localhost").
+-define(S3_HOST, "s3.amazonaws.com").
+-define(S3_PORT, 80).
+-define(DEFAULT_PROTO, "http").
+
+-define(REQUEST_POOL_SIZE, 8).
+-define(BUCKET_LIST_POOL_SIZE, 2).
+
+request_pool_size() ->
+    ?REQUEST_POOL_SIZE.
+
+bucket_list_pool_size() ->
+    ?BUCKET_LIST_POOL_SIZE.
+
+configs(CustomConfigs) ->
+    [{riak, proplists:get_value(riak, CustomConfigs, riak_config())},
+     {cs, proplists:get_value(cs, CustomConfigs, cs_config())},
+     {stanchion, proplists:get_value(stanchion,
+                                     CustomConfigs,
+                                     stanchion_config())}].
+
+previous_configs() ->
+    previous_configs([]).
+
+previous_configs(CustomConfigs) ->
+    [{riak, proplists:get_value(riak, CustomConfigs, previous_riak_config())},
+     {cs, proplists:get_value(cs, CustomConfigs, previous_cs_config())},
+     {stanchion, proplists:get_value(stanchion, CustomConfigs,
+                                     previous_stanchion_config())}].
+
+default_configs() ->
+    [{riak, riak_config()},
+     {stanchion, stanchion_config()},
+     {cs, cs_config()}].
+
+config(Key, Secret, Port) ->
+    erlcloud_s3:new(Key,
+                    Secret,
+                    ?S3_HOST,
+                    Port, % inets issue precludes using ?S3_PORT
+                    ?DEFAULT_PROTO,
+                    ?PROXY_HOST,
+                    Port,
+                    []).
+
+pb_port(N) when is_integer(N) ->
+    10000 + (N * 10) + 7;
+pb_port(Node) ->
+    pb_port(rt_cs_dev:node_id(Node)).
+
+cs_port(N) when is_integer(N) ->
+    15008 + 10 * N;
+cs_port(Node) ->
+    cs_port(rt_cs_dev:node_id(Node)).
+
+stanchion_port() -> 9095.
+
+riak_config(CustomConfig) ->
+    orddict:merge(fun(_, LHS, RHS) -> LHS ++ RHS end,
+                  orddict:from_list(lists:sort(CustomConfig)),
+                  orddict:from_list(lists:sort(riak_config()))).
+
+riak_config() ->
+    riak_config(
+      ?CS_CURRENT,
+      rt_config:get(build_type, oss),
+      rt_config:get(backend, {multi_backend, bitcask})).
+
+riak_config(CsVsn, oss, Backend) ->
+    riak_oss_config(CsVsn, Backend);
+riak_config(CsVsn, ee, Backend) ->
+    riak_ee_config(CsVsn, Backend).
+
+riak_oss_config(CsVsn, Backend) ->
+    CSPath = rt_config:get(CsVsn),
+    AddPaths = filelib:wildcard(CSPath ++ "/dev/dev1/lib/riak_cs*/ebin"),
+    [
+     lager_config(),
+     {riak_core,
+      [{default_bucket_props, [{allow_mult, true}]},
+       {ring_creation_size, 8}]
+     },
+     {riak_api,
+      [{pb_backlog, 256}]},
+     {riak_kv,
+      [{add_paths, AddPaths}] ++
+          backend_config(CsVsn, Backend)
+      }
+    ].
+
+backend_config(_CsVsn, memory) ->
+    [{storage_backend, riak_kv_memory_backend}];
+backend_config(_CsVsn, {multi_backend, BlocksBackend}) ->
+    [
+     {storage_backend, riak_cs_kv_multi_backend},
+     {multi_backend_prefix_list, [{<<"0b:">>, be_blocks}]},
+     {multi_backend_default, be_default},
+     {multi_backend,
+      [{be_default, riak_kv_eleveldb_backend,
+        [
+         {max_open_files, 20},
+         {data_root, "./data/leveldb"}
+        ]},
+       blocks_backend_config(BlocksBackend)
+      ]}
+    ];
+backend_config(?CS_CURRENT, prefix_multi) ->
+    [
+     {storage_backend, riak_kv_multi_prefix_backend},
+     {riak_cs_version, 20000}
+    ];
+backend_config(OlderCsVsn, prefix_multi) ->
+    backend_config(OlderCsVsn, {multi_backend, bitcask}).
+
+blocks_backend_config(fs) ->
+    {be_blocks, riak_kv_fs2_backend, [{data_root, "./data/fs2"},
+                                      {block_size, 1050000}]};
+blocks_backend_config(_) ->
+    {be_blocks, riak_kv_bitcask_backend, [{data_root, "./data/bitcask"}]}.
+
+riak_ee_config(CsVsn, Backend) ->
+    [repl_config() | riak_oss_config(CsVsn, Backend)].
+
+repl_config() ->
+    {riak_repl,
+     [
+      {fullsync_on_connect, false},
+      {fullsync_interval, disabled},
+      {proxy_get, enabled}
+     ]}.
+
+previous_riak_config() ->
+    riak_config(
+      ?CS_PREVIOUS,
+      rt_config:get(build_type, oss),
+      rt_config:get(backend, {multi_backend, bitcask})).
+
+previous_riak_config(CustomConfig) ->
+    orddict:merge(fun(_, LHS, RHS) -> LHS ++ RHS end,
+                  orddict:from_list(lists:sort(CustomConfig)),
+                  orddict:from_list(lists:sort(previous_riak_config()))).
+
+previous_riak_config(oss, Backend) ->
+    riak_oss_config(?CS_PREVIOUS, Backend);
+previous_riak_config(ee, Backend) ->
+    riak_ee_config(?CS_PREVIOUS, Backend).
+
+previous_cs_config() ->
+    previous_cs_config([], []).
+
+previous_cs_config(UserExtra) ->
+    previous_cs_config(UserExtra, []).
+
+previous_cs_config(UserExtra, OtherApps) ->
+    [
+     lager_config(),
+     {riak_cs,
+      UserExtra ++
+          [
+           {connection_pools,
+            [
+             {request_pool, {request_pool_size(), 0} },
+             {bucket_list_pool, {bucket_list_pool_size(), 0} }
+            ]},
+           {block_get_max_retries, 1},
+           {proxy_get, enabled},
+           {anonymous_user_creation, true},
+           {riak_pb_port, 10017},
+           {stanchion_port, stanchion_port()},
+           {cs_version, 010300}
+          ]
+     }] ++ OtherApps.
+
+cs_config() ->
+    cs_config([], []).
+
+cs_config(UserExtra) ->
+    cs_config(UserExtra, []).
+
+cs_config(UserExtra, OtherApps) ->
+    [
+     lager_config(),
+     {riak_cs,
+      UserExtra ++
+          [
+           {connection_pools,
+            [
+             {request_pool, {request_pool_size(), 0} },
+             {bucket_list_pool, {bucket_list_pool_size(), 0} }
+            ]},
+           {block_get_max_retries, 1},
+           {proxy_get, enabled},
+           {anonymous_user_creation, true},
+           {stanchion_host, {"127.0.0.1", stanchion_port()}},
+           {riak_host, {"127.0.0.1", 10017}},
+           {cs_version, 010300}
+          ]
+     }] ++ OtherApps.
+
+replace_cs_config(Key, Value, Config) ->
+    CSConfig0 = proplists:get_value(riak_cs, Config),
+    CSConfig = replace(Key, Value, CSConfig0),
+    replace(riak_cs, CSConfig, Config).
+
+replace(Key, Value, Config0) ->
+    Config1 = proplists:delete(Key, Config0),
+    [proplists:property(Key, Value)|Config1].
+
+replace_stanchion_config(Key, Value, Config) ->
+    CSConfig0 = proplists:get_value(stanchion, Config),
+    CSConfig = replace(Key, Value, CSConfig0),
+    replace(stanchion, CSConfig, Config).
+
+previous_stanchion_config() ->
+    [
+     lager_config(),
+     {stanchion,
+      [
+       {stanchion_port, stanchion_port()},
+       {riak_pb_port, 10017}
+      ]
+     }].
+
+previous_stanchion_config(UserExtra) ->
+    lists:foldl(fun({Key,Value}, Config0) ->
+                        replace_stanchion_config(Key,Value,Config0)
+                end, previous_stanchion_config(), UserExtra).
+
+stanchion_config() ->
+    [
+     lager_config(),
+     {stanchion,
+      [
+       {host, {"127.0.0.1", stanchion_port()}},
+       {riak_host, {"127.0.0.1", 10017}}
+      ]
+     }].
+
+stanchion_config(UserExtra) ->
+    lists:foldl(fun({Key,Value}, Config0) ->
+                        replace_stanchion_config(Key,Value,Config0)
+                end, stanchion_config(), UserExtra).
+
+lager_config() ->
+    {lager,
+     [
+      {handlers,
+       [
+        {lager_file_backend,
+         [
+          {"./log/error.log", error, 10485760, "$D0",5},
+          {"./log/console.log", rt_config:get(console_log_level, debug),
+           10485760, "$D0", 5}
+         ]}
+       ]}
+     ]}.
+
+riak_bitcaskroot(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/data/bitcask", [Prefix, N]).
+
+riak_binpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/bin/riak", [Prefix, N]).
+
+riakcmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [riak_binpath(Path, N), Cmd])).
+
+riakcs_home(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/", [Prefix, N]).
+
+riakcs_binpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/bin/riak-cs", [Prefix, N]).
+
+riakcs_etcpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/etc", [Prefix, N]).
+
+riakcs_libpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/lib", [Prefix, N]).
+
+riakcs_logpath(Prefix, N, File) ->
+    io_lib:format("~s/dev/dev~b/log/~s", [Prefix, N, File]).
+
+riakcscmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_statuscmd(Path, N) ->
+    lists:flatten(io_lib:format("~s-admin status", [riakcs_binpath(Path, N)])).
+
+riakcs_switchcmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin stanchion ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_gccmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin gc ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_accesscmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin access ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_storagecmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin storage ~s", [riakcs_binpath(Path, N), Cmd])).
+
+stanchion_binpath(Prefix) ->
+    io_lib:format("~s/dev/stanchion/bin/stanchion", [Prefix]).
+
+stanchion_etcpath(Prefix) ->
+    io_lib:format("~s/dev/stanchion/etc", [Prefix]).
+
+stanchioncmd(Path, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [stanchion_binpath(Path), Cmd])).
+
+stanchion_statuscmd(Path) ->
+    lists:flatten(io_lib:format("~s-admin status", [stanchion_binpath(Path)])).
+
+cs_current() ->
+    ?CS_CURRENT.
+
+stanchion_current() ->
+    ?STANCHION_CURRENT.
+
+get_rt_config(riak, current) ->
+    case rt_config:get(build_type, oss) of
+        oss -> rt_config:get(?RIAK_CURRENT);
+        ee  -> rt_config:get(?EE_CURRENT)
+    end;
+get_rt_config(riak, previous) ->
+    case rt_config:get(build_type, oss) of
+        oss -> rt_config:get(?RIAK_PREVIOUS);
+        ee  -> rt_config:get(?EE_PREVIOUS)
+    end;
+get_rt_config(cs, current) -> rt_config:get(?CS_CURRENT);
+get_rt_config(cs, previous) -> rt_config:get(?CS_PREVIOUS);
+get_rt_config(stanchion, current) -> rt_config:get(?STANCHION_CURRENT);
+get_rt_config(stanchion, previous) -> rt_config:get(?STANCHION_PREVIOUS).
+
+set_configs(NodeList, Configs, ConfigFun, Vsn) ->
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    rt_cs_dev:update_app_config(RiakNode, proplists:get_value(riak,
+                                                                              Config)),
+                    update_cs_config(get_rt_config(cs, Vsn), N,
+                                     proplists:get_value(cs, Config), ConfigFun),
+                    update_stanchion_config(get_rt_config(stanchion, Vsn),
+                                            proplists:get_value(stanchion, Config),
+                                            ConfigFun);
+               ({{_CSNode, RiakNode}, Config}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    rt_cs_dev:update_app_config(RiakNode,
+                                                proplists:get_value(riak, Config)),
+                    update_cs_config(get_rt_config(cs, Vsn), N,
+                                     proplists:get_value(cs, Config), ConfigFun)
+            end,
+            lists:zip(NodeList, Configs)),
+    enable_zdbbl(Vsn).
+
+set_admin_creds_in_configs(NodeList, Configs, ConfigFun, AdminCreds, Vsn) ->
+    rt:pmap(fun({_, default}) ->
+                    ok;
+               ({{_CSNode, RiakNode, _Stanchion}, Config}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    update_cs_config(get_rt_config(cs, Vsn),
+                                     N,
+                                     proplists:get_value(cs, Config),
+                                     ConfigFun,
+                                     AdminCreds),
+                    update_stanchion_config(get_rt_config(stanchion, Vsn),
+                                            proplists:get_value(stanchion, Config),
+                                            ConfigFun, AdminCreds);
+               ({{_CSNode, RiakNode}, Config}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    update_cs_config(get_rt_config(cs, Vsn),
+                                     N,
+                                     proplists:get_value(cs, Config),
+                                     ConfigFun,
+                                     AdminCreds)
+            end,
+            lists:zip(NodeList, Configs)).
+
+
+read_config(Vsn, N, Who) ->
+    Prefix = get_rt_config(Who, Vsn),
+    EtcPath = case Who of
+                  cs -> riakcs_etcpath(Prefix, N);
+                  stanchion -> stanchion_etcpath(Prefix)
+              end,
+    case file:consult(EtcPath ++ "/advanced.config") of
+         {ok, [Config]} ->
+             Config;
+         {error, enoent}->
+             {ok, [Config]} = file:consult(EtcPath ++ "/app.config"),
+             Config
+     end.
+
+update_cs_config(Prefix, N, Config, {_,_} = AdminCred) ->
+    update_cs_config(Prefix, N, Config, fun(_,Config0,_) -> Config0 end, AdminCred);
+update_cs_config(Prefix, N, Config, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
+    update_cs_config1(Prefix, N, Config, ConfigUpdateFun).
+
+update_cs_config(Prefix, N, Config, ConfigUpdateFun, {AdminKey, AdminSecret}) ->
+    CSSection = proplists:get_value(riak_cs, Config),
+    UpdConfig = [{riak_cs, update_admin_creds(CSSection, AdminKey, AdminSecret)} |
+                 proplists:delete(riak_cs, Config)],
+    update_cs_config1(Prefix, N, UpdConfig, ConfigUpdateFun).
+
+update_cs_config1(Prefix, N, Config, ConfigUpdateFun) ->
+    CSSection = proplists:get_value(riak_cs, Config),
+    UpdConfig0 = [{riak_cs, update_cs_port(CSSection, N)} |
+                  proplists:delete(riak_cs, Config)],
+    UpdConfig = ConfigUpdateFun(cs, UpdConfig0, N),
+    update_app_config(riakcs_etcpath(Prefix, N), UpdConfig).
+
+update_admin_creds(Config, AdminKey, AdminSecret) ->
+    [{admin_key, AdminKey}, {admin_secret, AdminSecret} |
+     proplists:delete(admin_secret,
+                      proplists:delete(admin_key, Config))].
+
+update_cs_port(Config, N) ->
+    Config2 = [{riak_host, {"127.0.0.1", pb_port(N)}} | proplists:delete(riak_host, Config)],
+    [{listener, {"127.0.0.1", cs_port(N)}} | proplists:delete(listener, Config2)].
+
+update_stanchion_config(Prefix, Config, {_,_} = AdminCreds) ->
+    update_stanchion_config(Prefix, Config, fun(_,Config0,_) -> Config0 end, AdminCreds);
+update_stanchion_config(Prefix, Config, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
+    update_stanchion_config1(Prefix, Config, ConfigUpdateFun).
+
+update_stanchion_config(Prefix, Config, ConfigUpdateFun, {AdminKey, AdminSecret}) ->
+    StanchionSection = proplists:get_value(stanchion, Config),
+    UpdConfig = [{stanchion, update_admin_creds(StanchionSection, AdminKey, AdminSecret)} |
+                 proplists:delete(stanchion, Config)],
+    update_stanchion_config1(Prefix, UpdConfig, ConfigUpdateFun).
+
+update_stanchion_config1(Prefix, Config0, ConfigUpdateFun) when is_function(ConfigUpdateFun) ->
+    Config = ConfigUpdateFun(stanchion, Config0, undefined),
+    update_app_config(stanchion_etcpath(Prefix), Config).
+
+update_app_config(Path, Config) ->
+    lager:debug("rtcs:update_app_config(~s,~p)", [Path, Config]),
+    FileFormatString = "~s/~s.config",
+    AppConfigFile = io_lib:format(FileFormatString, [Path, "app"]),
+    AdvConfigFile = io_lib:format(FileFormatString, [Path, "advanced"]),
+
+    {BaseConfig, ConfigFile} = case file:consult(AppConfigFile) of
+        {ok, [ValidConfig]} ->
+            {ValidConfig, AppConfigFile};
+        {error, enoent} ->
+            {ok, [ValidConfig]} = file:consult(AdvConfigFile),
+            {ValidConfig, AdvConfigFile}
+    end,
+    lager:debug("updating ~s", [ConfigFile]),
+
+    MergeA = orddict:from_list(Config),
+    MergeB = orddict:from_list(BaseConfig),
+    NewConfig =
+        orddict:merge(fun(_, VarsA, VarsB) ->
+                              MergeC = orddict:from_list(VarsA),
+                              MergeD = orddict:from_list(VarsB),
+                              orddict:merge(fun(_, ValA, _ValB) ->
+                                                    ValA
+                                            end, MergeC, MergeD)
+                      end, MergeA, MergeB),
+    NewConfigOut = io_lib:format("~p.", [NewConfig]),
+    ?assertEqual(ok, file:write_file(ConfigFile, NewConfigOut)),
+    ok.
+
+enable_zdbbl(Vsn) ->
+    Fs = filelib:wildcard(filename:join([get_rt_config(riak, Vsn),
+                                         "dev", "dev*", "etc", "vm.args"])),
+    lager:info("rtcs:enable_zdbbl for vm.args : ~p~n", [Fs]),
+    [os:cmd("sed -i -e 's/##+zdbbl /+zdbbl /g' " ++ F) || F <- Fs],
+    ok.
+
+%% @doc update current app.config, assuming CS is already stopped
+upgrade_cs(N, AdminCreds) ->
+    migrate_cs(previous, current, N, AdminCreds).
+
+%% @doc update config file from `From' to `To' version.
+migrate_cs(From, To, N, AdminCreds) ->
+    migrate(From, To, N, AdminCreds, cs).
+
+migrate(From, To, N, AdminCreds, Who) when
+      (From =:= current andalso To =:= previous)
+      orelse ( From =:= previous andalso To =:= current) ->
+    Config0 = read_config(From, N, Who),
+    Config1 = migrate_config(From, To, Config0, Who),
+    Prefix = get_rt_config(Who, To),
+    lager:debug("migrating ~s => ~s", [get_rt_config(Who, From), Prefix]),
+    case Who of
+        cs -> update_cs_config(Prefix, N, Config1, AdminCreds);
+        stanchion -> update_stanchion_config(Prefix, Config1, AdminCreds)
+    end.
+
+migrate_stanchion(From, To, AdminCreds) ->
+    migrate(From, To, -1, AdminCreds, stanchion).
+
+migrate_config(previous, current, Conf, stanchion) ->
+    {AddList, RemoveList} = diff_config(stanchion_config(),
+                                        previous_stanchion_config()),
+    migrate_config(Conf, AddList, RemoveList);
+migrate_config(current, previous, Conf, stanchion) ->
+    {AddList, RemoveList} = diff_config(previous_stanchion_config(),
+                                        stanchion_config()),
+    migrate_config(Conf, AddList, RemoveList);
+migrate_config(previous, current, Conf, cs) ->
+    {AddList, RemoveList} = diff_config(cs_config([{anonymous_user_creation, false}]),
+                                        previous_cs_config()),
+    migrate_config(Conf, AddList, RemoveList);
+migrate_config(current, previous, Conf, cs) ->
+    {AddList, RemoveList} = diff_config(previous_cs_config(), cs_config()),
+    migrate_config(Conf, AddList, RemoveList).
+
+migrate_config(Conf0, AddList, RemoveList) ->
+    RemoveFun = fun(Key, Config) ->
+                  InnerConf0 = proplists:get_value(Key, Config),
+                  InnerRemoveList = proplists:get_value(Key, RemoveList),
+                  InnerConf1 = lists:foldl(fun proplists:delete/2,
+                                           InnerConf0,
+                                           proplists:get_keys(InnerRemoveList)),
+                  replace(Key, InnerConf1, Config)
+          end,
+    Conf1 = lists:foldl(RemoveFun, Conf0, proplists:get_keys(RemoveList)),
+
+    AddFun = fun(Key, Config) ->
+                  InnerConf = proplists:get_value(Key, Config)
+                              ++ proplists:get_value(Key, AddList),
+                  replace(Key, InnerConf, Config)
+             end,
+    lists:foldl(AddFun, Conf1, proplists:get_keys(AddList)).
+
+diff_config(Conf, BaseConf)->
+    Keys = lists:umerge(proplists:get_keys(Conf),
+                        proplists:get_keys(BaseConf)),
+
+    Fun = fun(Key, {AddList, RemoveList}) ->
+                  {Add, Remove} = diff_props(proplists:get_value(Key,Conf),
+                                             proplists:get_value(Key, BaseConf)),
+                  case {Add, Remove} of
+                      {[], []} ->
+                          {AddList, RemoveList};
+                      {{}, Remove} ->
+                          {AddList, RemoveList++[{Key, Remove}]};
+                      {Add, []} ->
+                          {AddList++[{Key, Add}], RemoveList};
+                      {Add, Remove} ->
+                          {AddList++[{Key, Add}], RemoveList++[{Key, Remove}]}
+                  end
+          end,
+    lists:foldl(Fun, {[], []}, Keys).
+
+diff_props(undefined, BaseProps) ->
+    {[], BaseProps};
+diff_props(Props, undefined) ->
+    {Props, []};
+diff_props(Props, BaseProps) ->
+    Keys = lists:umerge(proplists:get_keys(Props),
+                        proplists:get_keys(BaseProps)),
+    Fun = fun(Key, {Add, Remove}) ->
+                  Values = {proplists:get_value(Key, Props),
+                            proplists:get_value(Key, BaseProps)},
+                  case Values of
+                      {undefined, V2} ->
+                          {Add, Remove++[{Key, V2}]};
+                      {V1, undefined} ->
+                          {Add++[{Key, V1}], Remove};
+                      {V, V} ->
+                          {Add, Remove};
+                      {V1, V2} ->
+                          {Add++[{Key, V1}], Remove++[{Key, V2}]}
+                  end
+          end,
+    lists:foldl(Fun, {[], []}, Keys).
+

--- a/riak_test/src/rtcs_dev.erl
+++ b/riak_test/src/rtcs_dev.erl
@@ -19,7 +19,7 @@
 %% -------------------------------------------------------------------
 
 %% @private
--module(rt_cs_dev).
+-module(rtcs_dev).
 -compile(export_all).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -142,7 +142,7 @@ reset_nodes(Project, Path) ->
 
 -spec set_conf(atom() | {atom(), atom()} | string(), [{string(), string()}]) -> ok.
 set_conf(all, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_conf(all, ~p)", [NameValuePairs]),
+    lager:info("rtcs_dev:set_conf(all, ~p)", [NameValuePairs]),
     [ set_conf(DevPath, NameValuePairs) || DevPath <- devpaths()],
     ok;
 set_conf(Name, NameValuePairs) when Name =:= riak orelse
@@ -151,18 +151,18 @@ set_conf(Name, NameValuePairs) when Name =:= riak orelse
     set_conf({Name, current}, NameValuePairs),
     ok;
 set_conf({Name, Vsn}, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
+    lager:info("rtcs_dev:set_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
     set_conf(devpath(Name, Vsn), NameValuePairs),
     ok;
 set_conf({Name, Vsn, N}, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
+    lager:info("rtcs_dev:set_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
     rtdev:append_to_conf_file(get_conf(devpath(Name, Vsn), N), NameValuePairs),
     ok;
 set_conf(Node, NameValuePairs) when is_atom(Node) ->
     rtdev:append_to_conf_file(get_conf(Node), NameValuePairs),
     ok;
 set_conf(DevPath, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_conf(~p, ~p)", [DevPath, NameValuePairs]),
+    lager:info("rtcs_dev:set_conf(~p, ~p)", [DevPath, NameValuePairs]),
     [rtdev:append_to_conf_file(RiakConf, NameValuePairs) || RiakConf <- all_the_files(DevPath, "etc/*.conf")],
     ok.
 
@@ -177,11 +177,11 @@ set_advanced_conf(Name, NameValuePairs) when Name =:= riak orelse
     set_advanced_conf({Name, current}, NameValuePairs),
     ok;
 set_advanced_conf({Name, Vsn}, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_advanced_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
+    lager:info("rtcs_dev:set_advanced_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
     set_advanced_conf(devpath(Name, Vsn), NameValuePairs),
     ok;
 set_advanced_conf({Name, Vsn, N}, NameValuePairs) ->
-    lager:info("rt_cs_dev:set_advanced_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
+    lager:info("rtcs_dev:set_advanced_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
     update_app_config_file(get_app_config(devpath(Name, Vsn), N), NameValuePairs),
     ok;
 set_advanced_conf(Node, NameValuePairs) when is_atom(Node) ->

--- a/riak_test/src/rtcs_dev.erl
+++ b/riak_test/src/rtcs_dev.erl
@@ -140,65 +140,6 @@ reset_nodes(Project, Path) ->
     rtdev:run_git(Path, "clean -fd"),
     ok.
 
--spec set_conf(atom() | {atom(), atom()} | string(), [{string(), string()}]) -> ok.
-set_conf(all, NameValuePairs) ->
-    lager:info("rtcs_dev:set_conf(all, ~p)", [NameValuePairs]),
-    [ set_conf(DevPath, NameValuePairs) || DevPath <- devpaths()],
-    ok;
-set_conf(Name, NameValuePairs) when Name =:= riak orelse
-                                    Name =:= cs orelse
-                                    Name =:= stanchion ->
-    set_conf({Name, current}, NameValuePairs),
-    ok;
-set_conf({Name, Vsn}, NameValuePairs) ->
-    lager:info("rtcs_dev:set_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
-    set_conf(devpath(Name, Vsn), NameValuePairs),
-    ok;
-set_conf({Name, Vsn, N}, NameValuePairs) ->
-    lager:info("rtcs_dev:set_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
-    rtdev:append_to_conf_file(get_conf(devpath(Name, Vsn), N), NameValuePairs),
-    ok;
-set_conf(Node, NameValuePairs) when is_atom(Node) ->
-    rtdev:append_to_conf_file(get_conf(Node), NameValuePairs),
-    ok;
-set_conf(DevPath, NameValuePairs) ->
-    lager:info("rtcs_dev:set_conf(~p, ~p)", [DevPath, NameValuePairs]),
-    [rtdev:append_to_conf_file(RiakConf, NameValuePairs) || RiakConf <- all_the_files(DevPath, "etc/*.conf")],
-    ok.
-
--spec set_advanced_conf(atom() | {atom(), atom()} | string(), [{string(), string()}]) -> ok.
-set_advanced_conf(all, NameValuePairs) ->
-    lager:info("rtdev:set_advanced_conf(all, ~p)", [NameValuePairs]),
-    [ set_advanced_conf(DevPath, NameValuePairs) || DevPath <- devpaths()],
-    ok;
-set_advanced_conf(Name, NameValuePairs) when Name =:= riak orelse
-                                             Name =:= cs orelse
-                                             Name =:= stanchion ->
-    set_advanced_conf({Name, current}, NameValuePairs),
-    ok;
-set_advanced_conf({Name, Vsn}, NameValuePairs) ->
-    lager:info("rtcs_dev:set_advanced_conf({~p, ~p}, ~p)", [Name, Vsn, NameValuePairs]),
-    set_advanced_conf(devpath(Name, Vsn), NameValuePairs),
-    ok;
-set_advanced_conf({Name, Vsn, N}, NameValuePairs) ->
-    lager:info("rtcs_dev:set_advanced_conf({~p, ~p, ~p}, ~p)", [Name, Vsn, N, NameValuePairs]),
-    update_app_config_file(get_app_config(devpath(Name, Vsn), N), NameValuePairs),
-    ok;
-set_advanced_conf(Node, NameValuePairs) when is_atom(Node) ->
-    update_app_config_file(get_app_config(Node), NameValuePairs),
-    ok;
-set_advanced_conf(DevPath, NameValuePairs) ->
-    AdvancedConfs = case all_the_files(DevPath, "etc/a*.config") of
-                        [] ->
-                            %% no advanced conf? But we _need_ them, so make 'em
-                            rtdev:make_advanced_confs(DevPath);
-                        Confs ->
-                            Confs
-                    end,
-    lager:info("AdvancedConfs = ~p~n", [AdvancedConfs]),
-    [update_app_config_file(RiakConf, NameValuePairs) || RiakConf <- AdvancedConfs],
-    ok.
-
 get_conf(Node) ->
     N = node_id(Node),
     Path = relpath(node_version(N)),

--- a/riak_test/src/rtcs_exec.erl
+++ b/riak_test/src/rtcs_exec.erl
@@ -1,0 +1,270 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+-module(rtcs_exec).
+-compile(export_all).
+
+start_cs_and_stanchion_nodes(NodeList, Vsn) ->
+    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    start_stanchion(Vsn),
+                    start_cs(N, Vsn);
+               ({_CSNode, RiakNode}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    start_cs(N, Vsn)
+            end, NodeList).
+
+stop_cs_and_stanchion_nodes(NodeList, Vsn) ->
+    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    stop_cs(N, Vsn),
+                    stop_stanchion(Vsn),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(Stanchion);
+               ({CSNode, RiakNode}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    stop_cs(N, Vsn),
+                    rt:wait_until_unpingable(CSNode)
+            end, NodeList).
+
+start_all_nodes(NodeList, Vsn) ->
+    rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    NodeVersion = rt_cs_dev:node_version(N),
+                    lager:debug("starting riak #~p > ~p => ~p",
+                                [N,  NodeVersion,
+                                 rt_cs_dev:relpath(NodeVersion)]),
+                    rtdev:run_riak(N, rt_cs_dev:relpath(NodeVersion), "start"),
+                    rt:wait_for_service(RiakNode, riak_kv),
+                    spawn(fun() -> start_stanchion(Vsn) end),
+                    spawn(fun() -> start_cs(N, Vsn) end);
+               ({_CSNode, RiakNode}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "start"),
+                    rt:wait_for_service(RiakNode, riak_kv),
+                    spawn(fun() -> start_cs(N, Vsn) end)
+            end, NodeList).
+
+stop_all_nodes(NodeList, Vsn) ->
+    rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    stop_cs(N, Vsn),
+                    stop_stanchion(Vsn),
+                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(Stanchion),
+                    rt:wait_until_unpingable(RiakNode);
+               ({CSNode, RiakNode}) ->
+                    N = rt_cs_dev:node_id(RiakNode),
+                    stop_cs(N, Vsn),
+                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
+                    rt:wait_until_unpingable(CSNode),
+                    rt:wait_until_unpingable(RiakNode)
+            end, NodeList).
+
+start_cs(N) -> start_cs(N, current).
+
+start_cs(N, Vsn) ->
+    NodePath = rtcs_config:get_rt_config(cs, Vsn),
+    Cmd = riakcscmd(NodePath, N, "start"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+stop_cs(N) -> stop_cs(N, current).
+
+stop_cs(N, Vsn) ->
+    Cmd = riakcscmd(rtcs_config:get_rt_config(cs, Vsn), N, "stop"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+riakcmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [riak_binpath(Path, N), Cmd])).
+
+riakcscmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_statuscmd(Path, N) ->
+    lists:flatten(io_lib:format("~s-admin status", [riakcs_binpath(Path, N)])).
+
+riakcs_switchcmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin stanchion ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_gccmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin gc ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_accesscmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin access ~s", [riakcs_binpath(Path, N), Cmd])).
+
+riakcs_storagecmd(Path, N, Cmd) ->
+    lists:flatten(io_lib:format("~s-admin storage ~s", [riakcs_binpath(Path, N), Cmd])).
+
+stanchioncmd(Path, Cmd) ->
+    lists:flatten(io_lib:format("~s ~s", [stanchion_binpath(Path), Cmd])).
+
+stanchion_statuscmd(Path) ->
+    lists:flatten(io_lib:format("~s-admin status", [stanchion_binpath(Path)])).
+
+riak_bitcaskroot(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/data/bitcask", [Prefix, N]).
+
+riak_binpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/bin/riak", [Prefix, N]).
+
+riakcs_home(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/", [Prefix, N]).
+
+riakcs_binpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/bin/riak-cs", [Prefix, N]).
+
+riakcs_etcpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/etc", [Prefix, N]).
+
+riakcs_libpath(Prefix, N) ->
+    io_lib:format("~s/dev/dev~b/lib", [Prefix, N]).
+
+riakcs_logpath(Prefix, N, File) ->
+    io_lib:format("~s/dev/dev~b/log/~s", [Prefix, N, File]).
+
+stanchion_binpath(Prefix) ->
+    io_lib:format("~s/dev/stanchion/bin/stanchion", [Prefix]).
+
+stanchion_etcpath(Prefix) ->
+    io_lib:format("~s/dev/stanchion/etc", [Prefix]).
+
+repair_gc_bucket(N, Options) -> repair_gc_bucket(N, Options, current).
+
+repair_gc_bucket(N, Options, Vsn) ->
+    Prefix = rtcs_config:get_rt_config(cs, Vsn),
+    RepairScriptWild = string:join([riakcs_libpath(Prefix, N), "riak_cs*",
+                                    "priv/tools/repair_gc_bucket.erl"] , "/"),
+    [RepairScript] = filelib:wildcard(RepairScriptWild),
+    Cmd = riakcscmd(Prefix, N, "escript " ++ RepairScript ++
+                        " " ++ Options),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+exec_priv_escript(N, Command, Options) ->
+    exec_priv_escript(N, Command, Options, cs).
+
+exec_priv_escript(N, Command, Options, ByWhom) ->
+    CsPrefix = rtcs_config:get_rt_config(cs, current),
+    ExecuterPrefix = rtcs_config:get_rt_config(ByWhom, current),
+    ScriptWild = string:join([riakcs_libpath(CsPrefix, N), "riak_cs*",
+                              "priv/tools/"] , "/"),
+    [ToolsDir] = filelib:wildcard(ScriptWild),
+    Cmd = case ByWhom of
+              cs ->
+                  riakcscmd(ExecuterPrefix, N, "escript " ++ ToolsDir ++
+                                "/" ++ Command ++
+                                " " ++ Options);
+              riak ->
+                  riakcmd(ExecuterPrefix, N, "escript " ++ ToolsDir ++
+                              "/" ++ Command ++
+                              " " ++ Options)
+          end,
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+switch_stanchion_cs(N, Host, Port) -> switch_stanchion_cs(N, Host, Port, current).
+
+switch_stanchion_cs(N, Host, Port, Vsn) ->
+    SubCmd = io_lib:format("switch ~s ~p", [Host, Port]),
+    Cmd = riakcs_switchcmd(rtcs_config:get_rt_config(cs, Vsn), N, SubCmd),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+show_stanchion_cs(N) -> show_stanchion_cs(N, current).
+
+show_stanchion_cs(N, Vsn) ->
+    Cmd = riakcs_switchcmd(rtcs_config:get_rt_config(cs, Vsn), N, "show"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+start_stanchion() -> start_stanchion(current).
+
+start_stanchion(Vsn) ->
+    Cmd = stanchioncmd(rtcs_config:get_rt_config(stanchion, Vsn), "start"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+stop_stanchion() -> stop_stanchion(current).
+
+stop_stanchion(Vsn) ->
+    Cmd = stanchioncmd(rtcs_config:get_rt_config(stanchion, Vsn), "stop"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+flush_access(N) -> flush_access(N, current).
+
+flush_access(N, Vsn) ->
+    Cmd = riakcs_accesscmd(rtcs_config:get_rt_config(cs, Vsn), N, "flush"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+gc(N, SubCmd) -> gc(N, SubCmd, current).
+
+gc(N, SubCmd, Vsn) ->
+    Cmd = riakcs_gccmd(rtcs_config:get_rt_config(cs, Vsn), N, SubCmd),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+calculate_storage(N) -> calculate_storage(N, current).
+
+calculate_storage(N, Vsn) ->
+    Cmd = riakcs_storagecmd(rtcs_config:get_rt_config(cs, Vsn), N, "batch -r"),
+    lager:info("Running ~p", [Cmd]),
+    os:cmd(Cmd).
+
+enable_proxy_get(SrcN, Vsn, SinkCluster) ->
+    rtdev:run_riak_repl(SrcN, rtcs_config:get_rt_config(riak, Vsn),
+                        "proxy_get enable " ++ SinkCluster).
+
+disable_proxy_get(SrcN, Vsn, SinkCluster) ->
+    rtdev:run_riak_repl(SrcN, rtcs_config:get_rt_config(riak, Vsn),
+                        "proxy_get disable " ++ SinkCluster).
+
+%% TODO: this is added as riak-1.4 branch of riak_test/src/rt_cs_dev.erl
+%% throws out the return value. Let's get rid of these functions when
+%% we entered to Riak CS 2.0 dev, updating to riak_test master branch
+cmd(Cmd, Opts) ->
+    cmd(Cmd, Opts, rt_config:get(rt_max_wait_time)).
+
+cmd(Cmd, Opts, WaitTime) ->
+    lager:info("Command: ~s", [Cmd]),
+    lager:info("Options: ~p", [Opts]),
+    Port = open_port({spawn_executable, Cmd},
+                     [in, exit_status, binary,
+                      stream, stderr_to_stdout,{line, 200} | Opts]),
+    get_cmd_result(Port, WaitTime).
+
+get_cmd_result(Port, WaitTime) ->
+    receive
+        {Port, {data, {Flag, Line}}} when Flag =:= eol orelse Flag =:= noeol ->
+            lager:info(Line),
+            get_cmd_result(Port, WaitTime);
+        {Port, {exit_status, 0}} ->
+            ok;
+        {Port, {exit_status, Status}} ->
+            {error, {exit_status, Status}};
+        {Port, Other} ->
+            lager:warning("Other data from port: ~p", [Other]),
+            get_cmd_result(Port, WaitTime)
+    after WaitTime ->
+            {error, timeout}
+    end.

--- a/riak_test/src/rtcs_exec.erl
+++ b/riak_test/src/rtcs_exec.erl
@@ -22,58 +22,58 @@
 
 start_cs_and_stanchion_nodes(NodeList, Vsn) ->
     rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     start_stanchion(Vsn),
                     start_cs(N, Vsn);
                ({_CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     start_cs(N, Vsn)
             end, NodeList).
 
 stop_cs_and_stanchion_nodes(NodeList, Vsn) ->
     rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     stop_cs(N, Vsn),
                     stop_stanchion(Vsn),
                     rt:wait_until_unpingable(CSNode),
                     rt:wait_until_unpingable(Stanchion);
                ({CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     stop_cs(N, Vsn),
                     rt:wait_until_unpingable(CSNode)
             end, NodeList).
 
 start_all_nodes(NodeList, Vsn) ->
     rt:pmap(fun({_CSNode, RiakNode, _Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    NodeVersion = rt_cs_dev:node_version(N),
+                    N = rtcs_dev:node_id(RiakNode),
+                    NodeVersion = rtcs_dev:node_version(N),
                     lager:debug("starting riak #~p > ~p => ~p",
                                 [N,  NodeVersion,
-                                 rt_cs_dev:relpath(NodeVersion)]),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(NodeVersion), "start"),
+                                 rtcs_dev:relpath(NodeVersion)]),
+                    rtdev:run_riak(N, rtcs_dev:relpath(NodeVersion), "start"),
                     rt:wait_for_service(RiakNode, riak_kv),
                     spawn(fun() -> start_stanchion(Vsn) end),
                     spawn(fun() -> start_cs(N, Vsn) end);
                ({_CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "start"),
+                    N = rtcs_dev:node_id(RiakNode),
+                    rtdev:run_riak(N, rtcs_dev:relpath(rtcs_dev:node_version(N)), "start"),
                     rt:wait_for_service(RiakNode, riak_kv),
                     spawn(fun() -> start_cs(N, Vsn) end)
             end, NodeList).
 
 stop_all_nodes(NodeList, Vsn) ->
     rt:pmap(fun({CSNode, RiakNode, Stanchion}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     stop_cs(N, Vsn),
                     stop_stanchion(Vsn),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
+                    rtdev:run_riak(N, rtcs_dev:relpath(rtcs_dev:node_version(N)), "stop"),
                     rt:wait_until_unpingable(CSNode),
                     rt:wait_until_unpingable(Stanchion),
                     rt:wait_until_unpingable(RiakNode);
                ({CSNode, RiakNode}) ->
-                    N = rt_cs_dev:node_id(RiakNode),
+                    N = rtcs_dev:node_id(RiakNode),
                     stop_cs(N, Vsn),
-                    rtdev:run_riak(N, rt_cs_dev:relpath(rt_cs_dev:node_version(N)), "stop"),
+                    rtdev:run_riak(N, rtcs_dev:relpath(rtcs_dev:node_version(N)), "stop"),
                     rt:wait_until_unpingable(CSNode),
                     rt:wait_until_unpingable(RiakNode)
             end, NodeList).
@@ -239,7 +239,7 @@ disable_proxy_get(SrcN, Vsn, SinkCluster) ->
     rtdev:run_riak_repl(SrcN, rtcs_config:devpath(riak, Vsn),
                         "proxy_get disable " ++ SinkCluster).
 
-%% TODO: this is added as riak-1.4 branch of riak_test/src/rt_cs_dev.erl
+%% TODO: this is added as riak-1.4 branch of riak_test/src/rtcs_dev.erl
 %% throws out the return value. Let's get rid of these functions when
 %% we entered to Riak CS 2.0 dev, updating to riak_test master branch
 cmd(Cmd, Opts) ->

--- a/riak_test/src/rtcs_exec.erl
+++ b/riak_test/src/rtcs_exec.erl
@@ -81,7 +81,7 @@ stop_all_nodes(NodeList, Vsn) ->
 start_cs(N) -> start_cs(N, current).
 
 start_cs(N, Vsn) ->
-    NodePath = rtcs_config:get_rt_config(cs, Vsn),
+    NodePath = rtcs_config:devpath(cs, Vsn),
     Cmd = riakcscmd(NodePath, N, "start"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
@@ -89,7 +89,7 @@ start_cs(N, Vsn) ->
 stop_cs(N) -> stop_cs(N, current).
 
 stop_cs(N, Vsn) ->
-    Cmd = riakcscmd(rtcs_config:get_rt_config(cs, Vsn), N, "stop"),
+    Cmd = riakcscmd(rtcs_config:devpath(cs, Vsn), N, "stop"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
@@ -150,7 +150,7 @@ stanchion_etcpath(Prefix) ->
 repair_gc_bucket(N, Options) -> repair_gc_bucket(N, Options, current).
 
 repair_gc_bucket(N, Options, Vsn) ->
-    Prefix = rtcs_config:get_rt_config(cs, Vsn),
+    Prefix = rtcs_config:devpath(cs, Vsn),
     RepairScriptWild = string:join([riakcs_libpath(Prefix, N), "riak_cs*",
                                     "priv/tools/repair_gc_bucket.erl"] , "/"),
     [RepairScript] = filelib:wildcard(RepairScriptWild),
@@ -163,8 +163,8 @@ exec_priv_escript(N, Command, Options) ->
     exec_priv_escript(N, Command, Options, cs).
 
 exec_priv_escript(N, Command, Options, ByWhom) ->
-    CsPrefix = rtcs_config:get_rt_config(cs, current),
-    ExecuterPrefix = rtcs_config:get_rt_config(ByWhom, current),
+    CsPrefix = rtcs_config:devpath(cs, current),
+    ExecuterPrefix = rtcs_config:devpath(ByWhom, current),
     ScriptWild = string:join([riakcs_libpath(CsPrefix, N), "riak_cs*",
                               "priv/tools/"] , "/"),
     [ToolsDir] = filelib:wildcard(ScriptWild),
@@ -185,58 +185,58 @@ switch_stanchion_cs(N, Host, Port) -> switch_stanchion_cs(N, Host, Port, current
 
 switch_stanchion_cs(N, Host, Port, Vsn) ->
     SubCmd = io_lib:format("switch ~s ~p", [Host, Port]),
-    Cmd = riakcs_switchcmd(rtcs_config:get_rt_config(cs, Vsn), N, SubCmd),
+    Cmd = riakcs_switchcmd(rtcs_config:devpath(cs, Vsn), N, SubCmd),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 show_stanchion_cs(N) -> show_stanchion_cs(N, current).
 
 show_stanchion_cs(N, Vsn) ->
-    Cmd = riakcs_switchcmd(rtcs_config:get_rt_config(cs, Vsn), N, "show"),
+    Cmd = riakcs_switchcmd(rtcs_config:devpath(cs, Vsn), N, "show"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 start_stanchion() -> start_stanchion(current).
 
 start_stanchion(Vsn) ->
-    Cmd = stanchioncmd(rtcs_config:get_rt_config(stanchion, Vsn), "start"),
+    Cmd = stanchioncmd(rtcs_config:devpath(stanchion, Vsn), "start"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 stop_stanchion() -> stop_stanchion(current).
 
 stop_stanchion(Vsn) ->
-    Cmd = stanchioncmd(rtcs_config:get_rt_config(stanchion, Vsn), "stop"),
+    Cmd = stanchioncmd(rtcs_config:devpath(stanchion, Vsn), "stop"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 flush_access(N) -> flush_access(N, current).
 
 flush_access(N, Vsn) ->
-    Cmd = riakcs_accesscmd(rtcs_config:get_rt_config(cs, Vsn), N, "flush"),
+    Cmd = riakcs_accesscmd(rtcs_config:devpath(cs, Vsn), N, "flush"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 gc(N, SubCmd) -> gc(N, SubCmd, current).
 
 gc(N, SubCmd, Vsn) ->
-    Cmd = riakcs_gccmd(rtcs_config:get_rt_config(cs, Vsn), N, SubCmd),
+    Cmd = riakcs_gccmd(rtcs_config:devpath(cs, Vsn), N, SubCmd),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 calculate_storage(N) -> calculate_storage(N, current).
 
 calculate_storage(N, Vsn) ->
-    Cmd = riakcs_storagecmd(rtcs_config:get_rt_config(cs, Vsn), N, "batch -r"),
+    Cmd = riakcs_storagecmd(rtcs_config:devpath(cs, Vsn), N, "batch -r"),
     lager:info("Running ~p", [Cmd]),
     os:cmd(Cmd).
 
 enable_proxy_get(SrcN, Vsn, SinkCluster) ->
-    rtdev:run_riak_repl(SrcN, rtcs_config:get_rt_config(riak, Vsn),
+    rtdev:run_riak_repl(SrcN, rtcs_config:devpath(riak, Vsn),
                         "proxy_get enable " ++ SinkCluster).
 
 disable_proxy_get(SrcN, Vsn, SinkCluster) ->
-    rtdev:run_riak_repl(SrcN, rtcs_config:get_rt_config(riak, Vsn),
+    rtdev:run_riak_repl(SrcN, rtcs_config:devpath(riak, Vsn),
                         "proxy_get disable " ++ SinkCluster).
 
 %% TODO: this is added as riak-1.4 branch of riak_test/src/rt_cs_dev.erl

--- a/riak_test/src/tools_helper.erl
+++ b/riak_test/src/tools_helper.erl
@@ -44,7 +44,7 @@ offline_delete({RiakNodes, CSNodes, Stanchion}, BlockKeysFileList) ->
          Res = rtcs:exec_priv_escript(
                  1, "internal/offline_delete.erl",
                  "-r 8 --yes " ++
-                     rtcs:riak_bitcaskroot(rtcs:get_rt_config(riak, current), 1) ++
+                     rtcs:riak_bitcaskroot(rtcs:devpath(riak, current), 1) ++
                      " " ++ BlockKeysFile,
                  riak),
          lager:debug("offline_delete.erl log:\n~s", [Res]),

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -33,9 +33,7 @@
 -define(KEY, "a").
 
 confirm() ->
-    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true}])}],
-    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2, Config),
+    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2),
     rt:setup_log_capture(hd(CSNodes)),
 
     {Begin, End} = generate_some_accesses(UserConfig),

--- a/riak_test/tests/access_stats_test.erl
+++ b/riak_test/tests/access_stats_test.erl
@@ -33,8 +33,8 @@
 -define(KEY, "a").
 
 confirm() ->
-    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
-              {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
+    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
+              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true}])}],
     {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2, Config),
     rt:setup_log_capture(hd(CSNodes)),
 
@@ -69,7 +69,7 @@ generate_some_accesses(UserConfig) ->
     {Begin, End}.
 
 flush_access_stats() ->
-    Res = rtcs:flush_access(1),
+    Res = rtcs_exec:flush_access(1),
     lager:info("riak-cs-access flush result: ~s", [Res]),
     ExpectRegexp = "All access logs were flushed.\n$",
     ?assertMatch({match, _}, re:run(Res, ExpectRegexp)).

--- a/riak_test/tests/active_delete_test.erl
+++ b/riak_test/tests/active_delete_test.erl
@@ -28,7 +28,7 @@ config() ->
 
 confirm() ->
     %% 10MB threshold, for 3MB objects are used in cs_suites:run/2
-    rt_cs_dev:set_advanced_conf(cs, config()),
+    rtcs_dev:set_advanced_conf(cs, config()),
     Setup = rtcs:setup(1),
 
     %% Just do verify on typical normal case

--- a/riak_test/tests/active_delete_test.erl
+++ b/riak_test/tests/active_delete_test.erl
@@ -28,7 +28,7 @@ config() ->
 
 confirm() ->
     %% 10MB threshold, for 3MB objects are used in cs_suites:run/2
-    rtcs_dev:set_advanced_conf(cs, config()),
+    rtcs:set_advanced_conf(cs, config()),
     Setup = rtcs:setup(1),
 
     %% Just do verify on typical normal case

--- a/riak_test/tests/active_delete_test.erl
+++ b/riak_test/tests/active_delete_test.erl
@@ -26,7 +26,7 @@
 
 confirm() ->
     %% 10MB threshold, for 3MB objects are used in cs_suites:run/2
-    CSConfig = rtcs:cs_config([{active_delete_threshold, 10000000}]),
+    CSConfig = rtcs_config:cs_config([{active_delete_threshold, 10000000}]),
     Setup = rtcs:setup(1, [{cs, CSConfig}]),
 
     %% Just do verify on typical normal case

--- a/riak_test/tests/active_delete_test.erl
+++ b/riak_test/tests/active_delete_test.erl
@@ -23,11 +23,13 @@
 %% @doc `riak_test' module for testing active delete situation behavior.
 
 -export([confirm/0]).
+config() ->
+    [{riak_cs, [{active_delete_threshold, 10000000}]}].
 
 confirm() ->
     %% 10MB threshold, for 3MB objects are used in cs_suites:run/2
-    CSConfig = rtcs_config:cs_config([{active_delete_threshold, 10000000}]),
-    Setup = rtcs:setup(1, [{cs, CSConfig}]),
+    rt_cs_dev:set_advanced_conf(cs, config()),
+    Setup = rtcs:setup(1),
 
     %% Just do verify on typical normal case
     History = [{cs_suites, run, ["run-1"]}],

--- a/riak_test/tests/auth_bypass_test.erl
+++ b/riak_test/tests/auth_bypass_test.erl
@@ -25,10 +25,10 @@
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 confirm() ->
-    Config = [{cs, rtcs:cs_config([{admin_auth_enabled, false}])}],
+    Config = [{cs, rtcs_config:cs_config([{admin_auth_enabled, false}])}],
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, Config),
     KeyId = UserConfig#aws_config.access_key_id,
-    Port = rtcs:cs_port(hd(RiakNodes)),
+    Port = rtcs_config:cs_port(hd(RiakNodes)),
 
     confirm_auth_bypass_for_stats("riak-cs", "stats", UserConfig, Port),
     confirm_auth_bypass("riak-cs", "users", UserConfig, Port),

--- a/riak_test/tests/auth_bypass_test.erl
+++ b/riak_test/tests/auth_bypass_test.erl
@@ -27,7 +27,7 @@ config() ->
     [{riak_cs, [{admin_auth_enabled, false}]}].
 
 confirm() ->
-    rt_cs_dev:set_advanced_conf(cs, config()),
+    rtcs_dev:set_advanced_conf(cs, config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     KeyId = UserConfig#aws_config.access_key_id,
     Port = rtcs_config:cs_port(hd(RiakNodes)),

--- a/riak_test/tests/auth_bypass_test.erl
+++ b/riak_test/tests/auth_bypass_test.erl
@@ -23,10 +23,12 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
+config() ->
+    [{riak_cs, [{admin_auth_enabled, false}]}].
 
 confirm() ->
-    Config = [{cs, rtcs_config:cs_config([{admin_auth_enabled, false}])}],
-    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, Config),
+    rt_cs_dev:set_advanced_conf(cs, config()),
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     KeyId = UserConfig#aws_config.access_key_id,
     Port = rtcs_config:cs_port(hd(RiakNodes)),
 

--- a/riak_test/tests/auth_bypass_test.erl
+++ b/riak_test/tests/auth_bypass_test.erl
@@ -27,7 +27,7 @@ config() ->
     [{riak_cs, [{admin_auth_enabled, false}]}].
 
 confirm() ->
-    rtcs_dev:set_advanced_conf(cs, config()),
+    rtcs:set_advanced_conf(cs, config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     KeyId = UserConfig#aws_config.access_key_id,
     Port = rtcs_config:cs_port(hd(RiakNodes)),

--- a/riak_test/tests/block_audit_test.erl
+++ b/riak_test/tests/block_audit_test.erl
@@ -56,15 +56,15 @@ confirm1() ->
         [setup_objects(RiakNodes, UserConfig, Bucket, mp,
                        ?KEY_ALIVE_MP, ?KEY_ORPHANED_MP, ?KEY_FALSE_ORPHANED_MP) ||
             Bucket <- [?BUCKET1, ?BUCKET2]],
-    Home = rtcs:riakcs_home(rtcs:get_rt_config(cs, current), 1),
+    Home = rtcs_config:riakcs_home(rtcs_config:get_rt_config(cs, current), 1),
     os:cmd("rm -rf " ++ filename:join([Home, "maybe-orphaned-blocks"])),
     os:cmd("rm -rf " ++ filename:join([Home, "actual-orphaned-blocks"])),
-    Res1 = rtcs:exec_priv_escript(1, "internal/block_audit.erl",
+    Res1 = rtcs_exec:exec_priv_escript(1, "internal/block_audit.erl",
                                   "-h 127.0.0.1 -p 10017 -dd"),
     lager:debug("block_audit.erl log:\n~s", [Res1]),
     lager:debug("block_audit.erl log:============= END"),
     fake_false_orphans(RiakNodes, FalseOrphans1 ++ FalseOrphans2),
-    Res2 = rtcs:exec_priv_escript(1, "internal/ensure_orphan_blocks.erl",
+    Res2 = rtcs_exec:exec_priv_escript(1, "internal/ensure_orphan_blocks.erl",
                                   "-h 127.0.0.1 -p 10017 -dd"),
     lager:debug("ensure_orphan_blocks.erl log:\n~s", [Res2]),
     lager:debug("ensure_orphan_blocks.erl log:============= END"),
@@ -106,7 +106,7 @@ fake_false_orphans(RiakNodes, FalseOrphans) ->
         {B, K, O} <- FalseOrphans].
 
 assert_result(Bucket) ->
-    Home = rtcs:riakcs_home(rtcs:get_rt_config(cs, current), 1),
+    Home = rtcs_config:riakcs_home(rtcs_config:get_rt_config(cs, current), 1),
     OutFile1 = filename:join([Home, "actual-orphaned-blocks", Bucket]),
     {ok, Bin} = file:read_file(OutFile1),
     KeySeqs = [begin

--- a/riak_test/tests/block_audit_test.erl
+++ b/riak_test/tests/block_audit_test.erl
@@ -56,7 +56,7 @@ confirm1() ->
         [setup_objects(RiakNodes, UserConfig, Bucket, mp,
                        ?KEY_ALIVE_MP, ?KEY_ORPHANED_MP, ?KEY_FALSE_ORPHANED_MP) ||
             Bucket <- [?BUCKET1, ?BUCKET2]],
-    Home = rtcs_config:riakcs_home(rtcs_config:get_rt_config(cs, current), 1),
+    Home = rtcs_config:riakcs_home(rtcs_config:devpath(cs, current), 1),
     os:cmd("rm -rf " ++ filename:join([Home, "maybe-orphaned-blocks"])),
     os:cmd("rm -rf " ++ filename:join([Home, "actual-orphaned-blocks"])),
     Res1 = rtcs_exec:exec_priv_escript(1, "internal/block_audit.erl",
@@ -106,7 +106,7 @@ fake_false_orphans(RiakNodes, FalseOrphans) ->
         {B, K, O} <- FalseOrphans].
 
 assert_result(Bucket) ->
-    Home = rtcs_config:riakcs_home(rtcs_config:get_rt_config(cs, current), 1),
+    Home = rtcs_config:riakcs_home(rtcs_config:devpath(cs, current), 1),
     OutFile1 = filename:join([Home, "actual-orphaned-blocks", Bucket]),
     {ok, Bin} = file:read_file(OutFile1),
     KeySeqs = [begin

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -35,13 +35,13 @@
 
 
 confirm() ->
-    SetupConfig =  [{cs, rtcs:cs_config([{region, ?REGION}])}],
+    SetupConfig =  [{cs, rtcs_config:cs_config([{region, ?REGION}])}],
     {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1, SetupConfig),
 
 
     %% User 1, Cluster 1 config
     {AccessKeyId, SecretAccessKey} = rtcs:create_user(hd(RiakNodes), 1),
-    UserConfig1 = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(hd(RiakNodes))),
+    UserConfig1 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(RiakNodes))),
 
     ok = verify_create_delete(UserConfig),
 

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -36,7 +36,7 @@ config() ->
     [{riak_cs, [{region, ?REGION}]}].
 
 confirm() ->
-    rtcs_dev:set_advanced_conf(cs, config()),
+    rtcs:set_advanced_conf(cs, config()),
     {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
 
 

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -41,7 +41,7 @@ confirm() ->
 
 
     %% User 1, Cluster 1 config
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(hd(RiakNodes), 1),
+    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(hd(RiakNodes), 1),
     UserConfig1 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(RiakNodes))),
 
     ok = verify_create_delete(UserConfig),

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -32,11 +32,12 @@
 
 %% keys for multipart uploaded objects
 -define(KEY_MP,        "riak_test_mp").  % single part, single block
-
+config() ->
+    [{riak_cs, [{region, ?REGION}]}].
 
 confirm() ->
-    SetupConfig =  [{cs, rtcs_config:cs_config([{region, ?REGION}])}],
-    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1, SetupConfig),
+    rt_cs_dev:set_advanced_conf(cs, config()),
+    {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
 
 
     %% User 1, Cluster 1 config

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -41,8 +41,7 @@ confirm() ->
 
 
     %% User 1, Cluster 1 config
-    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(hd(RiakNodes), 1),
-    UserConfig1 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(RiakNodes))),
+    UserConfig1 = rtcs_admin:create_user(hd(RiakNodes), 1),
 
     ok = verify_create_delete(UserConfig),
 

--- a/riak_test/tests/buckets_test.erl
+++ b/riak_test/tests/buckets_test.erl
@@ -36,7 +36,7 @@ config() ->
     [{riak_cs, [{region, ?REGION}]}].
 
 confirm() ->
-    rt_cs_dev:set_advanced_conf(cs, config()),
+    rtcs_dev:set_advanced_conf(cs, config()),
     {UserConfig, {RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
 
 

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -31,8 +31,8 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    rtcs_dev:set_conf(cs, [{"stats.storage.archive_period", "1s"}]),
-    rtcs_dev:set_advanced_conf(cs, [{riak_cs, [{storage_calc_timeout, 1}]}]),
+    rtcs:set_conf(cs, [{"stats.storage.archive_period", "1s"}]),
+    rtcs:set_advanced_conf(cs, [{riak_cs, [{storage_calc_timeout, 1}]}]),
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2),
 
     Begin = rtcs:datetime(),

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -31,9 +31,9 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
+    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
               {cs,
-               rtcs:cs_config([{storage_calc_timeout, 1},
+               rtcs_config:cs_config([{storage_calc_timeout, 1},
                                {storage_archive_period, 1}])}],
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2, Config),
 

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -31,11 +31,9 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
-              {cs,
-               rtcs_config:cs_config([{storage_calc_timeout, 1},
-                               {storage_archive_period, 1}])}],
-    {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2, Config),
+    rt_cs_dev:set_conf(cs, [{"stats.storage.archive_period", "1s"}]),
+    rt_cs_dev:set_advanced_conf(cs, [{riak_cs, [{storage_calc_timeout, 1}]}]),
+    {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2),
 
     Begin = rtcs:datetime(),
     run_storage_batch(hd(CSNodes)),

--- a/riak_test/tests/cs743_regression_test.erl
+++ b/riak_test/tests/cs743_regression_test.erl
@@ -31,8 +31,8 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    rt_cs_dev:set_conf(cs, [{"stats.storage.archive_period", "1s"}]),
-    rt_cs_dev:set_advanced_conf(cs, [{riak_cs, [{storage_calc_timeout, 1}]}]),
+    rtcs_dev:set_conf(cs, [{"stats.storage.archive_period", "1s"}]),
+    rtcs_dev:set_advanced_conf(cs, [{riak_cs, [{storage_calc_timeout, 1}]}]),
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(2),
 
     Begin = rtcs:datetime(),

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -15,7 +15,7 @@ confirm() ->
 
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, [{cs, cs_config()}]),
     ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
-    CsPortStr = integer_to_list(rtcs:cs_port(hd(RiakNodes))),
+    CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),
 
     Cmd = os:find_executable("make"),
     Args = ["-j", "8", "test-client"],
@@ -24,7 +24,7 @@ confirm() ->
            {"AWS_SECRET_ACCESS_KEY", UserConfig#aws_config.secret_access_key},
            {"CS_BUCKET",             ?TEST_BUCKET}],
     WaitTime = 5 * rt_config:get(rt_max_wait_time),
-    case rtcs:cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}], WaitTime) of
+    case rtcs_exec:cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}], WaitTime) of
         ok ->
             rtcs:pass();
         {error, Reason} ->
@@ -34,13 +34,13 @@ confirm() ->
 
 cs_config() ->
     [
-     rtcs:lager_config(),
+     rtcs_config:lager_config(),
      {riak_cs,
       [
        {proxy_get, enabled},
        {anonymous_user_creation, true},
        {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs:stanchion_port()}},
+       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
        {cs_version, 010300},
        {enforce_multipart_part_size, false},
        {max_buckets_per_user, 300},

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -13,7 +13,8 @@ confirm() ->
     CsSrcDir = rt_cs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, [{cs, cs_config()}]),
+    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2),
     ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),
 
@@ -33,16 +34,8 @@ confirm() ->
     end.
 
 cs_config() ->
-    [
-     rtcs_config:lager_config(),
-     {riak_cs,
-      [
-       {proxy_get, enabled},
-       {anonymous_user_creation, true},
-       {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
-       {cs_version, 010300},
-       {enforce_multipart_part_size, false},
+    [{riak_cs,
+      [{enforce_multipart_part_size, false},
        {max_buckets_per_user, 300},
        {auth_v4_enabled, true}
       ]

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -8,12 +8,12 @@
 
 confirm() ->
     %% NOTE: This 'cs_src_root' path must appear in
-    %% ~/.riak_test.config in the 'rt_cs_dev' section, 'src_paths'
+    %% ~/.riak_test.config in the 'rtcs_dev' section, 'src_paths'
     %% subsection.
-    CsSrcDir = rt_cs_dev:srcpath(cs_src_root),
+    CsSrcDir = rtcs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs_dev:set_advanced_conf(cs, cs_config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2),
     ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -13,7 +13,7 @@ confirm() ->
     CsSrcDir = rtcs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    rtcs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs:set_advanced_conf(cs, cs_config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2),
     ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),

--- a/riak_test/tests/legacy_s3_rewrite_test.erl
+++ b/riak_test/tests/legacy_s3_rewrite_test.erl
@@ -28,12 +28,12 @@
 
 confirm() ->
     %% NOTE: This 'cs_src_root' path must appear in
-    %% ~/.riak_test.config in the 'rt_cs_dev' section, 'src_paths'
+    %% ~/.riak_test.config in the 'rtcs_dev' section, 'src_paths'
     %% subsection.
-    CsSrcDir = rt_cs_dev:srcpath(cs_src_root),
+    CsSrcDir = rtcs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs_dev:set_advanced_conf(cs, cs_config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     ok = erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),

--- a/riak_test/tests/legacy_s3_rewrite_test.erl
+++ b/riak_test/tests/legacy_s3_rewrite_test.erl
@@ -33,7 +33,8 @@ confirm() ->
     CsSrcDir = rt_cs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, [{cs, cs_config()}]),
+    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     ok = erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),
 
@@ -54,14 +55,8 @@ confirm() ->
 
 cs_config() ->
     [
-     rtcs_config:lager_config(),
      {riak_cs,
       [
-       {proxy_get, enabled},
-       {anonymous_user_creation, true},
-       {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
-       {cs_version, 010300},
        {enforce_multipart_part_size, false},
        {max_buckets_per_user, 150},
        {rewrite_module, riak_cs_s3_rewrite_legacy}

--- a/riak_test/tests/legacy_s3_rewrite_test.erl
+++ b/riak_test/tests/legacy_s3_rewrite_test.erl
@@ -35,7 +35,7 @@ confirm() ->
 
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, [{cs, cs_config()}]),
     ok = erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig),
-    CsPortStr = integer_to_list(rtcs:cs_port(hd(RiakNodes))),
+    CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),
 
     Cmd = os:find_executable("make"),
     Args = ["-C", "client_tests/python/boto_tests", "test-auth-v2"],
@@ -44,7 +44,7 @@ confirm() ->
            {"AWS_SECRET_ACCESS_KEY", UserConfig#aws_config.secret_access_key},
            {"CS_BUCKET",             ?TEST_BUCKET}],
     WaitTime = 2 * rt_config:get(rt_max_wait_time),
-    case rtcs:cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}], WaitTime) of
+    case rtcs_exec:cmd(Cmd, [{cd, CsSrcDir}, {env, Env}, {args, Args}], WaitTime) of
         ok ->
             rtcs:pass();
         {error, Reason} ->
@@ -54,13 +54,13 @@ confirm() ->
 
 cs_config() ->
     [
-     rtcs:lager_config(),
+     rtcs_config:lager_config(),
      {riak_cs,
       [
        {proxy_get, enabled},
        {anonymous_user_creation, true},
        {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs:stanchion_port()}},
+       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
        {cs_version, 010300},
        {enforce_multipart_part_size, false},
        {max_buckets_per_user, 150},

--- a/riak_test/tests/legacy_s3_rewrite_test.erl
+++ b/riak_test/tests/legacy_s3_rewrite_test.erl
@@ -33,7 +33,7 @@ confirm() ->
     CsSrcDir = rtcs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    rtcs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs:set_advanced_conf(cs, cs_config()),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
     ok = erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -28,8 +28,8 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
-              {cs, rtcs:cs_config([{fold_objects_for_list_keys, false}])}],
+    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
+              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, false}])}],
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1, Config),
     assert_v1(CSNodes),
     list_objects_test_helper:test(UserConfig).

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -28,9 +28,8 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, false}])}],
-    {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1, Config),
+    rt_cs_dev:set_conf(cs, [{"fold_objects_for_list_keys", "off"}]),
+    {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
     assert_v1(CSNodes),
     list_objects_test_helper:test(UserConfig).
 

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -28,7 +28,7 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    rt_cs_dev:set_conf(cs, [{"fold_objects_for_list_keys", "off"}]),
+    rtcs_dev:set_conf(cs, [{"fold_objects_for_list_keys", "off"}]),
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
     assert_v1(CSNodes),
     list_objects_test_helper:test(UserConfig).

--- a/riak_test/tests/list_objects_test.erl
+++ b/riak_test/tests/list_objects_test.erl
@@ -28,7 +28,7 @@
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
-    rtcs_dev:set_conf(cs, [{"fold_objects_for_list_keys", "off"}]),
+    rtcs:set_conf(cs, [{"fold_objects_for_list_keys", "off"}]),
     {UserConfig, {_RiakNodes, CSNodes, _Stanchion}} = rtcs:setup(1),
     assert_v1(CSNodes),
     list_objects_test_helper:test(UserConfig).

--- a/riak_test/tests/list_objects_v2_test.erl
+++ b/riak_test/tests/list_objects_v2_test.erl
@@ -47,7 +47,7 @@ list_to_non_existent_bucket_many_times(RiakNodes) ->
     ok.
 
 list_objects_by_anonymous(RiakNodes, Bucket) ->
-    Port = rtcs:cs_port(hd(RiakNodes)),
+    Port = rtcs_config:cs_port(hd(RiakNodes)),
     %% --write-out '%{http_code}': output http response status code to stdout
     Cmd = "curl -s --write-out '%{http_code}' -o /dev/null http://localhost:" ++
         integer_to_list(Port) ++ "/" ++ Bucket,

--- a/riak_test/tests/migration_15_to_20_test.erl
+++ b/riak_test/tests/migration_15_to_20_test.erl
@@ -149,9 +149,9 @@ upgrade_remaining(UpgradeFirstCount, State) ->
 %% Upgrade Riak and Riak CS pairs of nodes
 upgrade_nodes(AdminCreds, RiakNodes) ->
     {_, RiakCurrentVsn} =
-        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rtcs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
     [begin
-         N = rt_cs_dev:node_id(RiakNode),
+         N = rtcs_dev:node_id(RiakNode),
          rtcs_exec:stop_cs(N, previous),
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
          rt:wait_for_service(RiakNode, riak_kv),

--- a/riak_test/tests/migration_15_to_20_test.erl
+++ b/riak_test/tests/migration_15_to_20_test.erl
@@ -149,7 +149,7 @@ upgrade_remaining(UpgradeFirstCount, State) ->
 %% Upgrade Riak and Riak CS pairs of nodes
 upgrade_nodes(AdminCreds, RiakNodes) ->
     {_, RiakCurrentVsn} =
-        rtcs:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
     [begin
          N = rt_cs_dev:node_id(RiakNode),
          rtcs:stop_cs(N, previous),

--- a/riak_test/tests/migration_mixed_test.erl
+++ b/riak_test/tests/migration_mixed_test.erl
@@ -121,7 +121,7 @@ transition_to_cs15_with_kv20(State) ->
 
 migrate_nodes_to_cs15_with_kv20(AdminCreds, RiakNodes) ->
     {_, RiakCurrentVsn} =
-        rtcs:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
     [begin
          N = rt_cs_dev:node_id(RiakNode),
          rtcs:stop_cs(N, current),

--- a/riak_test/tests/migration_mixed_test.erl
+++ b/riak_test/tests/migration_mixed_test.erl
@@ -101,7 +101,7 @@ transition_to_cs20_with_kv14(State) ->
 
 migrate_nodes_to_cs20_with_kv14(AdminCreds, RiakNodes) ->
     [begin
-         N = rt_cs_dev:node_id(RiakNode),
+         N = rtcs_dev:node_id(RiakNode),
          rtcs_exec:stop_cs(N, previous),
          ok = rtcs_config:upgrade_cs(N, AdminCreds),
          rtcs_exec:start_cs(N, current)
@@ -121,9 +121,9 @@ transition_to_cs15_with_kv20(State) ->
 
 migrate_nodes_to_cs15_with_kv20(AdminCreds, RiakNodes) ->
     {_, RiakCurrentVsn} =
-        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rtcs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
     [begin
-         N = rt_cs_dev:node_id(RiakNode),
+         N = rtcs_dev:node_id(RiakNode),
          rtcs_exec:stop_cs(N, current),
          %% to check error log emptyness afterwards, truncate it here.
          rtcs:truncate_error_log(N),

--- a/riak_test/tests/migration_mixed_test.erl
+++ b/riak_test/tests/migration_mixed_test.erl
@@ -44,7 +44,7 @@ confirm() ->
     rtcs:pass().
 
 setup_previous() ->
-    PrevConfigs = rtcs:previous_configs(custom_configs(previous)),
+    PrevConfigs = rtcs_config:previous_configs(custom_configs(previous)),
     SetupRes = rtcs:setup(2, PrevConfigs, previous),
     lager:info("rt_nodes> ~p", [rt_config:get(rt_nodes)]),
     lager:info("rt_versions> ~p", [rt_config:get(rt_versions)]),
@@ -60,15 +60,15 @@ setup_previous() ->
 %% CS objects, run GC and merge+delete of bitcask.
 custom_configs(previous) ->
     [{riak,
-      rtcs:previous_riak_config([{bitcask, [{max_file_size, 4*1024*1024}]}])},
+      rtcs_config:previous_riak_config([{bitcask, [{max_file_size, 4*1024*1024}]}])},
      {cs,
-      rtcs:previous_cs_config([{leeway_seconds, 1}])}];
+      rtcs_config:previous_cs_config([{leeway_seconds, 1}])}];
 custom_configs(current) ->
     %% This branch is only for debugging this module
     [{riak,
-      rtcs:riak_config([{bitcask, [{max_file_size, 4*1024*1024}]}])},
+      rtcs_config:riak_config([{bitcask, [{max_file_size, 4*1024*1024}]}])},
      {cs,
-      rtcs:cs_config([{leeway_seconds, 1}])}].
+      rtcs_config:cs_config([{leeway_seconds, 1}])}].
 
 history() ->
     [
@@ -82,9 +82,9 @@ history() ->
     ].
 
 upgrade_stanchion(State) ->
-    rtcs:stop_stanchion(previous),
-    rtcs:migrate_stanchion(previous, current, cs_suites:admin_credential(State)),
-    rtcs:start_stanchion(current),
+    rtcs_exec:stop_stanchion(previous),
+    rtcs_config:migrate_stanchion(previous, current, cs_suites:admin_credential(State)),
+    rtcs_exec:start_stanchion(current),
     rtcs:assert_versions(stanchion, cs_suites:nodes_of(stanchion, State), "^2\."),
     {ok, State}.
 
@@ -102,9 +102,9 @@ transition_to_cs20_with_kv14(State) ->
 migrate_nodes_to_cs20_with_kv14(AdminCreds, RiakNodes) ->
     [begin
          N = rt_cs_dev:node_id(RiakNode),
-         rtcs:stop_cs(N, previous),
-         ok = rtcs:upgrade_cs(N, AdminCreds),
-         rtcs:start_cs(N, current)
+         rtcs_exec:stop_cs(N, previous),
+         ok = rtcs_config:upgrade_cs(N, AdminCreds),
+         rtcs_exec:start_cs(N, current)
      end
      || RiakNode <- RiakNodes],
     ok.
@@ -124,13 +124,13 @@ migrate_nodes_to_cs15_with_kv20(AdminCreds, RiakNodes) ->
         rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
     [begin
          N = rt_cs_dev:node_id(RiakNode),
-         rtcs:stop_cs(N, current),
+         rtcs_exec:stop_cs(N, current),
          %% to check error log emptyness afterwards, truncate it here.
          rtcs:truncate_error_log(N),
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
          rt:wait_for_service(RiakNode, riak_kv),
-         ok = rtcs:migrate_cs(current, previous, N, AdminCreds),
-         rtcs:start_cs(N, previous)
+         ok = rtcs_config:migrate_cs(current, previous, N, AdminCreds),
+         rtcs_exec:start_cs(N, previous)
      end
      || RiakNode <- RiakNodes],
     rt:wait_until_ring_converged(RiakNodes),

--- a/riak_test/tests/put_copy_test.erl
+++ b/riak_test/tests/put_copy_test.erl
@@ -51,10 +51,8 @@ confirm() ->
                  erlcloud_s3:put_object(?BUCKET, ?KEY2, Data, UserConfig)),
 
     RiakNode = hd(RiakNodes),
-    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(RiakNode, 1),
-    UserConfig2 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
-    {AccessKeyId1, SecretAccessKey1} = rtcs_admin:create_user(RiakNode, 1),
-    UserConfig3 = rtcs_config:config(AccessKeyId1, SecretAccessKey1, rtcs_config:cs_port(RiakNode)),
+    UserConfig2 = rtcs_admin:create_user(RiakNode, 1),
+    UserConfig3 = rtcs_admin:create_user(RiakNode, 1),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET2, UserConfig)),
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET3, UserConfig2)),
@@ -304,7 +302,7 @@ verify_without_cl_header(UserConfig, mp, Data) ->
 exec_curl(#aws_config{s3_port=Port} = UserConfig, Method, Resource, AmzHeaders) ->
     ContentType = "application/octet-stream",
     Date = httpd_util:rfc1123_date(),
-    Auth = rtcs:make_authorization(Method, Resource, ContentType, UserConfig, Date,
+    Auth = rtcs_admin:make_authorization(Method, Resource, ContentType, UserConfig, Date,
                                    AmzHeaders),
     HeaderArgs = [fmt("-H '~s: ~s' ", [K, V]) ||
                      {K, V} <- [{"Date", Date}, {"Authorization", Auth},

--- a/riak_test/tests/put_copy_test.erl
+++ b/riak_test/tests/put_copy_test.erl
@@ -52,9 +52,9 @@ confirm() ->
 
     RiakNode = hd(RiakNodes),
     {AccessKeyId, SecretAccessKey} = rtcs:create_user(RiakNode, 1),
-    UserConfig2 = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(RiakNode)),
+    UserConfig2 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
     {AccessKeyId1, SecretAccessKey1} = rtcs:create_user(RiakNode, 1),
-    UserConfig3 = rtcs:config(AccessKeyId1, SecretAccessKey1, rtcs:cs_port(RiakNode)),
+    UserConfig3 = rtcs_config:config(AccessKeyId1, SecretAccessKey1, rtcs_config:cs_port(RiakNode)),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET2, UserConfig)),
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET3, UserConfig2)),

--- a/riak_test/tests/put_copy_test.erl
+++ b/riak_test/tests/put_copy_test.erl
@@ -51,9 +51,9 @@ confirm() ->
                  erlcloud_s3:put_object(?BUCKET, ?KEY2, Data, UserConfig)),
 
     RiakNode = hd(RiakNodes),
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(RiakNode, 1),
+    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(RiakNode, 1),
     UserConfig2 = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
-    {AccessKeyId1, SecretAccessKey1} = rtcs:create_user(RiakNode, 1),
+    {AccessKeyId1, SecretAccessKey1} = rtcs_admin:create_user(RiakNode, 1),
     UserConfig3 = rtcs_config:config(AccessKeyId1, SecretAccessKey1, rtcs_config:cs_port(RiakNode)),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET2, UserConfig)),

--- a/riak_test/tests/regression_tests_2.erl
+++ b/riak_test/tests/regression_tests_2.erl
@@ -30,9 +30,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
-    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true}])}],
-    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, Config),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2),
 
     ok = verify_cs631(UserConfig, "cs-631-test-bukcet"),
     ok = verify_cs654(UserConfig),

--- a/riak_test/tests/regression_tests_2.erl
+++ b/riak_test/tests/regression_tests_2.erl
@@ -30,8 +30,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 confirm() ->
-    Config = [{riak, rtcs:riak_config()}, {stanchion, rtcs:stanchion_config()},
-              {cs, rtcs:cs_config([{fold_objects_for_list_keys, true}])}],
+    Config = [{riak, rtcs_config:riak_config()}, {stanchion, rtcs_config:stanchion_config()},
+              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true}])}],
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, Config),
 
     ok = verify_cs631(UserConfig, "cs-631-test-bukcet"),

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -16,17 +16,15 @@ confirm() ->
     AFirst = hd(ANodes),
     BFirst = hd(BNodes),
 
-    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(AFirst, 1),
-    {AccessKeyId2, SecretAccessKey2} = rtcs_admin:create_user(BFirst, 2),
-
     %% User 1, Cluster 1 config
-    U1C1Config = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(ANodes))),
-    %% User 2, Cluster 1 config
-    U2C1Config = rtcs_config:config(AccessKeyId2, SecretAccessKey2, rtcs_config:cs_port(hd(ANodes))),
+    U1C1Config = rtcs_admin:create_user(AFirst, 1),
     %% User 1, Cluster 2 config
-    U1C2Config = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(BNodes))),
+    U1C2Config = rtcs_admin:aws_config(U1C1Config, [{port, rtcs_config:cs_port(BFirst)}]),
+
     %% User 2, Cluster 2 config
-    U2C2Config = rtcs_config:config(AccessKeyId2, SecretAccessKey2, rtcs_config:cs_port(hd(BNodes))),
+    U2C2Config = rtcs_admin:create_user(BFirst, 2),
+    %% User 2, Cluster 1 config
+    U2C1Config = rtcs_admin:aws_config(U2C2Config, [{port, rtcs_config:cs_port(AFirst)}]),
 
     lager:info("User 1 IS valid on the primary cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(U1C1Config)),

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -20,13 +20,13 @@ confirm() ->
     {AccessKeyId2, SecretAccessKey2} = rtcs:create_user(BFirst, 2),
 
     %% User 1, Cluster 1 config
-    U1C1Config = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(hd(ANodes))),
+    U1C1Config = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(ANodes))),
     %% User 2, Cluster 1 config
-    U2C1Config = rtcs:config(AccessKeyId2, SecretAccessKey2, rtcs:cs_port(hd(ANodes))),
+    U2C1Config = rtcs_config:config(AccessKeyId2, SecretAccessKey2, rtcs_config:cs_port(hd(ANodes))),
     %% User 1, Cluster 2 config
-    U1C2Config = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(hd(BNodes))),
+    U1C2Config = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(BNodes))),
     %% User 2, Cluster 2 config
-    U2C2Config = rtcs:config(AccessKeyId2, SecretAccessKey2, rtcs:cs_port(hd(BNodes))),
+    U2C2Config = rtcs_config:config(AccessKeyId2, SecretAccessKey2, rtcs_config:cs_port(hd(BNodes))),
 
     lager:info("User 1 IS valid on the primary cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(U1C1Config)),

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -16,8 +16,8 @@ confirm() ->
     AFirst = hd(ANodes),
     BFirst = hd(BNodes),
 
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(AFirst, 1),
-    {AccessKeyId2, SecretAccessKey2} = rtcs:create_user(BFirst, 2),
+    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(AFirst, 1),
+    {AccessKeyId2, SecretAccessKey2} = rtcs_admin:create_user(BFirst, 2),
 
     %% User 1, Cluster 1 config
     U1C1Config = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(hd(ANodes))),

--- a/riak_test/tests/select_gc_bucket_test.erl
+++ b/riak_test/tests/select_gc_bucket_test.erl
@@ -48,8 +48,8 @@ confirm1() ->
 
     BlockKeysFile = "/tmp/select_gc.txt",
     os:cmd("rm -f " ++ BlockKeysFile),
-    rtcs:gc(1, "set-interval infinity"),
-    rtcs:gc(1, "cancel"),
+    rtcs_exec:gc(1, "set-interval infinity"),
+    rtcs_exec:gc(1, "cancel"),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),
     [upload_object(UserConfig, ?BUCKET, normal, K) ||
@@ -60,7 +60,7 @@ confirm1() ->
         K <- [?KEY_DELETED_S, ?KEY_DELETED_L1, ?KEY_DELETED_L2]],
 
     timer:sleep(1000),
-    Res1 = rtcs:exec_priv_escript(1, "internal/select_gc_bucket.erl",
+    Res1 = rtcs_exec:exec_priv_escript(1, "internal/select_gc_bucket.erl",
                                   "-h 127.0.0.1 -p 10017 -e today "
                                   "-o " ++ BlockKeysFile),
     lager:debug("select_gc_bucket.erl log:\n~s", [Res1]),

--- a/riak_test/tests/sibling_benchmark.erl
+++ b/riak_test/tests/sibling_benchmark.erl
@@ -52,15 +52,15 @@ confirm() ->
     Duration = proplists:get_value(duration_sec, RTConfig, 16),
     ?assert(is_integer(Duration) andalso Duration >= 0),
 
-    CSConfig0 = rtcs:replace_cs_config(connection_pools,
+    CSConfig0 = rtcs_config:replace_cs_config(connection_pools,
                                        [
                                         {request_pool, {Concurrency*2 + 5, 0} },
-                                        {bucket_list_pool, {rtcs:bucket_list_pool_size(), 0} }
+                                        {bucket_list_pool, {rtcs_config:bucket_list_pool_size(), 0} }
                                        ],
-                                       rtcs:cs_config()),
-    CSConfig1 = rtcs:replace_cs_config(leeway_seconds,
+                                       rtcs_config:cs_config()),
+    CSConfig1 = rtcs_config:replace_cs_config(leeway_seconds,
                                        5, CSConfig0),
-    CSConfig = rtcs:replace_cs_config(gc_interval,
+    CSConfig = rtcs_config:replace_cs_config(gc_interval,
                                       10, CSConfig1),
     ConnConfig = [{cs, CSConfig}],
 
@@ -71,7 +71,7 @@ confirm() ->
                 rtcs:setup(4, ConnConfig);
             previous ->
                 put(version, previous),
-                PrevConfig =  ConnConfig ++ rtcs:previous_configs(),
+                PrevConfig =  ConnConfig ++ rtcs_config:previous_configs(),
                 rtcs:setup(4, PrevConfig, previous)
         end,
 

--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -33,7 +33,7 @@ confirm() ->
     {UserConfig, {RiakNodes, _CSNodes, Stanchion}} = rtcs:setup(1),
 
     lists:foreach(fun(RiakNode) ->
-                          N = rt_cs_dev:node_id(RiakNode),
+                          N = rtcs_dev:node_id(RiakNode),
                           ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9095\n",
                                        rtcs_exec:show_stanchion_cs(N))
                   end, RiakNodes),
@@ -53,7 +53,7 @@ confirm() ->
     ?assertException(error, {aws_error, {http_error, 500, _, _}},
                     erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
 
-    rt_cs_dev:set_advanced_conf(stanchion, [{stanchion, [{host, {"127.0.0.1", ?BACKUP_PORT}}]}]),
+    rtcs_dev:set_advanced_conf(stanchion, [{stanchion, [{host, {"127.0.0.1", ?BACKUP_PORT}}]}]),
     _ = rtcs_exec:start_stanchion(),
     rt:wait_until_pingable(Stanchion),
 
@@ -64,7 +64,7 @@ confirm() ->
 
     %% switch stanchion here, for all CS nodes
     lists:foreach(fun(RiakNode) ->
-                          N = rt_cs_dev:node_id(RiakNode),
+                          N = rtcs_dev:node_id(RiakNode),
                           rtcs_exec:switch_stanchion_cs(N, "127.0.0.1", ?BACKUP_PORT),
                           ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9096\n",
                                        rtcs_exec:show_stanchion_cs(N))

--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -53,7 +53,7 @@ confirm() ->
     ?assertException(error, {aws_error, {http_error, 500, _, _}},
                     erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
 
-    rtcs_dev:set_advanced_conf(stanchion, [{stanchion, [{host, {"127.0.0.1", ?BACKUP_PORT}}]}]),
+    rtcs:set_advanced_conf(stanchion, [{stanchion, [{host, {"127.0.0.1", ?BACKUP_PORT}}]}]),
     _ = rtcs_exec:start_stanchion(),
     rt:wait_until_pingable(Stanchion),
 

--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -29,11 +29,6 @@
 
 -define(BACKUP_PORT, 9096).
 
-backup_stanchion_config() ->
-    rtcs_config:replace_stanchion_config(host,
-                                  {"127.0.0.1", ?BACKUP_PORT},
-                                  rtcs_config:stanchion_config()).
-
 confirm() ->
     {UserConfig, {RiakNodes, _CSNodes, Stanchion}} = rtcs:setup(1),
 
@@ -58,7 +53,8 @@ confirm() ->
     ?assertException(error, {aws_error, {http_error, 500, _, _}},
                     erlcloud_s3:create_bucket(?TEST_BUCKET, UserConfig)),
 
-    ok = rtcs:deploy_stanchion(backup_stanchion_config()),
+    rt_cs_dev:set_advanced_conf(stanchion, [{stanchion, [{host, {"127.0.0.1", ?BACKUP_PORT}}]}]),
+    _ = rtcs_exec:start_stanchion(),
     rt:wait_until_pingable(Stanchion),
 
     %% stanchion ops ng; we get 500 here for sure.

--- a/riak_test/tests/stanchion_switch_test.erl
+++ b/riak_test/tests/stanchion_switch_test.erl
@@ -30,9 +30,9 @@
 -define(BACKUP_PORT, 9096).
 
 backup_stanchion_config() ->
-    rtcs:replace_stanchion_config(host,
+    rtcs_config:replace_stanchion_config(host,
                                   {"127.0.0.1", ?BACKUP_PORT},
-                                  rtcs:stanchion_config()).
+                                  rtcs_config:stanchion_config()).
 
 confirm() ->
     {UserConfig, {RiakNodes, _CSNodes, Stanchion}} = rtcs:setup(1),
@@ -40,7 +40,7 @@ confirm() ->
     lists:foreach(fun(RiakNode) ->
                           N = rt_cs_dev:node_id(RiakNode),
                           ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9095\n",
-                                       rtcs:show_stanchion_cs(N))
+                                       rtcs_exec:show_stanchion_cs(N))
                   end, RiakNodes),
 
     %% stanchion ops ok
@@ -50,7 +50,7 @@ confirm() ->
     ?assertEqual(ok, erlcloud_s3:delete_bucket(?TEST_BUCKET, UserConfig)),
 
     %% stop stanchion to check ops fails
-    _ = rtcs:stop_stanchion(),
+    _ = rtcs_exec:stop_stanchion(),
     rt:wait_until_unpingable(Stanchion),
 
     %% stanchion ops ng; we get 500 here for sure.
@@ -69,9 +69,9 @@ confirm() ->
     %% switch stanchion here, for all CS nodes
     lists:foreach(fun(RiakNode) ->
                           N = rt_cs_dev:node_id(RiakNode),
-                          rtcs:switch_stanchion_cs(N, "127.0.0.1", ?BACKUP_PORT),
+                          rtcs_exec:switch_stanchion_cs(N, "127.0.0.1", ?BACKUP_PORT),
                           ?assertEqual("Current Stanchion Adderss: http://127.0.0.1:9096\n",
-                                       rtcs:show_stanchion_cs(N))
+                                       rtcs_exec:show_stanchion_cs(N))
                   end, RiakNodes),
 
     %% stanchion ops ok again

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -143,7 +143,7 @@ query_stats(Type, UserConfig, Port) ->
                                stanchion -> {"/stats", velvet}
                            end,
     Cmd="curl -s -H 'Date: " ++ Date ++ "' -H 'Authorization: " ++
-        rtcs:make_authorization(SignType, "GET", Resource, [], UserConfig, Date, []) ++
+        rtcs_admin:make_authorization(SignType, "GET", Resource, [], UserConfig, Date, []) ++
         "' http://localhost:" ++
         integer_to_list(Port) ++ Resource,
     lager:info("Stats query cmd: ~p", [Cmd]),

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -159,9 +159,9 @@ confirm_stat_count(StatData, StatType, ExpectedCount) ->
 confirm_status_cmd(Type, ExpectedToken) ->
     Cmd = case Type of
               cs ->
-                  rtcs_exec:riakcs_statuscmd(rtcs_config:get_rt_config(cs, current), 1);
+                  rtcs_exec:riakcs_statuscmd(rtcs_config:devpath(cs, current), 1);
               stanchion ->
-                  rtcs_exec:stanchion_statuscmd(rtcs_config:get_rt_config(stanchion, current))
+                  rtcs_exec:stanchion_statuscmd(rtcs_config:devpath(stanchion, current))
           end,
     Res = os:cmd(Cmd),
     ?assert(string:str(Res, ExpectedToken) > 0).

--- a/riak_test/tests/stats_test.erl
+++ b/riak_test/tests/stats_test.erl
@@ -28,14 +28,14 @@ confirm() ->
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
 
     lager:info("Confirming initial stats"),
-    confirm_initial_stats(cs, UserConfig, rtcs:cs_port(hd(RiakNodes))),
-    confirm_initial_stats(stanchion, UserConfig, rtcs:stanchion_port()),
+    confirm_initial_stats(cs, UserConfig, rtcs_config:cs_port(hd(RiakNodes))),
+    confirm_initial_stats(stanchion, UserConfig, rtcs_config:stanchion_port()),
 
     do_some_api_calls(UserConfig, "bucket1", "bucket2"),
 
     lager:info("Confirming stats after some operations"),
-    confirm_stats(cs, UserConfig, rtcs:cs_port(hd(RiakNodes))),
-    confirm_stats(stanchion, UserConfig, rtcs:stanchion_port()),
+    confirm_stats(cs, UserConfig, rtcs_config:cs_port(hd(RiakNodes))),
+    confirm_stats(stanchion, UserConfig, rtcs_config:stanchion_port()),
     rtcs:pass().
 
 confirm_initial_stats(cs, UserConfig, Port) ->
@@ -65,9 +65,9 @@ confirm_initial_stats(cs, UserConfig, Port) ->
                          "riakc_delete_block_constrained"
                         ]],
     ?assertEqual(1, proplists:get_value(<<"velvet_create_user_in_one">>, StatData)),
-    ?assertEqual(rtcs:request_pool_size() - 1,
+    ?assertEqual(rtcs_config:request_pool_size() - 1,
                  proplists:get_value(<<"request_pool_workers">>, StatData)),
-    ?assertEqual(rtcs:bucket_list_pool_size(),
+    ?assertEqual(rtcs_config:bucket_list_pool_size(),
                  proplists:get_value(<<"bucket_list_pool_workers">>, StatData));
 
 confirm_initial_stats(stanchion, UserConfig, Port) ->
@@ -159,9 +159,9 @@ confirm_stat_count(StatData, StatType, ExpectedCount) ->
 confirm_status_cmd(Type, ExpectedToken) ->
     Cmd = case Type of
               cs ->
-                  rtcs:riakcs_statuscmd(rtcs:get_rt_config(cs, current), 1);
+                  rtcs_exec:riakcs_statuscmd(rtcs_config:get_rt_config(cs, current), 1);
               stanchion ->
-                  rtcs:stanchion_statuscmd(rtcs:get_rt_config(stanchion, current))
+                  rtcs_exec:stanchion_statuscmd(rtcs_config:get_rt_config(stanchion, current))
           end,
     Res = os:cmd(Cmd),
     ?assert(string:str(Res, ExpectedToken) > 0).

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -41,7 +41,7 @@ confirm() ->
     SetupRes = rtcs:setup(1),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),
-    {AccessKeyId, SecretAccessKey} = rtcs:create_user(RiakNode, 1),
+    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(RiakNode, 1),
     UserConfig = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -41,8 +41,7 @@ confirm() ->
     SetupRes = rtcs:setup(1),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),
-    {AccessKeyId, SecretAccessKey} = rtcs_admin:create_user(RiakNode, 1),
-    UserConfig = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
+    UserConfig = rtcs_admin:create_user(RiakNode, 1),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),
     lager:info("Investigating stats for this empty bucket..."),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -39,8 +39,7 @@
 confirm() ->
     Config = [{riak, rtcs_config:riak_config()},
               {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true},
-                                   {detailed_storage_calc, true}])}],
+              {cs, rtcs_config:cs_config([{detailed_storage_calc, true}])}],
     SetupRes = rtcs:setup(1, Config),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -37,10 +37,8 @@
 -define(KEY3, "3").
 
 confirm() ->
-    Config = [{riak, rtcs_config:riak_config()},
-              {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{detailed_storage_calc, true}])}],
-    SetupRes = rtcs:setup(1, Config),
+    rt_cs_dev:set_advanced_conf(cs, [{riak_cs, [{detailed_storage_calc, true}]}]),
+    SetupRes = rtcs:setup(1),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),
     {AccessKeyId, SecretAccessKey} = rtcs:create_user(RiakNode, 1),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -37,7 +37,7 @@
 -define(KEY3, "3").
 
 confirm() ->
-    rtcs_dev:set_advanced_conf(cs, [{riak_cs, [{detailed_storage_calc, true}]}]),
+    rtcs:set_advanced_conf(cs, [{riak_cs, [{detailed_storage_calc, true}]}]),
     SetupRes = rtcs:setup(1),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -37,7 +37,7 @@
 -define(KEY3, "3").
 
 confirm() ->
-    rt_cs_dev:set_advanced_conf(cs, [{riak_cs, [{detailed_storage_calc, true}]}]),
+    rtcs_dev:set_advanced_conf(cs, [{riak_cs, [{detailed_storage_calc, true}]}]),
     SetupRes = rtcs:setup(1),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),

--- a/riak_test/tests/storage_stats_detailed_test.erl
+++ b/riak_test/tests/storage_stats_detailed_test.erl
@@ -37,15 +37,15 @@
 -define(KEY3, "3").
 
 confirm() ->
-    Config = [{riak, rtcs:riak_config()},
-              {stanchion, rtcs:stanchion_config()},
-              {cs, rtcs:cs_config([{fold_objects_for_list_keys, true},
+    Config = [{riak, rtcs_config:riak_config()},
+              {stanchion, rtcs_config:stanchion_config()},
+              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true},
                                    {detailed_storage_calc, true}])}],
     SetupRes = rtcs:setup(1, Config),
     {AdminConfig, {RiakNodes, CSNodes, _Stanchion}} = SetupRes,
     RiakNode = hd(RiakNodes),
     {AccessKeyId, SecretAccessKey} = rtcs:create_user(RiakNode, 1),
-    UserConfig = rtcs:config(AccessKeyId, SecretAccessKey, rtcs:cs_port(RiakNode)),
+    UserConfig = rtcs_config:config(AccessKeyId, SecretAccessKey, rtcs_config:cs_port(RiakNode)),
 
     ?assertEqual(ok, erlcloud_s3:create_bucket(?BUCKET, UserConfig)),
     lager:info("Investigating stats for this empty bucket..."),

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -57,7 +57,7 @@ confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
     confirm_2(SetupRes).
 
 confirm_2({UserConfig, {RiakNodes, CSNodes, _Stanchion}}) ->
-    {AccessKey2, SecretKey2} = rtcs:create_user(hd(RiakNodes), 1),
+    {AccessKey2, SecretKey2} = rtcs_admin:create_user(hd(RiakNodes), 1),
     UserConfig2 = rtcs_config:config(AccessKey2, SecretKey2, rtcs_config:cs_port(hd(RiakNodes))),
 
     TestSpecs = [store_object(?BUCKET1, UserConfig),

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -50,8 +50,8 @@ confirm() ->
     confirm_1(false).
 
 confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
-    rtcs_dev:set_advanced_conf(riak, [{riak_kv, [{delete_mode, keep}]}]),
-    rtcs_dev:set_advanced_conf(cs, [{riak_cs,
+    rtcs:set_advanced_conf(riak, [{riak_kv, [{delete_mode, keep}]}]),
+    rtcs:set_advanced_conf(cs, [{riak_cs,
                                       [{use_2i_for_storage_calc, Use2iForStorageCalc}]}]),
     SetupRes = rtcs:setup(1),
     confirm_2(SetupRes).

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -50,10 +50,10 @@ confirm() ->
     confirm_1(false).
 
 confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
-    Config = [{riak, rtcs_config:riak_config([{riak_kv, [{delete_mode, keep}]}])},
-              {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{use_2i_for_storage_calc, Use2iForStorageCalc}])}],
-    SetupRes = rtcs:setup(1, Config),
+    rt_cs_dev:set_advanced_conf(riak, [{riak_kv, [{delete_mode, keep}]}]),
+    rt_cs_dev:set_advanced_conf(cs, [{riak_cs,
+                                      [{use_2i_for_storage_calc, Use2iForStorageCalc}]}]),
+    SetupRes = rtcs:setup(1),
     confirm_2(SetupRes).
 
 confirm_2({UserConfig, {RiakNodes, CSNodes, _Stanchion}}) ->

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -50,8 +50,8 @@ confirm() ->
     confirm_1(false).
 
 confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
-    rt_cs_dev:set_advanced_conf(riak, [{riak_kv, [{delete_mode, keep}]}]),
-    rt_cs_dev:set_advanced_conf(cs, [{riak_cs,
+    rtcs_dev:set_advanced_conf(riak, [{riak_kv, [{delete_mode, keep}]}]),
+    rtcs_dev:set_advanced_conf(cs, [{riak_cs,
                                       [{use_2i_for_storage_calc, Use2iForStorageCalc}]}]),
     SetupRes = rtcs:setup(1),
     confirm_2(SetupRes).

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -50,16 +50,16 @@ confirm() ->
     confirm_1(false).
 
 confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
-    Config = [{riak, rtcs:riak_config([{riak_kv, [{delete_mode, keep}]}])},
-              {stanchion, rtcs:stanchion_config()},
-              {cs, rtcs:cs_config([{fold_objects_for_list_keys, true},
+    Config = [{riak, rtcs_config:riak_config([{riak_kv, [{delete_mode, keep}]}])},
+              {stanchion, rtcs_config:stanchion_config()},
+              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true},
                                    {use_2i_for_storage_calc, Use2iForStorageCalc}])}],
     SetupRes = rtcs:setup(1, Config),
     confirm_2(SetupRes).
 
 confirm_2({UserConfig, {RiakNodes, CSNodes, _Stanchion}}) ->
     {AccessKey2, SecretKey2} = rtcs:create_user(hd(RiakNodes), 1),
-    UserConfig2 = rtcs:config(AccessKey2, SecretKey2, rtcs:cs_port(hd(RiakNodes))),
+    UserConfig2 = rtcs_config:config(AccessKey2, SecretKey2, rtcs_config:cs_port(hd(RiakNodes))),
 
     TestSpecs = [store_object(?BUCKET1, UserConfig),
                  delete_object(?BUCKET2, UserConfig),
@@ -239,7 +239,7 @@ calc_storage_stats(CSNode) ->
     Begin = rtcs:datetime(),
     %% FIXME: workaround for #766
     timer:sleep(1000),
-    Res = rtcs:calculate_storage(1),
+    Res = rtcs_exec:calculate_storage(1),
     lager:info("riak-cs-storage batch result: ~s", [Res]),
     ExpectRegexp = "Batch storage calculation started.\n$",
     ?assertMatch({match, _}, re:run(Res, ExpectRegexp)),

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -52,8 +52,7 @@ confirm() ->
 confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
     Config = [{riak, rtcs_config:riak_config([{riak_kv, [{delete_mode, keep}]}])},
               {stanchion, rtcs_config:stanchion_config()},
-              {cs, rtcs_config:cs_config([{fold_objects_for_list_keys, true},
-                                   {use_2i_for_storage_calc, Use2iForStorageCalc}])}],
+              {cs, rtcs_config:cs_config([{use_2i_for_storage_calc, Use2iForStorageCalc}])}],
     SetupRes = rtcs:setup(1, Config),
     confirm_2(SetupRes).
 

--- a/riak_test/tests/storage_stats_test.erl
+++ b/riak_test/tests/storage_stats_test.erl
@@ -57,8 +57,7 @@ confirm_1(Use2iForStorageCalc) when is_boolean(Use2iForStorageCalc) ->
     confirm_2(SetupRes).
 
 confirm_2({UserConfig, {RiakNodes, CSNodes, _Stanchion}}) ->
-    {AccessKey2, SecretKey2} = rtcs_admin:create_user(hd(RiakNodes), 1),
-    UserConfig2 = rtcs_config:config(AccessKey2, SecretKey2, rtcs_config:cs_port(hd(RiakNodes))),
+    UserConfig2 = rtcs_admin:create_user(hd(RiakNodes), 1),
 
     TestSpecs = [store_object(?BUCKET1, UserConfig),
                  delete_object(?BUCKET2, UserConfig),

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -34,7 +34,7 @@
 -define(BAD_PART_SIZE, 2*1024*1024).
 
 confirm() ->
-    rtcs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs:set_advanced_conf(cs, cs_config()),
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
 
     lager:info("User is valid on the cluster, and has no buckets"),

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -34,7 +34,8 @@
 -define(BAD_PART_SIZE, 2*1024*1024).
 
 confirm() ->
-    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1, [{cs, cs_config()}]),
+    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
 
     lager:info("User is valid on the cluster, and has no buckets"),
     ?assertEqual([{buckets, []}], erlcloud_s3:list_buckets(UserConfig)),
@@ -108,15 +109,8 @@ upload_id_present(UploadId, UploadList) ->
                          proplists:get_value(upload_id, UploadData) =:= UploadId].
 
 cs_config() ->
-    [
-     rtcs_config:lager_config(),
-     {riak_cs,
+    [{riak_cs,
       [
-       {proxy_get, enabled},
-       {anonymous_user_creation, true},
-       {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
-       {cs_version, 010300},
        {max_content_length, 1000},
        {enforce_multipart_part_size, false}
       ]

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -109,13 +109,13 @@ upload_id_present(UploadId, UploadList) ->
 
 cs_config() ->
     [
-     rtcs:lager_config(),
+     rtcs_config:lager_config(),
      {riak_cs,
       [
        {proxy_get, enabled},
        {anonymous_user_creation, true},
        {riak_host, {"127.0.0.1", 10017}},
-       {stanchion_host, {"127.0.0.1", rtcs:stanchion_port()}},
+       {stanchion_host, {"127.0.0.1", rtcs_config:stanchion_port()}},
        {cs_version, 010300},
        {max_content_length, 1000},
        {enforce_multipart_part_size, false}

--- a/riak_test/tests/too_large_entity_test.erl
+++ b/riak_test/tests/too_large_entity_test.erl
@@ -34,7 +34,7 @@
 -define(BAD_PART_SIZE, 2*1024*1024).
 
 confirm() ->
-    rt_cs_dev:set_advanced_conf(cs, cs_config()),
+    rtcs_dev:set_advanced_conf(cs, cs_config()),
     {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(1),
 
     lager:info("User is valid on the cluster, and has no buckets"),

--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -41,11 +41,11 @@ confirm() ->
     AdminCreds = {UserConfig#aws_config.access_key_id,
                   UserConfig#aws_config.secret_access_key},
     {_, RiakCurrentVsn} =
-        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rtcs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
 
     %% Upgrade!!!
     [begin
-         N = rt_cs_dev:node_id(RiakNode),
+         N = rtcs_dev:node_id(RiakNode),
          lager:debug("upgrading ~p", [N]),
          rtcs_exec:stop_cs(N, previous),
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
@@ -66,7 +66,7 @@ confirm() ->
     {ok, Data2} = prepare_all_data(UserConfig),
 
     {_, RiakPrevVsn} =
-        rt_cs_dev:riak_root_and_vsn(previous, rt_config:get(build_type, oss)),
+        rtcs_dev:riak_root_and_vsn(previous, rt_config:get(build_type, oss)),
 
 
     %% Downgrade!!
@@ -74,14 +74,14 @@ confirm() ->
     rtcs_config:migrate_stanchion(current, previous, AdminCreds),
     rtcs_exec:start_stanchion(previous),
     [begin
-         N = rt_cs_dev:node_id(RiakNode),
+         N = rtcs_dev:node_id(RiakNode),
          lager:debug("downgrading ~p", [N]),
          rtcs_exec:stop_cs(N, current),
          rt:stop(RiakNode),
          rt:wait_until_unpingable(RiakNode),
 
          %% get the bitcask directory
-         BitcaskDataDir = filename:join([rt_cs_dev:node_path(RiakNode), "data", "bitcask"]),
+         BitcaskDataDir = filename:join([rtcs_dev:node_path(RiakNode), "data", "bitcask"]),
          lager:info("downgrading Bitcask datadir ~s...", [BitcaskDataDir]),
          %% and run the downgrade script:
          %% Downgrading from 2.0 does not work...

--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -41,7 +41,7 @@ confirm() ->
     AdminCreds = {UserConfig#aws_config.access_key_id,
                   UserConfig#aws_config.secret_access_key},
     {_, RiakCurrentVsn} =
-        rtcs:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
+        rt_cs_dev:riak_root_and_vsn(current, rt_config:get(build_type, oss)),
 
     %% Upgrade!!!
     [begin
@@ -66,7 +66,7 @@ confirm() ->
     {ok, Data2} = prepare_all_data(UserConfig),
 
     {_, RiakPrevVsn} =
-        rtcs:riak_root_and_vsn(previous, rt_config:get(build_type, oss)),
+        rt_cs_dev:riak_root_and_vsn(previous, rt_config:get(build_type, oss)),
 
 
     %% Downgrade!!

--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -28,7 +28,7 @@
 -define(KEY_MULTIPLE_BLOCK, "riak_test_key2").
 
 confirm() ->
-    PrevConfig = rtcs:previous_configs(),
+    PrevConfig = rtcs_config:previous_configs(),
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} =
         rtcs:setup(2, PrevConfig, previous),
 
@@ -47,17 +47,17 @@ confirm() ->
     [begin
          N = rt_cs_dev:node_id(RiakNode),
          lager:debug("upgrading ~p", [N]),
-         rtcs:stop_cs(N, previous),
+         rtcs_exec:stop_cs(N, previous),
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
          rt:wait_for_service(RiakNode, riak_kv),
-         ok = rtcs:upgrade_cs(N, AdminCreds),
-         rtcs:start_cs(N, current)
+         ok = rtcs_config:upgrade_cs(N, AdminCreds),
+         rtcs_exec:start_cs(N, current)
      end
      || RiakNode <- RiakNodes],
     rt:wait_until_ring_converged(RiakNodes),
-    rtcs:stop_stanchion(previous),
-    rtcs:migrate_stanchion(previous, current, AdminCreds),
-    rtcs:start_stanchion(current),
+    rtcs_exec:stop_stanchion(previous),
+    rtcs_config:migrate_stanchion(previous, current, AdminCreds),
+    rtcs_exec:start_stanchion(current),
 
     ok = verify_all_data(UserConfig, Data),
     ok = cleanup_all_data(UserConfig),
@@ -70,13 +70,13 @@ confirm() ->
 
 
     %% Downgrade!!
-    rtcs:stop_stanchion(current),
-    rtcs:migrate_stanchion(current, previous, AdminCreds),
-    rtcs:start_stanchion(previous),
+    rtcs_exec:stop_stanchion(current),
+    rtcs_config:migrate_stanchion(current, previous, AdminCreds),
+    rtcs_exec:start_stanchion(previous),
     [begin
          N = rt_cs_dev:node_id(RiakNode),
          lager:debug("downgrading ~p", [N]),
-         rtcs:stop_cs(N, current),
+         rtcs_exec:stop_cs(N, current),
          rt:stop(RiakNode),
          rt:wait_until_unpingable(RiakNode),
 
@@ -93,8 +93,8 @@ confirm() ->
 
          ok = rt:upgrade(RiakNode, RiakPrevVsn),
          rt:wait_for_service(RiakNode, riak_kv),
-         ok = rtcs:migrate_cs(current, previous, N, AdminCreds),
-         rtcs:start_cs(N, previous)
+         ok = rtcs_config:migrate_cs(current, previous, N, AdminCreds),
+         rtcs_exec:start_cs(N, previous)
      end
      || RiakNode <- RiakNodes],
     rt:wait_until_ring_converged(RiakNodes),

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -91,7 +91,7 @@ collect_users(N, Acc) ->
 create_users(_Port, [], Acc) ->
     ordsets:from_list(Acc);
 create_users(Port, [{Email, Name} | Users], Acc) ->
-    {Key, Secret, _Id} = rtcs:create_user(Port, Email, Name),
+    {Key, Secret, _Id} = rtcs_admin:create_user(Port, Email, Name),
     create_users(Port, Users, [{Email, Name, Key, Secret, "enabled"} | Acc]).
 
 user_listing_json_test_case(Users, UserConfig, Node) ->
@@ -127,8 +127,8 @@ update_user_xml_test_case(AdminConfig, Node) ->
 update_user_test(AdminConfig, Node, ContentType, Users) ->
     [{Email1, User1}, {Email2, User2}, {Email3, User3}]= Users,
     Port = rtcs_config:cs_port(Node),
-    {Key, Secret, _} = rtcs:create_user(Port, Email1, User1),
-    {BadUserKey, BadUserSecret, _} = rtcs:create_user(Port, Email3, User3),
+    {Key, Secret, _} = rtcs_admin:create_user(Port, Email1, User1),
+    {BadUserKey, BadUserSecret, _} = rtcs_admin:create_user(Port, Email3, User3),
 
     UserConfig = rtcs_config:config(Key, Secret, Port),
     BadUserConfig = rtcs_config:config(BadUserKey, BadUserSecret, Port),

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -42,7 +42,7 @@ confirm() ->
     user_listing_xml_test_case([AdminUser], AdminUserConfig, HeadRiakNode),
 
     %% Create other 1003 users and re-run user listing test cases
-    Port = rtcs:cs_port(HeadRiakNode),
+    Port = rtcs_config:cs_port(HeadRiakNode),
     Users1 = [AdminUser |
               create_users(Port, [{"bart@simpsons.com", "bart"},
                                   {"homer@simpsons.com", "homer"},
@@ -107,7 +107,7 @@ user_listing_many_times(Users, UserConfig, Node) ->
 
 user_listing_test(ExpectedUsers, UserConfig, Node, ContentType) ->
     Resource = "/riak-cs/users",
-    Port = rtcs:cs_port(Node),
+    Port = rtcs_config:cs_port(Node),
     Users = parse_user_info(
               rtcs:list_users(UserConfig, Port, Resource, ContentType)),
     ?assertEqual(ExpectedUsers, Users).
@@ -126,12 +126,12 @@ update_user_xml_test_case(AdminConfig, Node) ->
 
 update_user_test(AdminConfig, Node, ContentType, Users) ->
     [{Email1, User1}, {Email2, User2}, {Email3, User3}]= Users,
-    Port = rtcs:cs_port(Node),
+    Port = rtcs_config:cs_port(Node),
     {Key, Secret, _} = rtcs:create_user(Port, Email1, User1),
     {BadUserKey, BadUserSecret, _} = rtcs:create_user(Port, Email3, User3),
 
-    UserConfig = rtcs:config(Key, Secret, Port),
-    BadUserConfig = rtcs:config(BadUserKey, BadUserSecret, Port),
+    UserConfig = rtcs_config:config(Key, Secret, Port),
+    BadUserConfig = rtcs_config:config(BadUserKey, BadUserSecret, Port),
 
     UserResource = "/riak-cs/user",
     AdminResource = UserResource ++ "/" ++ UserConfig#aws_config.access_key_id,
@@ -221,7 +221,7 @@ update_user_test(AdminConfig, Node, ContentType, Users) ->
     {_, _, _, UpdSecret1, _} = parse_user_record(UpdateResult, ContentType),
 
     %% Generate an updated user config with the new secret
-    UserConfig2 = rtcs:config(Key, UpdSecret1, Port),
+    UserConfig2 = rtcs_config:config(Key, UpdSecret1, Port),
 
     %% Fetch the user record using the user's own credentials
     UserResult7 = parse_user_record(


### PR DESCRIPTION
Main Changes:
- Move rt_cs_dev from riak_test repo to here, and it was renamed to rtcs_dev.
- Devide rtcs into 3 modules: rtcs, rtcs_config, rtcs_exec
- Introduce new API to set custom config including `rtcs:set_conf` and `rtcs:set_advanced_conf`
- Avoid to use `rtcs:deploy/2` to set custom configs
- Refactor rt utility modules
# **Note**: After merging this PR, We have to use **`rtcs_dev`  as `rt_harness`**

instead of `rt_cs_dev`
