### PR TITLE
Supercluster by cuttlefish schema (aka multibag name chage)

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -76,7 +76,7 @@ case IsEE of
 {package_install_user, \"riakcs\"}.
 {package_install_group, \"riak\"}.
 {package_install_user_desc, \"Riak CS user\"}.
-{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}], [{name, \"riak-cs-stanchion\"}], [{name, \"riak-cs-debug\"}], [{name, \"riak-cs-admin\"}], [{name, \"riak-cs-multibag\"}]]}}.
+{package_commands, {list, [[{name, \"riak-cs\"}], [{name, \"riak-cs-access\"}], [{name, \"riak-cs-gc\"}], [{name, \"riak-cs-storage\"}], [{name, \"riak-cs-stanchion\"}], [{name, \"riak-cs-debug\"}], [{name, \"riak-cs-admin\"}], [{name, \"riak-cs-supercluster\"}], [{name, \"riak-cs-multibag\"}]]}}.
 {package_shortdesc, \"Riak CS\"}.
 {package_patch_dir, \"basho-patches\"}.
 {package_desc, \"Riak CS\"}.

--- a/rel/files/riak-cs-supercluster
+++ b/rel/files/riak-cs-supercluster
@@ -1,12 +1,5 @@
 #!/bin/sh
 
-cat<<EOS
-### WARNING ################################################################
-# This command has been deprecated and will be removed in a future release.
-# Use "riak-cs-supercluster <subcommand>" instead of this.
-############################################################################
-EOS
-
 # Pull environment for this install
 . "{{runner_base_dir}}/lib/env.sh"
 
@@ -27,12 +20,8 @@ case "$1" in
 
         $NODETOOL rpc riak_cs_multibag_console "$@"
         ;;
-    list-bags)
-        node_up_check
-        $NODETOOL rpc riak_cs_multibag_console list-members
-        ;;
     *)
-        echo "Usage: $SCRIPT { list-members |  weight | weight-manifest | weight-block | refresh | list-bags }"
+        echo "Usage: $SCRIPT { list-members |  weight | weight-manifest | weight-block | refresh }"
         exit 1
         ;;
 esac

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -671,6 +671,41 @@
   {default, "{{platform_log_dir}}"}
 ]}.
 
+%% == Supercluster aka Multi-bug Support ==
+
+%% @doc IP and port for supercluster members.  Specify one member for
+%% each line, in which the last token of key is member identifier and
+%% value is a PB address of Riak node to connect.
+{mapping, "supercluster.member.$member_id", "riak_cs_multibag.bags", [
+  {datatype, ip},
+  {include_default, "bag-A"},
+  {commented, {"192.168.0.101", 8087}},
+  hidden
+]}.
+
+{translation,
+ "riak_cs_multibag.bags",
+ fun(Conf) ->
+   Keys = cuttlefish_variable:fuzzy_matches(["supercluster", "member", "$member_id"], Conf),
+   case Keys of
+       [] -> undefined;
+       [_|_] -> [begin
+                     {Host, Port} = cuttlefish:conf_get(
+                                      "supercluster.member." ++ MemberId, Conf),
+                     {MemberId, Host, Port}
+                 end || {Key, MemberId} <- Keys]
+   end
+ end
+}.
+
+%% @doc Interval to refresh weight information for every supercluster member.
+{mapping, "supercluster.weight_refresh_interval", 
+ "riak_cs_multibag.weight_refresh_interval", [
+  {default, "15m"},
+  {datatype, [{duration, s}]},
+  hidden
+]}.
+
 %% @doc Cookie for distributed node communication.  All nodes in the
 %% same cluster should use the same cookie or they will not be able to
 %% communicate.

--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -80,6 +80,7 @@
            {template, "files/riak-cs-stanchion", "bin/riak-cs-stanchion"},
            {template, "files/riak-cs-debug", "bin/riak-cs-debug"},
            {template, "files/riak-cs-admin", "bin/riak-cs-admin"},
+           {template, "files/riak-cs-supercluster", "bin/riak-cs-supercluster"},
            {template, "files/riak-cs-multibag", "bin/riak-cs-multibag"},
            {mkdir, "lib/basho-patches"}
           ]}.


### PR DESCRIPTION
A little change for `s/multibag/supercluster/` by cuttlefish schema.

This PR depends on following PRs:
- https://github.com/basho/riak_cs_multibag/pull/31
- https://github.com/basho/stanchion/pull/106
