### PR TITLE
Allow any bytes (including non-UTF8 ones) in List Objects response XML

### DIFF
--- a/src/riak_cs_wm_bucket_location.erl
+++ b/src/riak_cs_wm_bucket_location.erl
@@ -57,7 +57,7 @@ to_xml(RD, Ctx=#context{user=User,bucket=Bucket}) ->
             Doc = [{'LocationConstraint',
                     [{xmlns, "http://s3.amazonaws.com/doc/2006-03-01/"}],
                     [riak_cs_config:region()]}],
-            {riak_cs_xml:export_xml(Doc), RD, Ctx}
+            {riak_cs_xml:to_xml(Doc), RD, Ctx}
     end.
 
 

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -94,7 +94,8 @@ to_xml(#acl_v1{}=Acl) ->
 to_xml(?LBRESP{}=ListBucketsResp) ->
     list_buckets_response_to_xml(ListBucketsResp);
 to_xml(?LORESP{}=ListObjsResp) ->
-    list_objects_response_to_xml(ListObjsResp);
+    SimpleForm = list_objects_response_to_simple_form(ListObjsResp),
+    to_xml(SimpleForm);
 to_xml(?RCS_USER{}=User) ->
     user_record_to_xml(User);
 to_xml({users, Users}) ->
@@ -151,25 +152,34 @@ owner_content({OwnerName, OwnerId}) ->
     [make_external_node('ID', OwnerId),
      make_external_node('DisplayName', OwnerName)].
 
-list_objects_response_to_xml(Resp) ->
-    KeyContents = [key_content_to_xml(Content) ||
-                   Content <- (Resp?LORESP.contents)],
-    CommonPrefixes = [common_prefix_to_xml(Prefix) ||
-                         Prefix <- Resp?LORESP.common_prefixes],
-    Contents = [make_external_node('Name', Resp?LORESP.name),
-                make_external_node('Prefix', Resp?LORESP.prefix),
-                make_external_node('Marker', Resp?LORESP.marker)] ++
+list_objects_response_to_simple_form(Resp) ->
+    KeyContents = [{'Contents', key_content_to_simple_form(Content)} ||
+                      Content <- (Resp?LORESP.contents)],
+    CommonPrefixes = [{'CommonPrefixes', [{'Prefix', [CommonPrefix]}]} ||
+                         CommonPrefix <- Resp?LORESP.common_prefixes],
+    Contents = [{'Name',       [Resp?LORESP.name]},
+                {'Prefix',     [Resp?LORESP.prefix]},
+                {'Marker',     [Resp?LORESP.marker]}] ++
                 %% use a list-comprehension trick to only include
                 %% the `NextMarker' element if it's not `undefined'
-               [make_external_node('NextMarker', NextMarker) ||
-                NextMarker <- [Resp?LORESP.next_marker],
-                NextMarker =/= undefined] ++
-               [make_external_node('MaxKeys', Resp?LORESP.max_keys),
-                make_external_node('Delimiter', Resp?LORESP.delimiter),
-                make_external_node('IsTruncated', Resp?LORESP.is_truncated)] ++
+               [{'NextMarker',  [NextMarker]} ||
+                   NextMarker <- [Resp?LORESP.next_marker],
+                   NextMarker =/= undefined] ++
+               [{'MaxKeys',     [Resp?LORESP.max_keys]},
+                {'Delimiter',   [Resp?LORESP.delimiter]},
+                {'IsTruncated', [Resp?LORESP.is_truncated]}] ++
         KeyContents ++ CommonPrefixes,
-    export_xml([make_internal_node('ListBucketResult', [{'xmlns', ?S3_XMLNS}],
-                                   Contents)]).
+    [{'ListBucketResult', [{'xmlns', ?S3_XMLNS}], Contents}].
+
+key_content_to_simple_form(KeyContent) ->
+    #list_objects_owner_v1{id=Id, display_name=Name} = KeyContent?LOKC.owner,
+    [{'Key',          [KeyContent?LOKC.key]},
+     {'LastModified', [KeyContent?LOKC.last_modified]},
+     {'ETag',         [KeyContent?LOKC.etag]},
+     {'Size',         [KeyContent?LOKC.size]},
+     {'StorageClass', [KeyContent?LOKC.storage_class]},
+     {'Owner',        [{'ID', [Id]},
+                       {'DisplayName', [Name]}]}].
 
 list_buckets_response_to_xml(Resp) ->
     BucketsContent =
@@ -191,23 +201,8 @@ bucket_to_xml(Name, CreationDate) ->
                         make_external_node('CreationDate', CreationDate)]).
 
 user_to_xml_owner(?RCS_USER{canonical_id=CanonicalId, display_name=Name}) ->
-    make_internal_node('Owner', [make_external_node('ID', CanonicalId),
-                                 make_external_node('DisplayName', Name)]).
-
-key_content_to_xml(KeyContent) ->
-    Contents =
-        [make_external_node('Key', KeyContent?LOKC.key),
-         make_external_node('LastModified', KeyContent?LOKC.last_modified),
-         make_external_node('ETag', KeyContent?LOKC.etag),
-         make_external_node('Size', KeyContent?LOKC.size),
-         make_external_node('StorageClass', KeyContent?LOKC.storage_class),
-         make_owner(KeyContent?LOKC.owner)],
-    make_internal_node('Contents', Contents).
-
--spec common_prefix_to_xml(binary()) -> internal_node().
-common_prefix_to_xml(CommonPrefix) ->
-    make_internal_node('CommonPrefixes',
-                       [make_external_node('Prefix', CommonPrefix)]).
+    make_internal_node('Owner', [make_external_node('ID', [CanonicalId]),
+                                 make_external_node('DisplayName', [Name])]).
 
 -spec make_internal_node(atom(), term()) -> internal_node().
 make_internal_node(Name, Content) ->
@@ -259,12 +254,6 @@ make_grant(DisplayName, CanonicalId, Permission) ->
         [make_internal_node('Grantee', Attributes, GranteeContent),
          make_external_node('Permission', Permission)],
     make_internal_node('Grant', GrantContent).
-
--spec make_owner(list_objects_owner()) -> internal_node().
-make_owner(#list_objects_owner_v1{id=Id, display_name=Name}) ->
-    Content = [make_external_node('ID', Id),
-               make_external_node('DisplayName', Name)],
-    make_internal_node('Owner', Content).
 
 -spec format_value(atom() | integer() | binary() | list()) -> string().
 %% @doc Format value depending on its type

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -54,6 +54,17 @@
                     xmlPI() | xmlDocument().
 -export_type([xmlNode/0, xmlElement/0, xmlText/0]).
 
+%% Types for simple forms
+-type tag() :: atom().
+-type content() :: [element()].
+-type element() :: {tag(), attributes(), content()} |
+                   {tag(), content()} |
+                   tag() |
+                   iodata() |
+                   integer() |
+                   float().         % Really Needed?
+-type simple_form() :: content().
+
 %% ===================================================================
 %% Public API
 %% ===================================================================
@@ -98,6 +109,7 @@ export_xml(XmlDoc) ->
       xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
 
 %% @doc Convert simple form into XML.
+-spec simple_form_to_xml(simple_form()) -> iodata().
 simple_form_to_xml(Elements) ->
     XmlDoc = format_elements(Elements),
     export_xml(XmlDoc).

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -106,8 +106,7 @@ to_xml({users, Users}) ->
 %% ===================================================================
 
 export_xml(XmlDoc) ->
-    unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
+    list_to_binary(xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}])).
 
 %% @doc Convert simple form into XML.
 -spec simple_form_to_xml(simple_form()) -> iodata().
@@ -125,8 +124,7 @@ format_element({Tag, Attrs, Elements}) ->
 format_element(Value) ->
     format_value(Value).
 
-%% @doc Convert an internal representation of an ACL
-%% into XML.
+%% @doc Convert an internal representation of an ACL into XML.
 -spec acl_to_xml(acl()) -> binary().
 acl_to_xml(Acl) ->
     Content = [make_internal_node('Owner', owner_content(acl_owner(Acl))),
@@ -256,24 +254,17 @@ make_grant(DisplayName, CanonicalId, Permission) ->
     make_internal_node('Grant', GrantContent).
 
 -spec format_value(atom() | integer() | binary() | list()) -> string().
-%% @doc Format value depending on its type
-%% Handling of characters (binaries or lists of integers) are as follows:
-%% - For binaries, we assume that they are encoded by UTF-8.
-%% - For lists, we assume they are converted from UTF-8 encoded binaries
-%%   by applying binary_to_list/1.
-%%   This is tricky point but binary_to_list/1 treats binaries as if it is
-%%   Latin-1 encoded, so we should turn them back by list_to_binary first.
-%%   Then we can apply unicode:characters_to_binary safely.
+%% @doc Convert value depending on its type into strings
 format_value(undefined) ->
     [];
 format_value(Val) when is_atom(Val) ->
     atom_to_list(Val);
 format_value(Val) when is_binary(Val) ->
-    unicode:characters_to_list(Val, unicode);
+    binary_to_list(Val);
 format_value(Val) when is_integer(Val) ->
     integer_to_list(Val);
 format_value(Val) when is_list(Val) ->
-    format_value(list_to_binary(Val));
+    Val;
 format_value(Val) when is_float(Val) ->
     io_lib:format("~p", [Val]).
 

--- a/src/riak_cs_xml.erl
+++ b/src/riak_cs_xml.erl
@@ -34,7 +34,6 @@
 
 %% Public API
 -export([scan/1,
-         export_xml/1,
          to_xml/1]).
 
 -define(XML_SCHEMA_INSTANCE, "http://www.w3.org/2001/XMLSchema-instance").
@@ -72,13 +71,6 @@ scan(String) ->
         _E -> {error, malformed_xml}
     end.
 
-%% This function is temporary and should be removed once all XML
-%% handling has been moved into this module.
-%% @TODO Remove this asap!
-export_xml(XmlDoc) ->
-    unicode:characters_to_binary(
-      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
-
 -spec to_xml(term()) -> binary().
 to_xml(undefined) ->
     [];
@@ -100,6 +92,10 @@ to_xml({users, Users}) ->
 %% ===================================================================
 %% Internal functions
 %% ===================================================================
+
+export_xml(XmlDoc) ->
+    unicode:characters_to_binary(
+      xmerl:export_simple(XmlDoc, xmerl_xml, [{prolog, ?XML_PROLOG}]), unicode, unicode).
 
 %% @doc Convert simple form into XML.
 simple_form_to_xml(Elements) ->


### PR DESCRIPTION
This PR addresses #974 (RCS-289) 

By some reasons, List Object response XML _can not_ be valid.
- AWS S3 response is XML 1.0 and XML 1.0 allow only `#x9`, `#xA` and
  `#xD` for characters < `#x1F`. Then, PUT Object with path like `%01`
  in URL-encoded form can not be included in valid XML 1.0.
  AWS S3 does allow such bytes [1].
- AWS S3 responds to List Objects by representing `%01` to
  numeric-character-reference-like-but-just-invalid byte in XML, `&#x1;` [2].
  s3cmd and aws cli both fails to parse response including `&#x1;`.

This policy that this PR chooses:
- If all keys are UTF-8 encoded byte sequences and all characters in
  them are valid XML 1.0 characters, then List Object responds contents
  which is valid XML 1.0.
- Otherwise, it responds with some byte sequences which is not valid XML
  1.0 but as =reasonable for humans= as possible in order to deliver
  information about keys in buckets.

The actual logic is very simple. Just return bytes as it has been
uploaded except xml escaping `<`, `>` and `&` [3]. (For reviewers,
the main commit in this PR is b28fec7ee6e32c9bba6145270ec28327a23ee908,
others are just refactoring.)

For example, assuming uploaded key was `%01`, then list results
includes binary like `<<"<Key>", 16#01, "</Key>">>` (in Erlang
notation).  Users can manipulate such response by grep, sed, or
anything if XML library fails [4]. What one should do are only:
- Extract bytes between `<Key>` and `</Key>` (not ambiguous because
  `<` is escaped)
- Unescape `&*` references

[1] Example by s3curl to AWS S3

```
% s3curl.pl --id shino --put rebar.config -- -s -v \
    http://shino.shun.test-us.s3.amazonaws.com/'%01'
> PUT /%01 HTTP/1.1
> User-Agent: curl/7.35.0
> Host: shino.shun.test-us.s3.amazonaws.com
> Accept: */*
> x-amz-date: Tue, 29 Sep 2015 03:02:00 GMT
> Authorization: AWS AKIAJBO7GX36NI32XDRA:gahZlOqOkkrkbGXL34ZyKgT5ZnQ=
> Content-Length: 2852
> Expect: 100-continue
>
< HTTP/1.1 100 Continue
< HTTP/1.1 200 OK
< x-amz-id-2: Ou1uOp+ZJDAwMqGDTnHa82F58sqCO9EWqzffke7/ga2lMEfnpwUQMhHDXCcX5QcQ
< x-amz-request-id: A69F3BE469CC0328
< Date: Tue, 29 Sep 2015 03:02:02 GMT
< ETag: "c90a5c0f80f9b5e2980deee859291373"
< Content-Length: 0
< Server: AmazonS3
<
```

Sidenote: `%00` is NOT allowd.

```
% s3curl.pl --id shino --put rebar.config -- -s -v \
     http://shino.shun.test-us.s3.amazonaws.com/'%00'
> PUT /%00 HTTP/1.1
> User-Agent: curl/7.35.0
> Host: shino.shun.test-us.s3.amazonaws.com
> Accept: */*
> x-amz-date: Tue, 29 Sep 2015 03:02:06 GMT
> Authorization: AWS AKIAJBO7GX36NI32XDRA:0Oa7g2tTC5VvyRbZEQjnmP9pxbs=
> Content-Length: 2852
> Expect: 100-continue
>
< HTTP/1.1 400 Invalid URI
< Content-Length: 0
< Date: Tue, 29 Sep 2015 03:02:07 GMT
< Connection: close
< Server: AmazonS3
<
```

Seems like AWS S3 validation is based on XML 1.1 character range for
PUT request {shrug}.

[2] Extracted from XML response: `<Contents><Key>abc&#x1;def</Key>[snip...]`.

[3] Numeric reference like (but not valid) representation, e.g. `&#x1;` is
    _not_ used.  It's because 1. it is not still valid in XML 1.0 because
    it is outside of character set and 2. if one treat it as XML 1.1 then
    the byte `0x01` (or `<<1>>` in Erlang) is valid as is.

[4] s3curl does nice job for such lower level manipulation. AWS CLI also
    nice because it output response body to stderr if it fails to parse
    it as XML. s3cmd can produce such output by `-d` debug switch.
