### PR TITLE
Increase request pool size on external client tests [JIRA: RCS-280]

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -33,7 +33,7 @@
 -define(CSDEV(N), list_to_atom(?CSDEVS(N))).
 
 setup(NumNodes) ->
-    setup(NumNodes, rtcs_config:default_configs(), current).
+    setup(NumNodes, [], current).
 
 setup(NumNodes, Configs) ->
     setup(NumNodes, Configs, current).
@@ -44,7 +44,7 @@ setup(NumNodes, Configs, Vsn) ->
     flavored_setup(NumNodes, Flavor, Configs, Vsn).
 
 setup2x2() ->
-    setup2x2(rtcs_config:default_configs()).
+    setup2x2([]).
 
 setup2x2(Configs) ->
     JoinFun = fun(Nodes) ->
@@ -56,7 +56,7 @@ setup2x2(Configs) ->
 
 %% 1 cluster with N nodes + M cluster with 1 node
 setupNxMsingles(N, M) ->
-    setupNxMsingles(N, M, rtcs_config:default_configs(), current).
+    setupNxMsingles(N, M, [], current).
 
 setupNxMsingles(N, M, Configs, Vsn)
   when Vsn =:= current orelse Vsn =:= previous ->
@@ -85,7 +85,7 @@ setup_clusters(Configs, JoinFun, NumNodes, Vsn) ->
     application:set_env(sasl, sasl_error_logger, false),
 
     {RiakNodes, _CSNodes, _Stanchion} = Nodes =
-        deploy_nodes(NumNodes, rtcs_config:configs(Configs), Vsn),
+        deploy_nodes(NumNodes, rtcs_config:configs(Configs, Vsn), Vsn),
     rt:wait_until_nodes_ready(RiakNodes),
     lager:info("Make cluster"),
     JoinFun(RiakNodes),

--- a/riak_test/tests/external_client_tests.erl
+++ b/riak_test/tests/external_client_tests.erl
@@ -13,8 +13,7 @@ confirm() ->
     CsSrcDir = rtcs_dev:srcpath(cs_src_root),
     lager:debug("cs_src_root = ~p", [CsSrcDir]),
 
-    rtcs:set_advanced_conf(cs, cs_config()),
-    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2),
+    {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup(2, [{cs, cs_config()}]),
     ok = erlcloud_s3:create_bucket("external-client-test", UserConfig),
     CsPortStr = integer_to_list(rtcs_config:cs_port(hd(RiakNodes))),
 
@@ -35,7 +34,8 @@ confirm() ->
 
 cs_config() ->
     [{riak_cs,
-      [{enforce_multipart_part_size, false},
+      [{connection_pools, [{request_pool, {32, 0}}]},
+       {enforce_multipart_part_size, false},
        {max_buckets_per_user, 300},
        {auth_v4_enabled, true}
       ]


### PR DESCRIPTION
This PR has 2 changes:
- Improve rtcs:setup/x to merge specified prams into default prams
- Increase request_pool size on external client tests

Sometimes request pool workers of poolboy is exhausted on external_client_tests, then it causes the
test fails, since external_client_tests runs individual client tests concurrently using 'make -j 8'.
So pool size should be increased enough.
I changed rtcs:setup to merge specified params into default configs before Increasing pool size, to do it easily.
