### PR TITLE
Fix failing EQC test on GC manager [JIRA: RCS-285]

### DIFF
--- a/test/riak_cs_gc_manager_eqc.erl
+++ b/test/riak_cs_gc_manager_eqc.erl
@@ -93,9 +93,9 @@ prop_set_interval() ->
                 ok = application:set_env(riak_cs, initial_gc_delay, 0),
                 {ok, Pid} = riak_cs_gc_manager:test_link(),
                 try
-                    {ok, {_, State1}} = riak_cs_gc_manager:status(),
+                    {ok, {_, _, State1}} = riak_cs_gc_manager:status(),
                     ok = riak_cs_gc_manager:set_interval(Interval),
-                    {ok, {_, State2}} = riak_cs_gc_manager:status(),
+                    {ok, {_, _, State2}} = riak_cs_gc_manager:status(),
                     conjunction([{initial_interval,
                                   equals(?DEFAULT_GC_INTERVAL, State1#gc_manager_state.interval)},
                                  {updated_interval,
@@ -161,7 +161,7 @@ precondition(_From, _To, _S, _C) ->
     true.
 
 postcondition(From, To, S , {call, _M, ManualCommad, _A}=C, R) ->
-    {ok, {Actual, _}} = riak_cs_gc_manager:status(),
+    {ok, {Actual, _, _}} = riak_cs_gc_manager:status(),
     ?assertEqual(To, Actual),
     ExpectedRes = expected_result(From, To, ManualCommad),
     case R of


### PR DESCRIPTION
Test code update that amends code change at #1234 . 

```
ok /= {postcondition,
          {'EXIT',
              {{badmatch,
                   {ok,{idle,not_running,
                           {gc_manager_state,undefined,undefined,[],
                               undefined,infinity,undefined,undefined}}}},
               [{riak_cs_gc_manager_eqc,postcondition,5,
                    [{file,"test/riak_cs_gc_manager_eqc.erl"},{line,164}]},
                {eqc_statem,run_commands,2,
                    [{file,"../src/eqc_statem.erl"},{line,737}]},
                {eqc_fsm,run_commands,2,
                    [{file,"../src/eqc_fsm.erl"},{line,658}]},
                {riak_cs_gc_manager_eqc,'-prop_manual_commands/0-fun-2-',1,
                    [{file,"test/riak_cs_gc_manager_eqc.erl"},{line,115}]}]}}}
riak_cs_gc_manager_eqc:81: eqc_test_...*failed*
in function riak_cs_gc_manager_eqc:'-eqc_test_/0-fun-8-'/1 (test/riak_cs_gc_manager_eqc.erl, line 81)
**error:{assertEqual_failed,[{module,riak_cs_gc_manager_eqc},
                     {line,81},
                     {expression,"eqc : quickcheck ( eqc : testing_time ( 30 , ? QC_OUT ( prop_manual_commands ( ) ) ) )"},
                     {expected,true},
                     {value,false}]}
```
