### PR TITLE
OTP 17 compatibility

### DIFF
--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -518,3 +518,11 @@
 -define(BLOCK_BUCKET_PREFIX, <<"0b:">>).        % Version # = 0
 
 -define(MAX_S3_KEY_LENGTH, 1024).
+
+-ifdef(namespaced_types).
+-type mochiweb_headers() :: gb_trees:tree().
+-type robj_md() :: dict:dict().
+-else.
+-type mochiweb_headers() :: gb_tree().
+-type robj_md() :: dict().
+-endif.

--- a/include/riak_cs.hrl
+++ b/include/riak_cs.hrl
@@ -521,8 +521,6 @@
 
 -ifdef(namespaced_types).
 -type mochiweb_headers() :: gb_trees:tree().
--type robj_md() :: dict:dict().
 -else.
 -type mochiweb_headers() :: gb_tree().
--type robj_md() :: dict().
 -endif.

--- a/rebar.config
+++ b/rebar.config
@@ -37,13 +37,13 @@
 ]}.
 
 {deps, [
+        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.0"}}},
+        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.4"}}},
         {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.3"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.1"}}},
-        {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.1.1"}}},
-        {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {eper, ".*", {git, "git://github.com/basho/eper.git", "0.92-basho1"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
         {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p3"}},

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {sub_dirs, ["rel"]}.
 
-{require_otp_vsn, "R16"}.
+{require_otp_vsn, "R16|17"}.
 
 {cover_enabled, false}.
 
@@ -9,7 +9,10 @@
 
 {lib_dirs, ["deps", "apps"]}.
 
-{erl_opts, [debug_info, warnings_as_errors, {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info,
+            warnings_as_errors,
+            {parse_transform, lager_transform},
+            {platform_define, "^[0-9]+", namespaced_types}]}.
 
 {xref_checks, []}.
 {xref_queries,
@@ -46,7 +49,7 @@
         {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p3"}},
         {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.3"}}},
-        {xmerl, ".*", {git, "git://github.com/shino/xmerl", "b35bcb05abaf27f183cfc3d85d8bffdde0f59325"}},
+        {xmerl, ".*", {git, "git://github.com/shino/xmerl", "1b016a05473e086abadbb3c12f63d167fe96c00f"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.5"}}},
         {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "3.1.0"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -56,5 +56,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.1.1"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0-pre5"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0-pre6"}}}
           ]}.

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -243,7 +243,6 @@ set_advanced_conf(DevPath, NameValuePairs) ->
     [rtcs_dev:update_app_config_file(RiakConf, NameValuePairs) || RiakConf <- AdvancedConfs],
     ok.
 
-
 assert_error_log_empty(N) ->
     assert_error_log_empty(current, N).
 

--- a/riak_test/tests/user_test.erl
+++ b/riak_test/tests/user_test.erl
@@ -66,8 +66,8 @@ japanese_aiueo() ->
 
 create_200_users(Port) ->
     From = self(),
-    Processes = 10,
-    PerProcess = 20,
+    Processes = 5,
+    PerProcess = 40,
     [spawn(fun() ->
                    Users = create_users(
                              Port,

--- a/src/riak_cs_get_fsm.erl
+++ b/src/riak_cs_get_fsm.erl
@@ -67,6 +67,12 @@
 
 -type block_name() :: {binary(), integer()}.
 
+-ifdef(namespaced_types).
+-type block_queue() :: queue:queue().
+-else.
+-type block_queue() :: queue().
+-endif.
+
 -record(state, {from :: {pid(), reference()},
                 riak_client :: riak_client(),
                 mani_fsm_pid :: pid(),
@@ -78,7 +84,7 @@
                 got_blocks=orddict:new() :: orddict:orddict(),
                 manifest :: term(),
                 blocks_order :: [block_name()],
-                blocks_intransit=queue:new() :: queue(),
+                blocks_intransit=queue:new() :: block_queue(),
                 test=false :: boolean(),
                 total_blocks :: pos_integer(),
                 num_sent=0 :: non_neg_integer(),

--- a/src/riak_cs_list_objects_ets_cache.erl
+++ b/src/riak_cs_list_objects_ets_cache.erl
@@ -52,9 +52,15 @@
 
 -define(DICTMODULE, dict).
 
+-ifdef(namespaced_types).
+-type dictionary() :: dict:dict().
+-else.
+-type dictionary() :: dict().
+-endif.
+
 -record(state, {tid :: ets:tid(),
-                monitor_to_timer = ?DICTMODULE:new() :: ?DICTMODULE(),
-                key_to_monitor = ?DICTMODULE:new() :: ?DICTMODULE()}).
+                monitor_to_timer = ?DICTMODULE:new() :: dictionary(),
+                key_to_monitor = ?DICTMODULE:new() :: dictionary()}).
 
 -type state() :: #state{}.
 -type cache_lookup_result() :: {true, [binary()]} | false.
@@ -257,7 +263,7 @@ handle_down(MonitorRef, State=#state{monitor_to_timer=MonToTimer}) ->
     NewMonToTimer = remove_timer(MonitorRef, MonToTimer),
     State#state{monitor_to_timer=NewMonToTimer}.
 
--spec remove_monitor(binary(), ?DICTMODULE()) -> ?DICTMODULE().
+-spec remove_monitor(binary(), dictionary()) -> dictionary().
 remove_monitor(ExpiredKey, KeyToMon) ->
     RefResult = safe_fetch(ExpiredKey, KeyToMon),
     case RefResult of
@@ -268,7 +274,7 @@ remove_monitor(ExpiredKey, KeyToMon) ->
     end,
     ?DICTMODULE:erase(ExpiredKey, KeyToMon).
 
--spec remove_timer(reference(), ?DICTMODULE()) -> ?DICTMODULE().
+-spec remove_timer(reference(), dictionary()) -> dictionary().
 remove_timer(MonitorRef, MonToTimer) ->
     RefResult = safe_fetch(MonitorRef, MonToTimer),
     _ = case RefResult of
@@ -281,7 +287,7 @@ remove_timer(MonitorRef, MonToTimer) ->
     end,
     ?DICTMODULE:erase(MonitorRef, MonToTimer).
 
--spec safe_fetch(Key :: term(), Dict :: ?DICTMODULE()) ->
+-spec safe_fetch(Key :: term(), Dict :: dictionary()) ->
     {ok, term()} | {error, term()}.
 safe_fetch(Key, Dict) ->
     try

--- a/src/riak_cs_oos_rewrite.erl
+++ b/src/riak_cs_oos_rewrite.erl
@@ -34,8 +34,8 @@
 -endif.
 
 %% @doc Function to rewrite headers prior to processing by webmachine.
--spec rewrite(atom(), atom(), {integer(), integer()}, gb_tree(), string()) ->
-                     {gb_tree(), string()}.
+-spec rewrite(atom(), atom(), {integer(), integer()}, mochiweb_headers(), string()) ->
+                     {mochiweb_headers(), string()}.
 rewrite(Method, _Scheme, _Vsn, Headers, RawPath) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"rewrite">>),
     {Path, QueryString, _} = mochiweb_util:urlsplit_path(RawPath),
@@ -63,7 +63,7 @@ parse_path(Path) ->
     {ApiVsn, Account, "/" ++ string:join(RestPath, "/")}.
 
 %% @doc Add headers for the raw path, the API version, and the account.
--spec rewrite_headers(gb_tree(), string(), string(), string()) -> gb_tree().
+-spec rewrite_headers(mochiweb_headers(), string(), string(), string()) -> mochiweb_headers().
 rewrite_headers(Headers, RawPath, ApiVsn, Account) ->
     UpdHdrs0 = mochiweb_headers:default(?RCS_REWRITE_HEADER, RawPath, Headers),
     UpdHdrs1 = mochiweb_headers:enter(?OOS_API_VSN_HEADER, ApiVsn, UpdHdrs0),

--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -61,8 +61,8 @@
 -type subresources() :: [subresource()].
 
 %% @doc Function to rewrite headers prior to processing by webmachine.
--spec rewrite(atom(), atom(), {integer(), integer()}, gb_tree(), string()) ->
-                     {gb_tree(), string()}.
+-spec rewrite(atom(), atom(), {integer(), integer()}, mochiweb_headers(), string()) ->
+                     {mochiweb_headers(), string()}.
 rewrite(Method, _Scheme, _Vsn, Headers, Url) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"rewrite">>),
     {Path, QueryString, _} = mochiweb_util:urlsplit_path(Url),
@@ -86,8 +86,8 @@ raw_url(RD) ->
             {Path, mochiweb_util:parse_qs(QS)}
     end.
 
--spec rewrite_path_and_headers(atom(), gb_tree(), string(), string(), string()) ->
-                    {gb_tree(), string()}.
+-spec rewrite_path_and_headers(atom(), mochiweb_headers(), string(), string(), string()) ->
+                    {mochiweb_headers(), string()}.
 rewrite_path_and_headers(Method, Headers, Url, Path, QueryString) ->
     Host = mochiweb_headers:get_value("host", Headers),
     HostBucket = bucket_from_host(Host),

--- a/src/riak_cs_s3_rewrite_legacy.erl
+++ b/src/riak_cs_s3_rewrite_legacy.erl
@@ -22,9 +22,11 @@
 
 -export([rewrite/5]).
 
+-include("riak_cs.hrl").
+
 %% @doc Function to rewrite headers prior to processing by webmachine.
--spec rewrite(atom(), atom(), {integer(), integer()}, gb_tree(), string()) ->
-                     {gb_tree(), string()}.
+-spec rewrite(atom(), atom(), {integer(), integer()}, mochiweb_headers(), string()) ->
+                     {mochiweb_headers(), string()}.
 rewrite(Method, _Scheme, _Vsn, Headers, Url) ->
     riak_cs_dtrace:dt_wm_entry(?MODULE, <<"rewrite">>),
     %% Unquote the path to accomodate some naughty client libs (looking

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -258,7 +258,7 @@ handle_active_manifests({error, no_active_manifest}) ->
     {error, notfound}.
 
 %% @doc Determine if a set of contents of a riak object has a tombstone.
--spec has_tombstone({robj_md(), binary()}) -> boolean().
+-spec has_tombstone({riakc_obj:metadata(), binary()}) -> boolean().
 has_tombstone({_, <<>>}) ->
     true;
 has_tombstone({MD, _V}) ->

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -258,7 +258,7 @@ handle_active_manifests({error, no_active_manifest}) ->
     {error, notfound}.
 
 %% @doc Determine if a set of contents of a riak object has a tombstone.
--spec has_tombstone({dict(), binary()}) -> boolean().
+-spec has_tombstone({robj_md(), binary()}) -> boolean().
 has_tombstone({_, <<>>}) ->
     true;
 has_tombstone({MD, _V}) ->

--- a/src/twop_set.erl
+++ b/src/twop_set.erl
@@ -53,7 +53,13 @@
          resolve/1
         ]).
 
--type twop_set() :: {set(), set()}.
+-ifdef(namespaced_types).
+-type stdlib_set() :: sets:set().
+-else.
+-type stdlib_set() :: set().
+-endif.
+
+-type twop_set() :: {stdlib_set(), stdlib_set()}.
 -export_type([twop_set/0]).
 
 %%%===================================================================
@@ -140,11 +146,11 @@ resolution_test() ->
 %%% Test API
 %%%===================================================================
 
--spec adds(twop_set()) -> set().
+-spec adds(twop_set()) -> stdlib_set().
 adds({Adds, _}) ->
     Adds.
 
--spec dels(twop_set()) -> set().
+-spec dels(twop_set()) -> stdlib_set().
 dels({_, Dels}) ->
     Dels.
 

--- a/test/twop_set_eqc.erl
+++ b/test/twop_set_eqc.erl
@@ -52,8 +52,14 @@
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).
 
--record(eqc_state, {adds=sets:new() :: set(),
-                    deletes=sets:new() :: set(),
+-ifdef(namespaced_types).
+-type stdlib_set() :: sets:set().
+-else.
+-type stdlib_set() :: set().
+-endif.
+
+-record(eqc_state, {adds=sets:new() :: stdlib_set(),
+                    deletes=sets:new() :: stdlib_set(),
                     operation_count=0 :: non_neg_integer(),
                     operation_limit=500 :: pos_integer(),
                     set :: twop_set:twop_set(),
@@ -66,8 +72,8 @@
 eqc_test_() ->
     {spawn,
         [
-            {timeout, 20, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_twop_set_api()))))},
-            {timeout, 20, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_twop_set_resolution()))))}
+            {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_twop_set_api()))))},
+            {timeout, 60, ?_assertEqual(true, quickcheck(numtests(?TEST_ITERATIONS, ?QC_OUT(prop_twop_set_resolution()))))}
         ]
     }.
 


### PR DESCRIPTION
This PR adds OTP 17 compatibility.
- depends on https://github.com/basho/riak_cs_multibag/pull/30.
- includes changes of https://github.com/shino/xmerl/pull/3 which has been merged.

Tested with
- Erlang/OTP R16B02 basho patch 5 (a little old)
- Erlang/OTP 17.4 (EQC version 1.33.2 is used)

---

Note:

In 17.4, `os:cmd/*` treats input as a list of unicode code points and
it outputs results in a list of unicode code points too.
To avoid this, user administration interface in `rtcs*` is changed
to use erlcloud instead of `curl` (and fight with IO/unicode/etc.)
