### PR TITLE
fall back on /etc/riak-cs/app.config when no generated one is found

### DIFF
--- a/rel/files/riak-cs-debug
+++ b/rel/files/riak-cs-debug
@@ -300,9 +300,13 @@ if [ 0 -ne $(( $get_cfgs + $get_logs + $get_riakcmds + $get_extracmds )) ]; then
     fi
 fi
 
-if [ -d "${cuttlefish_conf_dir}" ]; then
+#prefer vm.args if it exists
+if [ -f "${cs_etc_dir}/vm.args" ]; then
+    vmargs="${cs_etc_dir}/vm.args"
+elif [ -d "${cuttlefish_conf_dir}" ]; then
     vmargs=`ls -t ${cuttlefish_conf_dir}/vm.*.args | head -1`
 fi
+
 
 if [ -f "${vmargs}" ]; then
     node_name="`egrep '^\-s?name' "${vmargs}" 2>/dev/null | cut -d ' ' -f 2`"
@@ -491,9 +495,14 @@ if [ 1 -eq $get_logs ]; then
     cd "${start_dir}"/"${debug_dir}"/logs
 
     # if not already made, make a flat, searchable version of the app.config
-    if [ -z "$riak_epaths" -a -d "cuttlefish_conf_dir" ]; then
-      appconfig=`ls -t ${cuttlefish_conf_dir}/app.*.config | head -1`
-      riak_epaths=`make_app_epaths "${appconfig}"`
+    if [ -z "$riak_epaths" ]; then
+        #prefer app.config if it exists
+        if [ -f "${cs_etc_dir}/app.config" ]; then
+            appconfig="${cs_etc_dir}/app.config"
+        elif [  -d "cuttlefish_conf_dir" ]; then
+            appconfig=`ls -t ${cuttlefish_conf_dir}/app.*.config | head -1`
+        fi
+        riak_epaths=`make_app_epaths "${appconfig}"`
     fi
 
     # grab a listing of the log directory to show if there are crash dumps

--- a/rel/files/riak-cs-debug
+++ b/rel/files/riak-cs-debug
@@ -499,7 +499,7 @@ if [ 1 -eq $get_logs ]; then
         #prefer app.config if it exists
         if [ -f "${cs_etc_dir}/app.config" ]; then
             appconfig="${cs_etc_dir}/app.config"
-        elif [  -d "cuttlefish_conf_dir" ]; then
+        elif [  -d "${cuttlefish_conf_dir}" ]; then
             appconfig=`ls -t ${cuttlefish_conf_dir}/app.*.config | head -1`
         fi
         riak_epaths=`make_app_epaths "${appconfig}"`


### PR DESCRIPTION
Prevent the error "cannot access /usr/lib64/riak-cs//var/lib/riak-cs/generated.config/vm.*.args" when a using app.config/vm.args instead of riak.conf, such as when upgrading from 1.5.x
