### PR TITLE
Don't use any bags

### DIFF
--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -676,7 +676,7 @@
 %% @doc IP and port for supercluster members.  Specify one member for
 %% each line, in which the last token of key is member identifier and
 %% value is a PB address of Riak node to connect.
-{mapping, "supercluster.member.$member_id", "riak_cs_multibag.bags", [
+{mapping, "supercluster.member.$member_id", "riak_cs.supercluster_members", [
   {datatype, ip},
   {include_default, "bag-A"},
   {commented, {"192.168.0.101", 8087}},
@@ -684,7 +684,7 @@
 ]}.
 
 {translation,
- "riak_cs_multibag.bags",
+ "riak_cs.supercluster_members",
  fun(Conf) ->
    Keys = cuttlefish_variable:fuzzy_matches(["supercluster", "member", "$member_id"], Conf),
    case Keys of
@@ -700,7 +700,7 @@
 
 %% @doc Interval to refresh weight information for every supercluster member.
 {mapping, "supercluster.weight_refresh_interval", 
- "riak_cs_multibag.weight_refresh_interval", [
+ "riak_cs.supercluster_weight_refresh_interval", [
   {default, "15m"},
   {datatype, [{duration, s}]},
   hidden

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -56,6 +56,7 @@
          queue_if_disconnected/0,
          auto_reconnect/0,
          is_multibag_enabled/0,
+         set_multibag_appenv/0,
          max_buckets_per_user/0,
          max_key_length/0,
          read_before_last_manifest_write/0,
@@ -366,6 +367,20 @@ queue_if_disconnected() ->
 -spec is_multibag_enabled() -> boolean().
 is_multibag_enabled() ->
     application:get_env(riak_cs_multibag, bags) =/= undefined.
+
+%% Set riak_cs_multibag app env vars for backward compatibility
+%% to hide any bags from user-facing (TM) parts.
+-spec set_multibag_appenv() -> ok.
+set_multibag_appenv() ->
+    case application:get_env(riak_cs, supercluster_members) of
+        undefined -> ok;
+        {ok, Bags} -> application:set_env(riak_cs_multibag, bags, Bags)
+    end,
+    case application:get_env(riak_cs, supercluster_weight_refresh_interval) of
+        undefined -> ok;
+        {ok, Interval} -> application:set_env(
+                            riak_cs_multibag, weight_refresh_interval, Interval)
+    end.
 
 -spec max_buckets_per_user() -> non_neg_integer() | unlimited.
 max_buckets_per_user() ->

--- a/src/riak_cs_sup.erl
+++ b/src/riak_cs_sup.erl
@@ -161,6 +161,7 @@ pbc_pool_specs(Options) ->
                                                   {Fixed + FAcc, Overflow + OAcc}
                                           end,
                                           {0, 0}, MasterPools),
+    riak_cs_config:set_multibag_appenv(),
     Bags = riak_cs_mb_helper:bags(),
     [pbc_pool_spec(BagId, FixedSum, OverflowSum, Address, Port, WorkerStop)
      || {BagId, Address, Port} <- Bags].

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -61,8 +61,8 @@ default_config_test() ->
                                                                    {size, 10485760},
                                                                    {date, "$D0"},
                                                                    {count, 5}]),
-   cuttlefish_unit:assert_not_configured(Config, "riak_cs_multibag.bags"),
-   cuttlefish_unit:assert_config(Config, "riak_cs_multibag.weight_refresh_interval", 900),
+   cuttlefish_unit:assert_not_configured(Config, "riak_cs.supercluster_members"),
+   cuttlefish_unit:assert_config(Config, "riak_cs.supercluster_weight_refresh_interval", 900),
 %%    cuttlefish_unit:assert_config(Config, "vm_args.+scl", false),
     ok.
 
@@ -226,7 +226,7 @@ supercluster_members_test_() ->
               Conf = [{["supercluster", "member", "bag-A"], "192.168.0.101:8087"}],
               Config = cuttlefish_unit:generate_templated_config(
                          schema_files(), Conf, context()),
-              cuttlefish_unit:assert_config(Config, "riak_cs_multibag.bags",
+              cuttlefish_unit:assert_config(Config, "riak_cs.supercluster_members",
                                             [{"bag-A", "192.168.0.101", 8087}])
       end},
      {"Two bags",
@@ -235,7 +235,7 @@ supercluster_members_test_() ->
                       {["supercluster", "member", "bag-B"], "192.168.0.102:28087"}],
               Config = cuttlefish_unit:generate_templated_config(
                          schema_files(), Conf, context()),
-              cuttlefish_unit:assert_config(Config, "riak_cs_multibag.bags",
+              cuttlefish_unit:assert_config(Config, "riak_cs.supercluster_members",
                                             [{"bag-A", "192.168.0.101", 18087},
                                              {"bag-B", "192.168.0.102", 28087}])
       end},
@@ -244,24 +244,24 @@ supercluster_members_test_() ->
               Conf = [{["supercluster", "member", "bag-A"], "riak-A1.example.com:8087"}],
               Config = cuttlefish_unit:generate_templated_config(
                          schema_files(), Conf, context()),
-              cuttlefish_unit:assert_config(Config, "riak_cs_multibag.bags",
+              cuttlefish_unit:assert_config(Config, "riak_cs.supercluster_members",
                                             [{"bag-A", "riak-A1.example.com", 8087}])
       end}
     ].
 
-supercluster_refresh_interval_test_() ->
+supercluster_weight_refresh_interval_test_() ->
     [fun() ->
              Conf = [{["supercluster", "weight_refresh_interval"], "5s"}],
              Config = cuttlefish_unit:generate_templated_config(
                         schema_files(), Conf, context()),
              cuttlefish_unit:assert_config(
-               Config, "riak_cs_multibag.weight_refresh_interval", 5) end,
+               Config, "riak_cs.supercluster_weight_refresh_interval", 5) end,
      fun() ->
              Conf = [{["supercluster", "weight_refresh_interval"], "1h"}],
              Config = cuttlefish_unit:generate_templated_config(
                         schema_files(), Conf, context()),
              cuttlefish_unit:assert_config(
-               Config, "riak_cs_multibag.weight_refresh_interval", 3600) end
+               Config, "riak_cs.supercluster_weight_refresh_interval", 3600) end
     ].
 
 schema_files() ->


### PR DESCRIPTION
Enforce to use supercluster and some backward compatibility workaround.

Rule of thumb: Use `riak-cs.conf`.
