### PR TITLE
Set DVV explicitly in riak_test execution

### DIFF
--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -77,6 +77,11 @@ cs_port(Node) ->
 
 stanchion_port() -> 9095.
 
+riak_conf() ->
+    [{"ring_size", "8"},
+     {"buckets.default.allow_mult", "true"},
+     {"buckets.default.merge_strategy", "2"}].
+
 riak_config(CustomConfig) ->
     orddict:merge(fun(_, LHS, RHS) -> LHS ++ RHS end,
                   orddict:from_list(lists:sort(CustomConfig)),
@@ -98,10 +103,6 @@ riak_oss_config(CsVsn, Backend) ->
     AddPaths = filelib:wildcard(CSPath ++ "/dev/dev1/lib/riak_cs*/ebin"),
     [
      lager_config(),
-     {riak_core,
-      [{default_bucket_props, [{allow_mult, true}]},
-       {ring_creation_size, 8}]
-     },
      {riak_api,
       [{pb_backlog, 256}]},
      {riak_kv,
@@ -333,6 +334,7 @@ devpath(stanchion, current) -> rt_config:get(?STANCHION_CURRENT);
 devpath(stanchion, previous) -> rt_config:get(?STANCHION_PREVIOUS).
 
 set_configs(NumNodes, Config, Vsn) ->
+    rtcs:set_conf({riak, Vsn}, riak_conf()),
     rt:pmap(fun(N) ->
                     rtcs_dev:update_app_config(rtcs:riak_node(N),
                                                 proplists:get_value(riak, Config)),


### PR DESCRIPTION
Before this commit, sibling_benchmark succeeded with the help of
DVV but it was accidental because of a bug [1]. The bug was fixed
by [2] between riak 2.1.1 and (coming, hopefully) 2.1.2 and DVV
should be set explicitly, no surprises.

[1] https://github.com/basho/riak/issues/759
[2] https://github.com/basho/riak_core/pull/765
