### PR TITLE
Give grace period for `riakc_pb_socket` to reconnect

### DIFF
--- a/src/riak_cs_block_server.erl
+++ b/src/riak_cs_block_server.erl
@@ -294,6 +294,7 @@ try_local_get(RcPid, FullBucket, FullKey, GetOptions1, GetOptions2,
                           Why == disconnected;
                           Why == <<"{insufficient_vnodes,0,need,1}">>;
                           Why == {insufficient_vnodes,0,need,1} ->
+            _ = riak_cs_pbc:pause_to_reconnect(block_pbc(RcPid), Why, Timeout),
             handle_local_notfound(RcPid, FullBucket, FullKey, GetOptions2,
                                   ProceedFun, RetryFun,
                                   [{local_one, Why}|ErrorReasons], UseProxyGet,
@@ -316,6 +317,7 @@ handle_local_notfound(RcPid, FullBucket, FullKey, GetOptions2,
         {error, Why} when Why == disconnected;
                           Why == timeout ->
             _ = lager:debug("get_block_local() failed: {error, ~p}", [Why]),
+            _ = riak_cs_pbc:pause_to_reconnect(block_pbc(RcPid), Why, Timeout),
             RetryFun([{local_quorum, Why}|ErrorReasons]);
 
         {error, notfound} when UseProxyGet andalso ProxyActive->

--- a/src/riak_cs_riak_client.erl
+++ b/src/riak_cs_riak_client.erl
@@ -333,6 +333,8 @@ get_user_with_pbc(MasterPbc, Key, false) ->
         {ok, _} = OK -> OK;
         {error, Reason} ->
             _ = lager:warning("Fetching user record with strong option failed: ~p", [Reason]),
+            Timeout = riak_cs_config:get_user_timeout(),
+            _ = riak_cs_pbc:pause_to_reconnect(MasterPbc, Reason, Timeout),
             weak_get_user_with_pbc(MasterPbc, Key)
     end.
 


### PR DESCRIPTION
This PR addresses #1201 (RCS-250) (RCS-250) .

When `riakc_pb_socket` detects timeout errors, it disconnects the
TCP connection and enters reconnection phase.  Immediate next
request to `riakc_pb_socket` process will likely fail with
infamous `disconnect` errors.

Typical case is described in #1201 (RCS-250) (RCS-250) for user object fetch.
Also, there is another case for block get. If the first
primary vnode for a block is very slow, the reuqest will
timeout because it is `N=one`. Then subsequent `N=all`
request will likely fail.

This PR fixes these two cases by adding grace period so that
`riakc_pb_socket` can reconnect if possible.
