### PR TITLE
Bugfix: active delete hangup in overwrite by MP

### DIFF
--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -28,16 +28,18 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
-
 -endif.
 
 %% API
 -export([start_link/5,
+         delete/1,
+         sync_delete/1,
          block_deleted/2]).
 
 %% gen_fsm callbacks
 -export([init/1,
          prepare/2,
+         prepare/3,
          deleting/2,
          handle_event/3,
          handle_sync_event/4,
@@ -50,6 +52,7 @@
                 uuid :: binary(),
                 manifest :: lfs_manifest(),
                 riak_client :: riak_client(),
+                caller :: term(),
                 finished_callback :: fun(),
                 %% For GC, Key in GC bucket which this manifest belongs to.
                 %% For active deletion, not used.
@@ -74,6 +77,14 @@ start_link(BagId, Manifest, GCWorkerPid, GCKey, Options) ->
     Args = [BagId, Manifest, GCWorkerPid, GCKey, Options],
     gen_fsm:start_link(?MODULE, Args, []).
 
+%% @doc Let the fsm start deleting
+delete(Pid) ->
+    gen_fsm:send_event(Pid, delete).
+
+%% @doc Let the fsm start deleting and wait for response
+sync_delete(Pid) ->
+    gen_fsm:sync_send_event(Pid, delete).
+
 -spec block_deleted(pid(), {ok, {binary(), integer()}} | {error, binary()}) -> ok.
 block_deleted(Pid, Response) ->
     gen_fsm:send_event(Pid, {block_deleted, Response, self()}).
@@ -97,12 +108,15 @@ init([BagId, {UUID, Manifest}, FinishedCallback, GCKey, Options]) ->
                    finished_callback=FinishedCallback,
                    gc_key=GCKey,
                    cleanup_manifests=CleanupManifests},
-    {ok, prepare, State, 0}.
+    {ok, prepare, State}.
 
 %% @TODO Make sure we avoid any race conditions here
 %% like we had in the other fsms.
-prepare(timeout, State) ->
+prepare(delete, State) ->
     handle_receiving_manifest(State).
+
+prepare(delete, From, State) ->
+    handle_receiving_manifest(State#state{caller=From}).
 
 deleting({block_deleted, {ok, BlockID}, DeleterPid},
          State=#state{deleted_blocks=DeletedBlocks}) ->
@@ -133,7 +147,6 @@ terminate(Reason, _StateName,
                  key=Key,
                  uuid=UUID,
                  riak_client=RcPid,
-                 finished_callback=FinishedCallback,
                  cleanup_manifests=CleanupManifests} = State) ->
     if CleanupManifests ->
             manifest_cleanup(ManifestState, Bucket, Key, UUID, RcPid);
@@ -141,7 +154,7 @@ terminate(Reason, _StateName,
             noop
     end,
     _ = [riak_cs_block_server:stop(P) || P <- AllDeleteWorkers],
-    FinishedCallback(notification_msg(Reason, State)),
+    _ = reply_or_callback(Reason, State),
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
@@ -251,6 +264,11 @@ maybe_delete_blocks(State=#state{bucket=Bucket,
     maybe_delete_blocks(State#state{unacked_deletes=NewUnackedDeletes,
                                     free_deleters=NewFreeDeleters,
                                     delete_blocks_remaining=NewDeleteBlocksRemaining}).
+
+reply_or_callback(Reason, #state{caller=Caller}=State) when Caller =/= undefined ->
+    gen_fsm:reply(Caller, notification_msg(Reason, State));
+reply_or_callback(Reason, #state{finished_callback=Callback}=State) ->
+    Callback(notification_msg(Reason, State)).
 
 -spec notification_msg(term(), state()) -> {pid(),
                                             {ok, {non_neg_integer(), non_neg_integer()}} |

--- a/src/riak_cs_delete_fsm.erl
+++ b/src/riak_cs_delete_fsm.erl
@@ -18,8 +18,8 @@
 %%
 %% ---------------------------------------------------------------------
 
-%% @doc Module to manage storage of objects and files
-
+%% @doc Module to manage deletion process of objects, including
+%%      both manifests and blocks.
 -module(riak_cs_delete_fsm).
 
 -behaviour(gen_fsm).
@@ -73,8 +73,8 @@
 %% ===================================================================
 
 %% @doc Start a `riak_cs_delete_fsm'.
-start_link(BagId, Manifest, GCWorkerPid, GCKey, Options) ->
-    Args = [BagId, Manifest, GCWorkerPid, GCKey, Options],
+start_link(BagId, Manifest, FinishedCallback, GCKey, Options) ->
+    Args = [BagId, Manifest, FinishedCallback, GCKey, Options],
     gen_fsm:start_link(?MODULE, Args, []).
 
 %% @doc Let the fsm start deleting

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -412,39 +412,27 @@ maybe_delete_small_objects(Manifests, RcPid, Threshold) ->
 
 -spec try_delete_blocks(binary(), cs_uuid_and_manifest()) -> ok | {error, term()}.
 try_delete_blocks(BagId, {UUID, _} = UUIDManifest) ->
-    Self = self(),
-    FinishedFun = fun(Msg) -> Self ! Msg end,
-    Args = [BagId, UUIDManifest, FinishedFun,
+    Args = [BagId, UUIDManifest, undefined,
             dummy_gc_key_in_sync_delete,
             [{cleanup_manifests, false}]],
     {ok, Pid} = riak_cs_delete_fsm_sup:start_delete_fsm(node(), Args),
-    Ref = erlang:monitor(process, Pid),
-    receive
+    case riak_cs_delete_fsm:sync_delete(Pid) of
         {Pid, {ok, {_, _, _, TotalBlocks, TotalBlocks}}} ->
-            %% successfully deleted
-            erlang:demonitor(Ref, [flush]),
+            %% all the blocks are successfully deleted
             _ = lager:debug("Active deletion of ~p succeeded", [UUID]),
             ok;
         {Pid, {ok, {_, _, _, NumDeleted, TotalBlocks}}} ->
-            erlang:demonitor(Ref, [flush]),
             _ = lager:debug("Only ~p/~p blocks of ~p deleted",
                             [NumDeleted, TotalBlocks, UUID]),
             {error, partially_deleted};
         {Pid, {error, _} = E} ->
-            erlang:demonitor(Ref, [flush]),
             _ = lager:warning("Active deletion of ~p failed. Reason: ~p",
                               [UUID, E]),
             E;
-        {'DOWN', Ref, _Type, Pid, Reason} ->
-            _ = lager:warning("Delete FSM for ~p crashed. Reason: ~p", [Reason]),
-            {error, Reason};
         Other ->
-            %% Handling unknown error, or died unexpectedly
-            erlang:demonitor(Ref, [flush]),
             _ = lager:error("Active deletion failed. Reason: ~p", [Other]),
             {error, Other}
     end.
-
 
 %% @doc Copy data for a list of manifests to the
 %% `riak-cs-gc' bucket to schedule them for deletion.

--- a/src/riak_cs_gc_worker.erl
+++ b/src/riak_cs_gc_worker.erl
@@ -144,11 +144,7 @@ initiating_file_delete(continue, ?STATE{batch=[CurrentFileSetKey | _],
     Args = [BagId, Manifest,
             fun(Msg) -> gen_fsm:sync_send_event(Self, Msg, infinity) end,
             CurrentFileSetKey, []],
-    %% The delete FSM is hard-coded to send a sync event to our registered
-    %% name upon terminate(), so we do not have to pass our pid to it
-    %% in order to get a reply.
     {ok, Pid} = riak_cs_delete_fsm_sup:start_delete_fsm(node(), Args),
-
     %% Link to the delete fsm, so that if it dies,
     %% we go down too. In the future we might want to do
     %% something more complicated like retry

--- a/src/riak_cs_gc_worker.erl
+++ b/src/riak_cs_gc_worker.erl
@@ -157,6 +157,7 @@ initiating_file_delete(continue, ?STATE{batch=[CurrentFileSetKey | _],
     %% skip an object to GC, we can change the epoch start
     %% time in app.config
     link(Pid),
+    riak_cs_delete_fsm:delete(Pid),
     {next_state, waiting_file_delete, State?STATE{delete_fsm_pid = Pid}};
 initiating_file_delete(_, State) ->
     {next_state, initiating_file_delete, State}.


### PR DESCRIPTION
This PR addresses #1225.

Before this PR, active delete path communicates with delete FSM
with monitor and bare `receive` statement. This PR separates exection
trigger for delete FSM from start_link and introduce two functions for
the trigger, `delete` for async and `sync_delete` for sync.
The change eliminates of monitor handling and bare `receive`.

As a bonus, it decreases race window between
- riak_cs_delete_fsm:start_link and
- link/monitor the process
  because actual work assciated with access to Riak KV
  is defered until `(sync_)delete` call.

Second commit is just a refactoring. Third commit is a little remaining changes for `rtcs*` refactoring of #1222.
