### PR TITLE
Add requestPayment and lifecycle stub callbacks [JIRA: RCS-272]

### DIFF
--- a/include/s3_api.hrl
+++ b/include/s3_api.hrl
@@ -22,7 +22,7 @@
 -define(SUBRESOURCES, ["acl", "location", "logging", "notification", "partNumber",
                        "policy", "requestPayment", "torrent", "uploadId", "uploads",
                        "versionId", "versioning", "versions", "website",
-                       "delete"]).
+                       "delete", "lifecycle"]).
 
 % type and record definitions for S3 policy API
 -type s3_object_action() :: 's3:GetObject'       | 's3:GetObjectVersion'

--- a/src/riak_cs_s3_policy.erl
+++ b/src/riak_cs_s3_policy.erl
@@ -403,6 +403,7 @@ make_action(Method, Target) ->
         {'PUT', object_acl} -> {ok, 's3:PutObjectAcl'};
         {'PUT', bucket_acl} -> {ok, 's3:PutBucketAcl'};
         {'PUT', bucket_policy} -> {ok, 's3:PutBucketPolicy'};
+        {'PUT', bucket_request_payment} -> {ok, 's3:PutBucketRequestPayment'};
 
         {'GET', object} ->     {ok, 's3:GetObject'};
         {'GET', object_part} -> {ok, 's3:ListMultipartUploadParts'};
@@ -412,6 +413,7 @@ make_action(Method, Target) ->
         {'GET', bucket_acl} -> {ok, 's3:GetBucketAcl'};
         {'GET', bucket_policy} -> {ok, 's3:GetBucketPolicy'};
         {'GET', bucket_location} -> {ok, 's3:GetBucketLocation'};
+        {'GET', bucket_request_payment} -> {ok, 's3:GetBucketRequestPayment'};
         {'GET', bucket_uploads} -> {ok, 's3:ListBucketMultipartUploads'};
 
         {'DELETE', object} ->  {ok, 's3:DeleteObject'};

--- a/src/riak_cs_stats.erl
+++ b/src/riak_cs_stats.erl
@@ -65,6 +65,7 @@ duration_metrics() ->
          [bucket_policy, delete],
          [bucket_location, get],
          [bucket_versioning, get],
+         [bucket_request_payment, get],
          [list_uploads, get],
          [multiple_delete, post],
          [list_objects, get],

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -71,9 +71,13 @@ base_resources() ->
      {["buckets", bucket, "objects"], riak_cs_wm_common, props(riak_cs_wm_objects)},
      {["buckets", bucket, "delete"], riak_cs_wm_common, props(riak_cs_wm_bucket_delete)},
      {["buckets", bucket, "acl"], riak_cs_wm_common, props(riak_cs_wm_bucket_acl)},
+     %% Just stub, no dynamic contents
      {["buckets", bucket, "location"], riak_cs_wm_common, props(riak_cs_wm_bucket_location)},
      {["buckets", bucket, "versioning"], riak_cs_wm_common, props(riak_cs_wm_bucket_versioning)},
+     {["buckets", bucket, "requestPayment"], riak_cs_wm_common, props(riak_cs_wm_bucket_request_payment)},
+     %% NYI
      {["buckets", bucket, "versions"], riak_cs_wm_common, props(riak_cs_wm_not_implemented)},
+     {["buckets", bucket, "lifecycle"], riak_cs_wm_common, props(riak_cs_wm_not_implemented)},
      %% Object resources
      {["buckets", bucket, "objects", object], riak_cs_wm_common, props(riak_cs_wm_object)},
      {["buckets", bucket, "objects", object, "acl"], riak_cs_wm_common, props(riak_cs_wm_object_acl)}

--- a/src/riak_cs_web.erl
+++ b/src/riak_cs_web.erl
@@ -71,8 +71,8 @@ base_resources() ->
      {["buckets", bucket, "objects"], riak_cs_wm_common, props(riak_cs_wm_objects)},
      {["buckets", bucket, "delete"], riak_cs_wm_common, props(riak_cs_wm_bucket_delete)},
      {["buckets", bucket, "acl"], riak_cs_wm_common, props(riak_cs_wm_bucket_acl)},
-     %% Just stub, no dynamic contents
      {["buckets", bucket, "location"], riak_cs_wm_common, props(riak_cs_wm_bucket_location)},
+     %% No dynamic contents, almost stub
      {["buckets", bucket, "versioning"], riak_cs_wm_common, props(riak_cs_wm_bucket_versioning)},
      {["buckets", bucket, "requestPayment"], riak_cs_wm_common, props(riak_cs_wm_bucket_request_payment)},
      %% NYI

--- a/src/riak_cs_wm_bucket_request_payment.erl
+++ b/src/riak_cs_wm_bucket_request_payment.erl
@@ -1,0 +1,66 @@
+%% ---------------------------------------------------------------------
+%%
+%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% ---------------------------------------------------------------------
+
+-module(riak_cs_wm_bucket_request_payment).
+
+-export([stats_prefix/0,
+         content_types_provided/2,
+         to_xml/2,
+         allowed_methods/0]).
+
+-export([authorize/2]).
+
+-include("riak_cs.hrl").
+-include_lib("webmachine/include/webmachine.hrl").
+
+-spec stats_prefix() -> bucket_request_payment.
+stats_prefix() -> bucket_request_payment.
+
+%% @doc Get the list of methods this resource supports.
+% TODO: no PUT support yet
+-spec allowed_methods() -> [atom()].
+allowed_methods() ->
+    ['GET'].
+
+-spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
+content_types_provided(RD, Ctx) ->
+    {[{"application/xml", to_xml}], RD, Ctx}.
+
+-spec authorize(#wm_reqdata{}, #context{}) ->
+                       {boolean() | {halt, non_neg_integer()}, #wm_reqdata{}, #context{}}.
+authorize(RD, Ctx) ->
+    riak_cs_wm_utils:bucket_access_authorize_helper(bucket_request_payment, false, RD, Ctx).
+
+-spec to_xml(#wm_reqdata{}, #context{}) ->
+                    {binary() | {'halt', term()}, #wm_reqdata{}, #context{}}.
+to_xml(RD, Ctx=#context{user=User,bucket=Bucket}) ->
+    StrBucket = binary_to_list(Bucket),
+    case [B || B <- riak_cs_bucket:get_buckets(User),
+               B?RCS_BUCKET.name =:= StrBucket] of
+        [] ->
+            riak_cs_s3_response:api_error(no_such_bucket, RD, Ctx);
+        [_BucketRecord] ->
+            Doc = [{'RequestPaymentConfiguration',
+                    [{xmlns, "http://s3.amazonaws.com/doc/2006-03-01/"}],
+                    [{'Payer', [<<"BucketOwner">>]}]}],
+            {riak_cs_xml:to_xml(Doc), RD, Ctx}
+    end.
+
+


### PR DESCRIPTION
Before this PR,
- GET Bucket Lifecycle returns 403 Access Denied because `lifecycle` is not
  included in subresources definition of Riak CS. 
- GET Bucket RequestPayment returns 404 Not Found because no dispatch rule for it.

In order to response a little more understandable response, this PR changes them as:
- For requestPayment, just reply XML with "BucketOwner" after authn/authz.
- For lifecycle, just reply error XML of "NotImplemented" without anthentication.

---

To be truthful, motivation for these changes were from s3cmd error for `s3cmd info <bucket>` :secret: 
