### PR TITLE
Suppress noisy logs  [JIRA: RCS-281]

### DIFF
--- a/src/riak_cs_access_log_handler.erl
+++ b/src/riak_cs_access_log_handler.erl
@@ -182,9 +182,13 @@ handle_call(_Request, State) ->
     {ok, ok, State}.
 
 %% @private
+handle_event({log_access, #wm_log_data{notes=undefined,
+                                       method=Method, path=Path, headers=Headers}},
+             State) ->
+    lager:debug("No WM route: ~p ~s ~p\n", [Method, Path, Headers]),
+    {ok, State};
 handle_event({log_access, LogData},
              #state{table=T, size=S, max_size=MaxS}=State) ->
-
     %% Updates for quotas
     case lists:keyfind(?STAT(user), 1, LogData#wm_log_data.notes) of
         {?STAT(user), Key} ->
@@ -297,10 +301,6 @@ do_archive(#state{period=P, table=T, current=C}=State) ->
 -spec access_record(#wm_log_data{})
          -> {ok, {iodata(), {binary(), list()}}}
           | ignore.
-access_record(#wm_log_data{notes=undefined,
-                           method=Method,path=Path,headers=Headers}=_X) ->
-    error_logger:error_msg("No WM route: ~p ~s ~p\n", [Method, Path, Headers]),
-    ignore;
 access_record(#wm_log_data{notes=Notes}=Log) ->
     case lists:keyfind(?STAT(user), 1, Notes) of
         {?STAT(user), Key} ->

--- a/src/riak_cs_riak_client.erl
+++ b/src/riak_cs_riak_client.erl
@@ -331,6 +331,8 @@ get_user_with_pbc(MasterPbc, Key, true) ->
 get_user_with_pbc(MasterPbc, Key, false) ->
     case strong_get_user_with_pbc(MasterPbc, Key) of
         {ok, _} = OK -> OK;
+        {error, <<"{pr_val_unsatisfied,", _/binary>>} ->
+            weak_get_user_with_pbc(MasterPbc, Key);
         {error, Reason} ->
             _ = lager:warning("Fetching user record with strong option failed: ~p", [Reason]),
             weak_get_user_with_pbc(MasterPbc, Key)


### PR DESCRIPTION
This PR consists of two independent commits.
### commit 8960fe2386b3dd9e1de47b0e95f89650eea1f0f1

This commit Suppresses warning log of unsatisfied PR in strong user get.
It is noisy because single node down should be considered as normal state
and neither direct client effects (weak user get will follow) nor operator
action needed.

To reproduce, setup multiple node cluster and stop one of the nodes.
Almost any request to riak cs let warning log like :

```
18:01:37.070 [warning] Fetching user record with strong option failed:
  <<"{pr_val_unsatisfied,3,2}">>
```
### commit f95acf0d14fe2ebee3d90cf3a774c0f9472147db

This filters out undefined log data notes at the beginning of handle_event.
It is a fix of bug of 2.1 development cycle (#1130).

Following log is an example which is output when GET `?torrent` is called.

```
12:15:29.888 [error] gen_event riak_cs_access_log_handler installed in
  webmachine_log_event terminated with reason: bad argument in call to
  lists:keyfind({access,user}, 1, undefined) in
  riak_cs_access_log_handler:handle_event/2 line 189
```

The fix revives log of "No WM route" that have been exists prior 2.1.
This commit also changes its log severity from error to debug
because the error indicates client error except in development
phase.  Just responding 4xx is sufficient.
