### PR TITLE
Bugfix/gc status race

### DIFF
--- a/riak_test/src/cs_suites.erl
+++ b/riak_test/src/cs_suites.erl
@@ -250,10 +250,7 @@ apply_operation(gc, Circle, #state{cs_nodes=[CSNode|_]} = State) ->
                    ExpectSubstr = "There is no garbage collection in progress",
                    case string:str(Res, ExpectSubstr) of
                        0 ->
-                           {match, Captured} =
-                               re:run(Res, "Elapsed time of current run: [0-9]*\n",
-                                      [{capture, first, binary}]),
-                           lager:debug("riak-cs-gc status: ~s", [Captured]),
+                           lager:debug("riak-cs-gc status: ~s", [Res]),
                            false;
                        _ ->
                            lager:debug("GC completed"),

--- a/src/riak_cs_gc.erl
+++ b/src/riak_cs_gc.erl
@@ -273,7 +273,7 @@ gc_max_workers() ->
     end.
 
 %% @doc Return the start of GC epoch represented as a binary.
-%% This is the time that the GC daemon uses to  begin collecting keys
+%% This is the time that the GC manager uses to  begin collecting keys
 %% from the `riak-cs-gc' bucket.
 -spec epoch_start() -> non_neg_integer().
 epoch_start() ->

--- a/src/riak_cs_gc_batch.erl
+++ b/src/riak_cs_gc_batch.erl
@@ -72,7 +72,7 @@ start_link(Options) ->
 current_state(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, current_state, infinity).
 
-%% @doc Stop the daemon
+%% @doc Stop the process
 -spec stop(pid()) -> ok | {error, term()}.
 stop(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, stop, infinity).

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -57,7 +57,7 @@
 batch(Opts) ->
     ?SAFELY(start_batch(parse_batch_opts(Opts)), "Starting garbage collection batch").
 
-%% @doc Find out what the gc daemon is up to.
+%% @doc Find out what the gc manager is up to.
 status(_Opts) ->
     ?SAFELY(get_status(), "Checking garbage collection status").
 
@@ -153,7 +153,7 @@ handle_batch_start(ok) ->
     output("Garbage collection batch started."),
     ok;
 handle_batch_start({error, running}) ->
-    output("The garbage collection daemon is already running."),
+    output("The garbage collection batch is already running."),
     error.
 
 handle_status({ok, {State, Details}}) ->
@@ -178,7 +178,7 @@ print_state(running) ->
 print_state(finishing) ->
     output("A garbage collection batch is finishing").
 
-%% @doc Pretty-print the status returned from the gc daemon.
+%% @doc Pretty-print the status returned from the gc manager.
 print_details(finishing, _Details) ->
     ok;
 print_details(_, Details) ->

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -158,7 +158,7 @@ handle_batch_start({error, running}) ->
 
 handle_status({ok, {State, Details}}) ->
     _ = print_state(State),
-    _ = print_details(Details),
+    _ = print_details(State, Details),
     ok.
 
 handle_batch_cancellation(ok) ->
@@ -174,10 +174,14 @@ output(Output) ->
 print_state(idle) ->
     output("There is no garbage collection in progress");
 print_state(running) ->
-    output("A garbage collection batch is in progress").
+    output("A garbage collection batch is in progress");
+print_state(finishing) ->
+    output("A garbage collection batch is finishing").
 
 %% @doc Pretty-print the status returned from the gc daemon.
-print_details(Details) ->
+print_details(finishing, _Details) ->
+    ok;
+print_details(_, Details) ->
     [ begin
           {HumanName, HumanValue} = human_detail(K, V),
           io:format("  ~s: ~s~n", [HumanName, HumanValue])

--- a/src/riak_cs_gc_key_list.erl
+++ b/src/riak_cs_gc_key_list.erl
@@ -18,7 +18,7 @@
 %%
 %% ---------------------------------------------------------------------
 
-%% @doc Key listing logic for GC daemon.
+%% @doc Key listing logic for GC batch.
 
 -module(riak_cs_gc_key_list).
 

--- a/src/riak_cs_gc_worker.erl
+++ b/src/riak_cs_gc_worker.erl
@@ -20,7 +20,7 @@
 
 %% @doc A worker module that handles garbage collection of deleted
 %% file manifests and blocks at the direction of the garbace
-%% collection daemon.
+%% collection manager.
 
 -module(riak_cs_gc_worker).
 
@@ -63,7 +63,7 @@
 start_link(BagId, Keys) ->
     gen_fsm:start_link(?MODULE, [BagId, Keys], []).
 
-%% @doc Stop the daemon
+%% @doc Stop the process
 -spec stop(pid()) -> ok | {error, term()}.
 stop(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, stop, infinity).


### PR DESCRIPTION
Addresses #1229 (RCS-273)

Before this PR, there are two race conditions:
1. Manager's state (idle or running) and detailed information from a batch process.
   It's possible that the command says "A garbage collection batch is
   in progress" but less detailed information
2. riak_cs_gc_batch may had been dead at riak_cs_gc_batch:current_state(Pid).

Introduced 'finishing' state for command output (not an actual state of certan
fsm). Just output "finishing" but no details for it in command line.
Also added try/catch to riak_cs_gc_batch:current_state() call

The first commit is the actual fix and second one is just for cosmetics.
