### PR TITLE
Remove admin.secret from configuration

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -56,5 +56,5 @@
 
 {deps_ee, [
            {riak_repl_pb_api,".*",{git,"git@github.com:basho/riak_repl_pb_api.git", {tag, "2.1.1"}}},
-           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0"}}}
+           {riak_cs_multibag,".*",{git,"git@github.com:basho/riak_cs_multibag.git", {tag, "2.1.0p1"}}}
           ]}.

--- a/rel/files/riak_cs.schema
+++ b/rel/files/riak_cs.schema
@@ -73,16 +73,17 @@
 
 %% @doc Admin user credentials. Admin access like /riak-cs/stats
 %% requires this entry to be set properly. The credentials specified
-%% here must match the admin credentials specified in the stanchion
-%% app.config for the system to function properly.
+%% here must match the admin credentials specified in the
+%% stanchion.conf for the system to function properly.
 {mapping, "admin.key", "riak_cs.admin_key", [
   {default, "{{admin_key}}"},
   {datatype, string}
 ]}.
 
+%% @doc admin.secret is deprecated.
 {mapping, "admin.secret", "riak_cs.admin_secret", [
-  {default, "{{admin_secret}}"},
-  {datatype, string}
+  {datatype, string},
+  hidden
 ]}.
 
 %% @doc Root host name which Riak CS accepts.

--- a/rel/vars.config
+++ b/rel/vars.config
@@ -23,7 +23,6 @@
 {riak_pb_port,      8087}.
 {auth_bypass,       false}.
 {admin_key,         "admin-key"}.
-{admin_secret,      "admin-secret"}.
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
 {stanchion_ssl,     off}.

--- a/rel/vars/dev_vars.config.src
+++ b/rel/vars/dev_vars.config.src
@@ -21,7 +21,6 @@
 {riak_pb_port,      @RIAKPBPORT@}.
 {auth_bypass,       false}.
 {admin_key,         "admin-key"}.
-{admin_secret,      "admin-secret"}.
 {stanchion_ip,      "127.0.0.1"}.
 {stanchion_port,    8085}.
 {stanchion_ssl,     off}.

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -165,7 +165,11 @@ setup_admin_user(NumNodes, Vsn)
     #aws_config{access_key_id=KeyID,
                 secret_access_key=KeySecret} = AdminCreds,
 
-    AdminConf = [{admin_key, KeyID}, {admin_secret, KeySecret}],
+    AdminConf = [{admin_key, KeyID}]
+        ++ case Vsn of
+               current -> [];
+               previous -> [{admin_secret, KeySecret}]
+           end,
     rt:pmap(fun(N) ->
                     rtcs:set_advanced_conf({cs, Vsn, N}, [{riak_cs, AdminConf}])
             end, lists:seq(1, NumNodes)),

--- a/riak_test/src/rtcs_config.erl
+++ b/riak_test/src/rtcs_config.erl
@@ -366,30 +366,29 @@ read_config(Vsn, N, Who) ->
              Config
      end.
 
-update_cs_config(Prefix, N, Config, {AdminKey, AdminSecret}) ->
+update_cs_config(Prefix, N, Config, {AdminKey, _AdminSecret}) ->
     CSSection = proplists:get_value(riak_cs, Config),
-    UpdConfig = [{riak_cs, update_admin_creds(CSSection, AdminKey, AdminSecret)} |
+    UpdConfig = [{riak_cs, update_admin_creds(CSSection, AdminKey)} |
                  proplists:delete(riak_cs, Config)],
     update_cs_config(Prefix, N, UpdConfig).
 
 update_cs_config(Prefix, N, Config) ->
     CSSection = proplists:get_value(riak_cs, Config),
     UpdConfig = [{riak_cs, update_cs_port(CSSection, N)} |
-                  proplists:delete(riak_cs, Config)],
+                 proplists:delete(riak_cs, Config)],
     update_app_config(riakcs_etcpath(Prefix, N), UpdConfig).
 
-update_admin_creds(Config, AdminKey, AdminSecret) ->
-    [{admin_key, AdminKey}, {admin_secret, AdminSecret} |
-     proplists:delete(admin_secret,
-                      proplists:delete(admin_key, Config))].
+update_admin_creds(Config, AdminKey) ->
+    [{admin_key, AdminKey}|
+     proplists:delete(admin_key, Config)].
 
 update_cs_port(Config, N) ->
     Config2 = [{riak_host, {"127.0.0.1", pb_port(N)}} | proplists:delete(riak_host, Config)],
     [{listener, {"127.0.0.1", cs_port(N)}} | proplists:delete(listener, Config2)].
 
-update_stanchion_config(Prefix, Config, {AdminKey, AdminSecret}) ->
+update_stanchion_config(Prefix, Config, {AdminKey, _AdminSecret}) ->
     StanchionSection = proplists:get_value(stanchion, Config),
-    UpdConfig = [{stanchion, update_admin_creds(StanchionSection, AdminKey, AdminSecret)} |
+    UpdConfig = [{stanchion, update_admin_creds(StanchionSection, AdminKey)} |
                  proplists:delete(stanchion, Config)],
     update_stanchion_config(Prefix, UpdConfig).
 

--- a/riak_test/tests/migration_15_to_20_test.erl
+++ b/riak_test/tests/migration_15_to_20_test.erl
@@ -156,6 +156,9 @@ upgrade_nodes(AdminCreds, RiakNodes) ->
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
          rt:wait_for_service(RiakNode, riak_kv),
          ok = rtcs_config:upgrade_cs(N, AdminCreds),
+         rtcs:set_advanced_conf({cs, current, N},
+                                [{riak_cs,
+                                  [{riak_host, {"127.0.0.1", rtcs_config:pb_port(1)}}]}]),
          rtcs_exec:start_cs(N, current)
      end
      || RiakNode <- RiakNodes],

--- a/riak_test/tests/migration_mixed_test.erl
+++ b/riak_test/tests/migration_mixed_test.erl
@@ -104,6 +104,10 @@ migrate_nodes_to_cs20_with_kv14(AdminCreds, RiakNodes) ->
          N = rtcs_dev:node_id(RiakNode),
          rtcs_exec:stop_cs(N, previous),
          ok = rtcs_config:upgrade_cs(N, AdminCreds),
+         %% actually after CS 2.1.1
+         rtcs:set_advanced_conf({cs, current, N},
+                                [{riak_cs,
+                                  [{riak_host, {"127.0.0.1", rtcs_config:pb_port(1)}}]}]),
          rtcs_exec:start_cs(N, current)
      end
      || RiakNode <- RiakNodes],

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -84,7 +84,7 @@ fetch_and_cache_admin_creds(Key) ->
         %% Do we count this into stats?; This is a startup query and
         %% system latency is expected to be low. So get timeout can be
         %% low like 10% of configuration value.
-        case riak_cs_pbc:get_sans_stats(MasterPbc, ?USER_BUCKET, Key,
+        case riak_cs_pbc:get_sans_stats(MasterPbc, ?USER_BUCKET, iolist_to_binary(Key),
                                         [{notfound_ok, false}],
                                         riak_cs_config:get_user_timeout() div 10) of
             {ok, Obj} ->

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -27,7 +27,6 @@
 %% application API
 -export([start/2,
          stop/1,
-         sanity_check/2,
          check_bucket_props/2,
          atoms_for_check_bucket_props/0]).
 
@@ -46,6 +45,7 @@
 start(_Type, _StartArgs) ->
     riak_cs_config:warnings(),
     sanity_check(is_config_valid(),
+                 check_admin_creds(),
                  check_bucket_props()).
 
 %% @doc application stop callback for riak_cs.
@@ -53,23 +53,82 @@ start(_Type, _StartArgs) ->
 stop(_State) ->
     ok.
 
--spec sanity_check(boolean(), {ok, boolean()} | {error, term()}) -> {ok, pid()} | {error, term()}.
-sanity_check(true, {ok, true}) ->
+-spec check_admin_creds() -> ok | {error, term()}.
+check_admin_creds() ->
+    case riak_cs_config:admin_creds() of
+        {ok, {"admin-key", _}} ->
+            %% The default key
+            lager:warning("admin.key is defined as default. Please create"
+                          " admin user and configure it.", []),
+            application:set_env(riak_cs, admin_secret, "admin-secret"),
+            ok;
+        {ok, {undefined, _}} ->
+            _ = lager:warning("The admin user's key id has not been specified."),
+            {error, admin_key_undefined};
+        {ok, {[], _}} ->
+            _ = lager:warning("The admin user's key id has not been specified."),
+            {error, admin_key_undefined};
+        {ok, {Key, undefined}} ->
+            fetch_and_cache_admin_creds(Key);
+        {ok, {Key, []}} ->
+            fetch_and_cache_admin_creds(Key);
+        {ok, {Key, _}} ->
+            _ = lager:warning("The admin user's secret is specified. Ignoring."),
+            fetch_and_cache_admin_creds(Key)
+    end.
+
+fetch_and_cache_admin_creds(Key) ->
+    %% Not using as the master pool might not be initialized
+    {ok, MasterPbc} = riak_connection(),
+    try
+        %% Do we count this into stats?; This is a startup query and
+        %% system latency is expected to be low. So get timeout can be
+        %% low like 10% of configuration value.
+        case riak_cs_pbc:get_sans_stats(MasterPbc, ?USER_BUCKET, Key,
+                                        [{notfound_ok, false}],
+                                        riak_cs_config:get_user_timeout() div 10) of
+            {ok, Obj} ->
+                User = riak_cs_user:from_riakc_obj(Obj, false),
+                Secret = User?RCS_USER.key_secret,
+                lager:info("setting admin secret as ~s", [Secret]),
+                application:set_env(riak_cs, admin_secret, Secret);
+            Error ->
+                _ = lager:error("Couldn't get admin user (~s) record: ~p",
+                                [Key, Error]),
+                Error
+        end
+    catch T:E ->
+            _ = lager:error("Couldn't get admin user (~s) record: ~p",
+                            [Key, {T, E}]),
+            {T, E}
+    after
+        riakc_pb_socket:stop(MasterPbc)
+    end.
+
+-spec sanity_check(boolean(),
+                   ok | {error, term()},
+                   {ok, boolean()} | {error, term()}) ->
+                          {ok, pid()} | {error, term()}.
+sanity_check(true, ok, {ok, true}) ->
     riak_cs_sup:start_link();
-sanity_check(false, _) ->
+sanity_check(false, _, _) ->
     _ = lager:error("You must update your Riak CS app.config. Please see the"
                     "release notes for more information on updating you"
                     "configuration."),
     {error, bad_config};
-sanity_check(true, {ok, false}) ->
-        _ = lager:error("Invalid Riak bucket properties detected. Please "
-                        "verify that allow_mult is set to true for all "
-                        "buckets."),
+sanity_check(true, _, {ok, false}) ->
+    _ = lager:error("Invalid Riak bucket properties detected. Please "
+                    "verify that allow_mult is set to true for all "
+                    "buckets."),
     {error, invalid_bucket_props};
-sanity_check(true, {error, Reason}) ->
-        _ = lager:error("Could not verify bucket properties. Error was"
-                       " ~p.", [Reason]),
-    {error, error_verifying_props}.
+sanity_check(true, _, {error, Reason}) ->
+    _ = lager:error("Could not verify bucket properties. Error was"
+                    " ~p.", [Reason]),
+    {error, error_verifying_props};
+sanity_check(_, {error, Reason}, _) ->
+    _ = lager:error("Admin credentials are not properly set: ~p.",
+                    [Reason]),
+    {error, Reason}.
 
 -spec is_config_valid() -> boolean().
 is_config_valid() ->

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -100,7 +100,7 @@ fetch_and_cache_admin_creds(Key) ->
     catch T:E ->
             _ = lager:error("Couldn't get admin user (~s) record: ~p",
                             [Key, {T, E}]),
-            {T, E}
+            {error, {T, E}}
     after
         riakc_pb_socket:stop(MasterPbc)
     end.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -143,7 +143,7 @@ anonymous_user_creation() ->
     get_env(riak_cs, anonymous_user_creation, false).
 
 %% @doc Return the credentials of the admin user
--spec admin_creds() -> {ok, {string(), string()}} | {error, term()}.
+-spec admin_creds() -> {ok, {string()|undefined, string()|undefined}}.
 admin_creds() ->
     {ok, {get_env(riak_cs, admin_key, undefined),
           get_env(riak_cs, admin_secret, undefined)}}.

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -145,30 +145,8 @@ anonymous_user_creation() ->
 %% @doc Return the credentials of the admin user
 -spec admin_creds() -> {ok, {string(), string()}} | {error, term()}.
 admin_creds() ->
-    admin_creds_response(
-      get_env(riak_cs, admin_key, undefined),
-      get_env(riak_cs, admin_secret, undefined)).
-
--spec admin_creds_response(term(), term()) -> {ok, {term(), term()}} |
-                                              {error, atom()}.
-admin_creds_response(undefined, _) ->
-    _ = lager:warning("The admin user's key id"
-                      "has not been specified."),
-    {error, admin_key_undefined};
-admin_creds_response([], _) ->
-    _ = lager:warning("The admin user's key id"
-                      "has not been specified."),
-    {error, admin_key_undefined};
-admin_creds_response(_, undefined) ->
-    _ = lager:warning("The admin user's secret"
-                      "has not been specified."),
-    {error, admin_secret_undefined};
-admin_creds_response(_, []) ->
-    _ = lager:warning("The admin user's secret"
-                      "has not been specified."),
-    {error, admin_secret_undefined};
-admin_creds_response(Key, Secret) ->
-    {ok, {Key, Secret}}.
+    {ok, {get_env(riak_cs, admin_key, undefined),
+          get_env(riak_cs, admin_secret, undefined)}}.
 
 %% @doc Get the active version of Riak CS to use in checks to
 %% determine if new features should be enabled.

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -68,12 +68,8 @@ create_user(Name, Email, KeyId, Secret) ->
             Error
     end.
 
--spec create_credentialed_user({error, term()}, rcs_user()) ->
-                                  {error, term()};
-                              ({ok, {term(), term()}}, rcs_user()) ->
-                                  {ok, rcs_user()} | {error, term()}.
-create_credentialed_user({error, _}=Error, _User) ->
-    Error;
+-spec create_credentialed_user({ok, {term(), term()}}, rcs_user()) ->
+                                      {ok, rcs_user()} | {error, term()}.
 create_credentialed_user({ok, AdminCreds}, User) ->
     {StIp, StPort, StSSL} = riak_cs_utils:stanchion_data(),
     %% Make a call to the user request serialization service.
@@ -118,24 +114,20 @@ handle_update_user({error, _}=Error, _User, _, _) ->
                          {ok, rcs_user()} | {error, term()}.
 update_user(User, UserObj, RcPid) ->
     {StIp, StPort, StSSL} = riak_cs_utils:stanchion_data(),
-    case riak_cs_config:admin_creds() of
-        {ok, AdminCreds} ->
-            Options = [{ssl, StSSL}, {auth_creds, AdminCreds}],
-            StatsKey = [velvet, update_user],
-            _ = riak_cs_stats:inflow(StatsKey),
-            StartTime = os:timestamp(),
-            %% Make a call to the user request serialization service.
-            Result = velvet:update_user(StIp,
-                                        StPort,
-                                        "application/json",
-                                        User?RCS_USER.key_id,
-                                        binary_to_list(riak_cs_json:to_json(User)),
-                                        Options),
-            _ = riak_cs_stats:update_with_start(StatsKey, StartTime, Result),
-            handle_update_user(Result, User, UserObj, RcPid);
-        {error, _}=Error ->
-            Error
-    end.
+    {ok, AdminCreds} = riak_cs_config:admin_creds(),
+    Options = [{ssl, StSSL}, {auth_creds, AdminCreds}],
+    StatsKey = [velvet, update_user],
+    _ = riak_cs_stats:inflow(StatsKey),
+    StartTime = os:timestamp(),
+    %% Make a call to the user request serialization service.
+    Result = velvet:update_user(StIp,
+                                StPort,
+                                "application/json",
+                                User?RCS_USER.key_id,
+                                binary_to_list(riak_cs_json:to_json(User)),
+                                Options),
+    _ = riak_cs_stats:update_with_start(StatsKey, StartTime, Result),
+    handle_update_user(Result, User, UserObj, RcPid).
 
 %% @doc Retrieve a Riak CS user's information based on their id string.
 -spec get_user('undefined' | list(), riak_client()) -> {ok, {rcs_user(), riakc_obj:riakc_obj()}} | {error, term()}.

--- a/src/riak_cs_user.erl
+++ b/src/riak_cs_user.erl
@@ -30,6 +30,7 @@
          is_admin/1,
          get_user/2,
          get_user_by_index/3,
+         from_riakc_obj/2,
          to_3tuple/1,
          save_user/3,
          update_key_secret/1,

--- a/test/riak_cs_config_test.erl
+++ b/test/riak_cs_config_test.erl
@@ -12,7 +12,7 @@ default_config_test() ->
     cuttlefish_unit:assert_not_configured(Config, "riak_cs.ssl"),
     cuttlefish_unit:assert_config(Config, "riak_cs.anonymous_user_creation", false),
     cuttlefish_unit:assert_config(Config, "riak_cs.admin_key", "admin-key"),
-    cuttlefish_unit:assert_config(Config, "riak_cs.admin_secret", "admin-secret"),
+    cuttlefish_unit:assert_not_configured(Config, "riak_cs.admin_secret"),
     cuttlefish_unit:assert_not_configured(Config, "riak_cs.admin_ip"),
     cuttlefish_unit:assert_not_configured(Config, "riak_cs.admin_port"),
     cuttlefish_unit:assert_config(Config, "riak_cs.cs_root_host", "s3.amazonaws.com"),


### PR DESCRIPTION
Instead it is retrieved from Riak directly in startup sequence, from
admin.key specified at configuration file. But in special case
admin.key is specified as "admin-key", it does not retrieve admin
secret from Riak, instead sets it as admin-secret. admin.secret will
be deprecated in near future, which is currently ignored at all.
