### PR TITLE
Fix false state transition riak_cs_gc_batch to waiting_workers without any more tasks [RCS-291]

### DIFF
--- a/src/riak_cs_gc_batch.erl
+++ b/src/riak_cs_gc_batch.erl
@@ -147,14 +147,12 @@ waiting_for_workers(_Msg, _From, State) ->
 
 %% @doc there are no all-state events for this fsm
 handle_event({batch_complete, WorkerPid, WorkerState}, StateName, State0) ->
-    %%?debugFmt("~w", [State0]),%% WorkerState#gc_worker_state.batch_count,
-    State = handle_batch_complete(WorkerPid, WorkerState, State0),
-    %%?debugFmt("StateName ~p, ~p ~w", [StateName, has_batch_finished(State), State]),
-    case {has_batch_finished(State), StateName} of
+    State1 = handle_batch_complete(WorkerPid, WorkerState, State0),
+    State2 = maybe_start_workers(State1),
+    case {has_batch_finished(State2), StateName} of
         {true, _} ->
-            {stop, normal, State};
+            {stop, normal, State2};
         {false, waiting_for_workers} ->
-            State2 = maybe_start_workers(State),
             {next_state, waiting_for_workers, State2}
     end;
 handle_event(_Event, StateName, State) ->


### PR DESCRIPTION
Before this commit, batch completion is verified _before_
maybe_start_workers call and maybe_start_workers always
make transitions to waiting_workers state.
When the count of gc keys is just multiple of gc_batch_size,
continuation indicates there (maybe) more results but
no more tasks actually. The riak_cs_gc_batch process is in
waiting_workers but no workers who triggers event transition.

This commit only changes the order of maybe_start_workers and
has_batch_finished.

---

Steps to reproduce:
1. Set gc.batch_size and gc.max_workers to 1
2. Put one object to riak cs and delete it, wait 1 sec.
3. Execute `riak-cs-admin gc batch 1` and wait.
4. GC does not finish at least several minutes.
