### PR TITLE
Fix not updating Content-Type on replacing source metadata by Put Copy

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -50,7 +50,7 @@
         {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.3"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "1b016a05473e086abadbb3c12f63d167fe96c00f"}},
-        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.5"}}},
+        {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.6"}}},
         {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {tag, "3.1.0"}}}
        ]}.
 

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -297,9 +297,9 @@ accept_body(RD, Ctx=#context{riak_client=RcPid,
     #key_context{bucket=Bucket, key=KeyStr, manifest=Mfst} = LocalCtx,
     Acl = Mfst?MANIFEST.acl,
     NewAcl = Acl?ACL{creation_time = now()},
-    Metadata = riak_cs_wm_utils:extract_user_metadata(RD),
+    {ContentType, Metadata} = riak_cs_copy_object:new_metadata(Mfst, RD),
     case riak_cs_utils:set_object_acl(Bucket, list_to_binary(KeyStr),
-                                      Mfst?MANIFEST{metadata=Metadata}, NewAcl,
+                                      Mfst?MANIFEST{metadata=Metadata, content_type=ContentType}, NewAcl,
                                       RcPid) of
         ok ->
             ETag = riak_cs_manifest:etag(Mfst),


### PR DESCRIPTION
It's not supported that a user replaces Content-Type of a source obj on Put Copy with `metadata-directive: REPLACE`. This PR fixes it.

To run riak_test, https://github.com/basho/erlcloud/pull/15 is needed.
