### PR TITLE
Handle socket error by catching badmatch

### DIFF
--- a/riak_test/tests/upgrade_downgrade_test.erl
+++ b/riak_test/tests/upgrade_downgrade_test.erl
@@ -51,6 +51,9 @@ confirm() ->
          ok = rt:upgrade(RiakNode, RiakCurrentVsn),
          rt:wait_for_service(RiakNode, riak_kv),
          ok = rtcs_config:upgrade_cs(N, AdminCreds),
+         rtcs:set_advanced_conf({cs, current, N},
+                                [{riak_cs,
+                                  [{riak_host, {"127.0.0.1", rtcs_config:pb_port(1)}}]}]),
          rtcs_exec:start_cs(N, current)
      end
      || RiakNode <- RiakNodes],

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -40,6 +40,7 @@
          add_new_manifest/2,
          update_manifest/2,
          update_manifests/2,
+         delete_specific_manifest/2,
          gc_specific_manifest/2,
          update_manifest_with_confirmation/2,
          update_manifests_with_confirmation/2,
@@ -123,6 +124,14 @@ update_manifest(Pid, Manifest) ->
 %% @doc Delete a specific manifest version from a manifest and
 %% update the manifest value in riak or delete the manifest key from
 %% riak if there are no manifest versions remaining.
+-spec delete_specific_manifest(pid(), binary()) -> ok | {error, term()}.
+delete_specific_manifest(Pid, UUID) ->
+    gen_fsm:sync_send_event(Pid, {delete_manifest, UUID}, infinity).
+
+%% @doc Not only delete a specific manifest version from a manifest
+%% and update the manifest value in riak or delete the manifest key
+%% from riak if there are no manifest versions remaining, but also
+%% moves them into GC bucket.
 -spec gc_specific_manifest(pid(), binary()) -> ok | {error, term()}.
 gc_specific_manifest(Pid, UUID) ->
     gen_fsm:sync_send_event(Pid, {gc_specific_manifest, UUID}, infinity).

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -274,7 +274,7 @@ waiting_update_command({gc_specific_manifest, UUID}, _From,
                   riak_cs_gc:gc_specific_manifests([UUID], RiakObj,
                                                    Bucket, Key, RcPid)
           end,
-    {reply, Res, waiting_update_command, State}.
+    {stop, normal, Res, State}.
 
 handle_event(_Event, StateName, State) ->
     {next_state, StateName, State}.

--- a/src/riak_cs_manifest_fsm.erl
+++ b/src/riak_cs_manifest_fsm.erl
@@ -40,7 +40,7 @@
          add_new_manifest/2,
          update_manifest/2,
          update_manifests/2,
-         delete_specific_manifest/2,
+         gc_specific_manifest/2,
          update_manifest_with_confirmation/2,
          update_manifests_with_confirmation/2,
          maybe_stop_manifest_fsm/1,
@@ -123,9 +123,9 @@ update_manifest(Pid, Manifest) ->
 %% @doc Delete a specific manifest version from a manifest and
 %% update the manifest value in riak or delete the manifest key from
 %% riak if there are no manifest versions remaining.
--spec delete_specific_manifest(pid(), binary()) -> ok | {error, term()}.
-delete_specific_manifest(Pid, UUID) ->
-    gen_fsm:sync_send_event(Pid, {delete_manifest, UUID}, infinity).
+-spec gc_specific_manifest(pid(), binary()) -> ok | {error, term()}.
+gc_specific_manifest(Pid, UUID) ->
+    gen_fsm:sync_send_event(Pid, {gc_specific_manifest, UUID}, infinity).
 
 -spec update_manifests_with_confirmation(pid(), orddict:orddict()) -> ok | {error, term()}.
 update_manifests_with_confirmation(Pid, Manifests) ->
@@ -196,7 +196,6 @@ waiting_update_command({update_manifests, WrappedManifests},
                                   WrappedManifests),
     {next_state, waiting_update_command, State#state{riak_object=undefined, manifests=undefined}}.
 
-
 waiting_command(get_manifests, _From, State) ->
     {Reply, NewState} = handle_get_manifests(State),
     {reply, Reply, waiting_update_command, NewState};
@@ -244,7 +243,30 @@ waiting_update_command({update_manifests_with_confirmation, WrappedManifests}, _
                                           WrappedManifests)
         end,
     {reply, Reply, waiting_update_command, State#state{riak_object=undefined,
-                                                       manifests=undefined}}.
+                                                       manifests=undefined}};
+waiting_update_command({gc_specific_manifest, UUID}, _From,
+                       #state{
+                          riak_object = RiakObj0,
+                          bucket = Bucket,
+                          key = Key,
+                          riak_client = RcPid
+                         } = State) ->
+    %% put_fsm has issued delete_manifest caused by force_stop
+    Res = case RiakObj0 of
+              undefined ->
+                  case riak_cs_manifest:get_manifests(RcPid, Bucket, Key) of
+                      {ok, RiakObj, _} ->
+                          riak_cs_gc:gc_specific_manifests([UUID], RiakObj,
+                                                           Bucket, Key, RcPid);
+                      Error ->
+                          Error
+                  end;
+              RiakObj ->
+                  riak_cs_gc:gc_specific_manifests([UUID], RiakObj,
+                                                   Bucket, Key, RcPid)
+          end,
+    {reply, Res, waiting_update_command, State}.
+
 handle_event(_Event, StateName, State) ->
     {next_state, StateName, State}.
 

--- a/src/riak_cs_put_fsm.erl
+++ b/src/riak_cs_put_fsm.erl
@@ -348,8 +348,11 @@ handle_event(_Event, StateName, State) ->
 handle_sync_event(current_state, _From, StateName, State) ->
     Reply = {StateName, State},
     {reply, Reply, StateName, State};
-handle_sync_event(force_stop, _From, _StateName, State) ->
-    {stop, normal, ok, State};
+handle_sync_event(force_stop, _From, _StateName, State = #state{mani_pid=ManiPid,
+                                                                uuid=UUID}) ->
+    Res = riak_cs_manifest_fsm:gc_specific_manifest(ManiPid, UUID),
+    lager:debug("Manifest collection on upload failure: ~p", [Res]),
+    {stop, normal, Res, State};
 handle_sync_event(_Event, _From, StateName, State) ->
     Reply = ok,
     {reply, Reply, StateName, State}.

--- a/src/riak_cs_wm_object.erl
+++ b/src/riak_cs_wm_object.erl
@@ -47,7 +47,6 @@ stats_prefix() -> object.
 
 -spec malformed_request(#wm_reqdata{}, #context{}) -> {false, #wm_reqdata{}, #context{}}.
 malformed_request(RD, #context{response_module=ResponseMod} = Ctx) ->
-    lager:debug("*********** ~p", [?LINE]),
     case riak_cs_wm_utils:extract_key(RD, Ctx) of
         {error, Reason} ->
             ResponseMod:api_error(Reason, RD, Ctx);
@@ -95,13 +94,11 @@ authorize(RD, Ctx, _BucketObj, _Method, _Manifest) ->
 %% @doc Get the list of methods this resource supports.
 -spec allowed_methods() -> [atom()].
 allowed_methods() ->
-    lager:debug("*********** ~p", [?LINE]),
     %% TODO: POST
     ['HEAD', 'GET', 'DELETE', 'PUT'].
 
 -spec valid_entity_length(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 valid_entity_length(RD, Ctx) ->
-    lager:debug("*********** ~p", [?LINE]),
     MaxLen = riak_cs_lfs_utils:max_content_len(),
     case riak_cs_wm_utils:valid_entity_length(MaxLen, RD, Ctx) of
         {true, NewRD, NewCtx} ->
@@ -114,7 +111,6 @@ valid_entity_length(RD, Ctx) ->
 -spec content_types_provided(#wm_reqdata{}, #context{}) -> {[{string(), atom()}], #wm_reqdata{}, #context{}}.
 content_types_provided(RD, Ctx=#context{local_context=LocalCtx,
                                         riak_client=RcPid}) ->
-    lager:debug("*********** ~p", [?LINE]),
     Mfst = LocalCtx#key_context.manifest,
     %% TODO:
     %% As I understand S3, the content types provided
@@ -172,7 +168,6 @@ produce_body(RD, Ctx=#context{rc_pool=RcPool,
                               start_time=StartTime,
                               user=User},
              {Start, End}, RespRange) ->
-    lager:debug("*********** ~p", [?LINE]),
     #key_context{get_fsm_pid=GetFsmPid, manifest=Mfst} = LocalCtx,
     {Bucket, File} = Mfst?MANIFEST.bkey,
     ResourceLength = Mfst?MANIFEST.content_length,
@@ -349,20 +344,16 @@ handle_normal_put(RD, Ctx) ->
              Metadata, BlockSize, ACL, timer:seconds(60), self(), RcPid}],
     {ok, Pid} = riak_cs_put_fsm_sup:start_put_fsm(node(), Args),
     try
-        lager:info("start putting data: ~s / ~s, ~p bytes", [Bucket, Key, Size]),
         accept_streambody(RD, Ctx, Pid,
                           wrq:stream_req_body(RD, riak_cs_lfs_utils:block_size()))
     catch
         Type:Error ->
-            %% Want to catch mochiweb_socket:recv() returns
-            %% {error, einval} or disconnected stuff, any
-            %% errors prevents this manifests from being
-            %% uploaded anymore
-            _ = lager:debug("upload failed: ~p", [{Type, Error}]),
+            %% Want to catch mochiweb_socket:recv() returns {error,
+            %% einval} or disconnected stuff, any errors prevents this
+            %% manifests from being uploaded anymore
             Res = riak_cs_put_fsm:force_stop(Pid),
-            _ = lager:debug("PUT FSM force_stop: ~p", [Res]),
+            _ = lager:debug("PUT FSM force_stop: ~p Reason: ~p", [Res, {Type, Error}]),
             error({Type, Error})
-            %% {{halt, 503}, RD, Ctx, Pid}
     end.
 
 %% @doc the head is PUT copy path

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -280,6 +280,9 @@ prepare_part_upload(RD, #context{riak_client=RcPid,
             case SrcManifest of
                 undefined ->
                     BlockSize = riak_cs_lfs_utils:block_size(),
+                    %% No badmatch errow by machiweb_socket:recv()
+                    %% will be catched here because writing state
+                    %% parts can be collected in Multipart Abort API.
                     accept_streambody(RD, Ctx, PutPid,
                                       wrq:stream_req_body(RD, BlockSize));
                 _ ->


### PR DESCRIPTION
When a client cancelled or stopped uploading an object in the middle,
the socket for TCP connection returns error when mochiweb tried to
read payload. It had been throwing badmatch and that request was just
failing, leaving already uploaded chunks and writing manifests.

This commit adds a try-catch clause to catch the badmatch error thrown
by mochiweb and calls amendment code that moves the exact manifest to
GC bucket and marks it as scheduled_delete.

A test is included in regression_tests.erl, where a socket error is
emulated by client-side socket close in the middle of upload.

~~Partial~~ solution for #770.
