### PR TITLE
Return 'ok' from riak_cs_console:status/1

### DIFF
--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -38,7 +38,7 @@
 status([]) ->
     Stats = riak_cs_stats:get_stats(),
     _ = [io:format("~p : ~p~n", [Name, Value])
-     || {Name, Value} <- Stats],
+         || {Name, Value} <- Stats],
     ok.
 
 %% in progress.
@@ -58,8 +58,7 @@ cluster_info([OutFile]) ->
         error:{badmatch, {error, enotdir}} ->
             io:format("Cluster_info failed, not a directory ~p~n", [filename:dirname(OutFile)]);
         Exception:Reason ->
-            lager:error("Cluster_info failed ~p:~p",
-                [Exception, Reason]),
+            lager:error("Cluster_info failed ~p:~p", [Exception, Reason]),
             io:format("Cluster_info failed, see log for details~n"),
             error
     end.

--- a/src/riak_cs_console.erl
+++ b/src/riak_cs_console.erl
@@ -37,8 +37,9 @@
 
 status([]) ->
     Stats = riak_cs_stats:get_stats(),
-    [io:format("~p : ~p~n", [Name, Value])
-     || {Name, Value} <- Stats].
+    _ = [io:format("~p : ~p~n", [Name, Value])
+     || {Name, Value} <- Stats],
+    ok.
 
 %% in progress.
 cluster_info([OutFile]) ->


### PR DESCRIPTION
riak-cs-admin status always returns 1 since riak_cs_console:status/1 return list of 'ok' even though [nodetool expects 'ok' as success of RPC call](https://github.com/basho/node_package/blob/2.0.3/priv/base/nodetool#L81-L92).
