### PR TITLE
Don't return 403 when Riak is unavailable

### DIFF
--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -316,7 +316,7 @@ deny_access(RD, Ctx) ->
 
 
 
-%% @doc Prodice an invalid-access-keyid error message from a
+%% @doc Produce an invalid-access-keyid error message from a
 %% webmachine resource's `forbidden/2' function.
 deny_invalid_key(RD, Ctx=#context{response_module=ResponseMod}) ->
     ResponseMod:api_error(invalid_access_key_id, RD, Ctx).


### PR DESCRIPTION
This is sort of in-anger change. Error reasons like `<<"pr_unsatisfied,2,0">>` lead to 404 HTTP status code which should be 500 or 503. This commit lets error response modules handle these miscellaneous errors.
