### PR TITLE
Update exometer_core version to 1.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -47,7 +47,7 @@
         {eper, ".*", {git, "git://github.com/basho/eper.git", "0.92-basho1"}},
         {druuid, ".*", {git, "git://github.com/kellymclaughlin/druuid.git", {tag, "0.2"}}},
         {poolboy, "0.8.*", {git, "git://github.com/basho/poolboy", "0.8.1p3"}},
-        {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.2"}}},
+        {exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {tag, "1.4"}}},
         {cluster_info, ".*", {git, "git://github.com/basho/cluster_info", {tag, "2.0.3"}}},
         {xmerl, ".*", {git, "git://github.com/shino/xmerl", "1b016a05473e086abadbb3c12f63d167fe96c00f"}},
         {erlcloud, ".*", {git, "git://github.com/basho/erlcloud.git", {tag, "0.4.6"}}},


### PR DESCRIPTION
To use this fix https://github.com/uwiger/setup/commit/346bff47d7ae4ee24dec74336a026280fbc8b404  included in setup 1.5. Found via https://github.com/basho/riak_cs/pull/1257#issuecomment-145771625 .
