### PR TITLE
test/gh1247 [RCS-292]

### DIFF
--- a/include/riak_cs_gc.hrl
+++ b/include/riak_cs_gc.hrl
@@ -25,6 +25,9 @@
 %% The name is general so declare local type for readability.
 -type index_result_keys() :: keys().
 
+-define(DEFAULT_GC_BATCH_SIZE, 1000).
+-define(DEFAULT_GC_WORKERS, 2).
+
 -record(gc_batch_state, {
           %% start of the current gc batch
           batch_start :: undefined | non_neg_integer(),
@@ -40,8 +43,8 @@
           block_count=0 :: non_neg_integer(),
           leeway :: non_neg_integer(),
           worker_pids=[] :: [pid()],
-          max_workers=1 :: pos_integer(),
-          batch_size=1 :: pos_integer(),
+          max_workers=?DEFAULT_GC_WORKERS :: pos_integer(),
+          batch_size=?DEFAULT_GC_BATCH_SIZE :: pos_integer(),
           %% Used for paginated 2I querying of GC bucket
           key_list_state :: undefined | gc_key_list_state(),
           %% Options to use when start workers
@@ -73,7 +76,7 @@
           %% start of the current gc interval
           start_key :: binary(),
           end_key :: binary(),
-          batch_size=1 :: pos_integer(),
+          batch_size=?DEFAULT_GC_BATCH_SIZE :: pos_integer(),
           %% Used for paginated 2I querying of GC bucket
           continuation :: continuation()
          }).
@@ -93,8 +96,6 @@
 -define(DEFAULT_GC_INTERVAL, 900). %% 15 minutes
 -define(DEFAULT_GC_RETRY_INTERVAL, 21600). %% 6 hours
 -define(DEFAULT_GC_KEY_SUFFIX_MAX, 256).
--define(DEFAULT_GC_BATCH_SIZE, 1000).
--define(DEFAULT_GC_WORKERS, 2).
 -define(EPOCH_START, <<"0">>).
 -define(DEFAULT_MAX_SCHEDULED_DELETE_MANIFESTS, 50).
 

--- a/include/riak_cs_gc.hrl
+++ b/include/riak_cs_gc.hrl
@@ -40,7 +40,8 @@
           block_count=0 :: non_neg_integer(),
           leeway :: non_neg_integer(),
           worker_pids=[] :: [pid()],
-          max_workers :: non_neg_integer(),
+          max_workers=1 :: pos_integer(),
+          batch_size=1 :: pos_integer(),
           %% Used for paginated 2I querying of GC bucket
           key_list_state :: undefined | gc_key_list_state(),
           %% Options to use when start workers
@@ -72,6 +73,7 @@
           %% start of the current gc interval
           start_key :: binary(),
           end_key :: binary(),
+          batch_size=1 :: pos_integer(),
           %% Used for paginated 2I querying of GC bucket
           continuation :: continuation()
          }).

--- a/src/riak_cs_gc_batch.erl
+++ b/src/riak_cs_gc_batch.erl
@@ -102,7 +102,7 @@ init([#gc_batch_state{
             %% EndKey <= BatchStart - Leeway
             _ = lager:info("Starting garbage collection: "
                            "(start, end) = (~p, ~p), "
-                           "leeway=~p, batch_start=~p, max_workers=~p, batch_size=~p",
+                           "leeway=~p, batch_start=~p, max_workers=~p, page-size=~p",
                            [StartKey, EndKey, Leeway, BatchStart, MaxWorkers, BatchSize]),
             {ok, prepare, State, 0};
         DefaultEndKey ->

--- a/src/riak_cs_gc_batch.erl
+++ b/src/riak_cs_gc_batch.erl
@@ -88,7 +88,8 @@ init([#gc_batch_state{
          start_key=StartKey,
          end_key=EndKey,
          leeway=Leeway,
-         max_workers=MaxWorkers} = State])
+         max_workers=MaxWorkers,
+         batch_size=BatchSize} = State])
   when
       %% StartKey can be negative as <<"-">> is smaller than any numeric digits
       0 =< StartKey andalso
@@ -101,8 +102,8 @@ init([#gc_batch_state{
             %% EndKey <= BatchStart - Leeway
             _ = lager:info("Starting garbage collection: "
                            "(start, end) = (~p, ~p), "
-                           "leeway=~p, batch_start=~p, max_workers=~p",
-                           [StartKey, EndKey, Leeway, BatchStart, MaxWorkers]),
+                           "leeway=~p, batch_start=~p, max_workers=~p, batch_size=~p",
+                           [StartKey, EndKey, Leeway, BatchStart, MaxWorkers, BatchSize]),
             {ok, prepare, State, 0};
         DefaultEndKey ->
             _ = lager:error("GC did not start: "
@@ -215,7 +216,8 @@ has_batch_finished(_) ->
 fetch_first_keys(?STATE{batch_start=_BatchStart,
                         start_key=StartKey,
                         end_key=EndKey,
-                        leeway=_Leeway} = State) ->
+                        leeway=_Leeway,
+                        batch_size=BatchSize} = State) ->
 
     %% [Fetch the first set of manifests for deletion]
     %% this does not check out a worker from the riak connection pool;
@@ -226,7 +228,7 @@ fetch_first_keys(?STATE{batch_start=_BatchStart,
     %% connection, and avoids duplicating the configuration lookup
     %% code.
     {KeyListRes, KeyListState} =
-        riak_cs_gc_key_list:new(StartKey, EndKey),
+        riak_cs_gc_key_list:new(StartKey, EndKey, BatchSize),
     #gc_key_list_result{bag_id=BagId, batch=Batch} = KeyListRes,
     _ = lager:debug("Initial batch keys: ~p", [Batch]),
     State?STATE{batch=Batch,

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -249,7 +249,8 @@ batch_options() ->
       "Start time (iso8601 format, like 20130320T094500Z)"},
      {'end',  $e, "end",    string,
       "End time (iso8601 format, like 20130420T094500Z)"},
-     {'max-workers', $c, "max-workers", integer, "Number of concurrent workers"}].
+     {'max-workers', $c, "max-workers", integer, "Number of concurrent workers"},
+     {'batch-size', $b, "batch-size", integer, "Unit size of each retrieval in a batch"}].
 
 convert(Options) ->
     lists:map(fun({leeway, Leeway}) when Leeway >= 0 ->
@@ -260,6 +261,8 @@ convert(Options) ->
                       {'end', iso8601_to_epoch(End)};
                  ({'max-workers', Concurrency}) when Concurrency > 0 ->
                       {'max-workers', Concurrency};
+                 ({'batch-size', BatchSize}) when BatchSize > 0 ->
+                      {batch_size, BatchSize};
                  (BadArg) ->
                       error({bad_arg, BadArg})
               end, Options).

--- a/src/riak_cs_gc_console.erl
+++ b/src/riak_cs_gc_console.erl
@@ -250,7 +250,8 @@ batch_options() ->
      {'end',  $e, "end",    string,
       "End time (iso8601 format, like 20130420T094500Z)"},
      {'max-workers', $c, "max-workers", integer, "Number of concurrent workers"},
-     {'batch-size', $b, "batch-size", integer, "Unit size of each retrieval in a batch"}].
+     {'page-size', $p, "page-size", integer,
+      "Unit size of each GC bucket pagination in a batch"}].
 
 convert(Options) ->
     lists:map(fun({leeway, Leeway}) when Leeway >= 0 ->
@@ -261,7 +262,12 @@ convert(Options) ->
                       {'end', iso8601_to_epoch(End)};
                  ({'max-workers', Concurrency}) when Concurrency > 0 ->
                       {'max-workers', Concurrency};
-                 ({'batch-size', BatchSize}) when BatchSize > 0 ->
+                 ({'page-size', BatchSize}) when BatchSize > 0 ->
+                      %% Note that internal description is different
+                      %% and confusing: "batch" is also a unit of
+                      %% single GC execution, which may include
+                      %% multiple combination of pagenation &
+                      %% deletion.
                       {batch_size, BatchSize};
                  (BadArg) ->
                       error({bad_arg, BadArg})

--- a/src/riak_cs_gc_manager.erl
+++ b/src/riak_cs_gc_manager.erl
@@ -267,6 +267,8 @@ start_batch(State, Options) ->
     StartKey = proplists:get_value(start, Options,riak_cs_gc:epoch_start()),
     DefaultEndKey = riak_cs_gc:default_batch_end(BatchStart, Leeway),
     EndKey = proplists:get_value('end', Options, DefaultEndKey),
+    BatchSize = proplists:get_value(batch_size, Options,
+                                    riak_cs_config:gc_batch_size()),
 
     %% set many items to GC batch state here
     BatchState = #gc_batch_state{
@@ -274,7 +276,8 @@ start_batch(State, Options) ->
                     start_key=StartKey,
                     end_key=EndKey,
                     leeway=Leeway,
-                    max_workers=MaxWorkers},
+                    max_workers=MaxWorkers,
+                    batch_size=BatchSize},
 
     case riak_cs_gc_batch:start_link(BatchState) of
         {ok, Pid} ->


### PR DESCRIPTION
- Use batch_size preset when starting riak_cs_gc_batch process
- Add QuickCheck test to address #1247 
- Add console option (`-b`) to `riak-cs-admin gc batch` to manually set batch size in each batch
