### PR TITLE
Remove equal at every Base64 URL encode/decoding

### DIFF
--- a/src/base64url.erl
+++ b/src/base64url.erl
@@ -90,17 +90,18 @@ urldecode_digit(D)  -> D.
 -ifdef(TEST).
 equal_strip_amend_test() ->
     %% TODO: rewrite this with EQC
-    [begin
-         UUID = druuid:v4(),
-         Encoded = base64url:encode(UUID),
-         ?assertEqual(nomatch, binary:match(Encoded, [<<"=">>, <<"+">>, <<"/">>])),
-         ?assertEqual(UUID, base64url:decode(Encoded))
-     end || _<- lists:seq(1, 1024)],
-    [begin
-         UUID = druuid:v4(),
-         Encoded = base64url:encode_to_string(UUID),
-         %% ?assertEqual(nomatch, binary:match(Encoded, [<<"=">>, <<"+">>, <<"/">>])),
-         ?assertEqual(UUID, base64url:decode(Encoded))
-     end || _<- lists:seq(1, 1024)].
+    _ = [begin
+             UUID = druuid:v4(),
+             Encoded = base64url:encode(UUID),
+             ?assertEqual(nomatch, binary:match(Encoded, [<<"=">>, <<"+">>, <<"/">>])),
+             ?assertEqual(UUID, base64url:decode(Encoded))
+         end || _<- lists:seq(1, 1024)],
+    _ = [begin
+             UUID = druuid:v4(),
+             Encoded = base64url:encode_to_string(UUID),
+             ?assertEqual(nomatch, re:run(Encoded, "(=\\+\\/)")),
+             ?assertEqual(UUID, base64url:decode(Encoded))
+         end || _<- lists:seq(1, 1024)],
+    ok.
 
 -endif.

--- a/src/base64url.erl
+++ b/src/base64url.erl
@@ -21,7 +21,7 @@
 %% @doc base64url is a wrapper around the base64 module to produce
 %%      base64-compatible encodings that are URL safe.
 %%      The / character in normal base64 encoding is replaced with
-%%      the _ character, and + is replaced with -.
+%%      the _ character, + is replaced with -,and = is omitted.
 %%      This replacement scheme is named "base64url" by
 %%      http://en.wikipedia.org/wiki/Base64
 

--- a/src/base64url.erl
+++ b/src/base64url.erl
@@ -27,30 +27,47 @@
 
 -module(base64url).
 
+-include_lib("eunit/include/eunit.hrl").
+
 -export([decode/1,
          decode_to_string/1,
          encode/1,
-         encode_to_string/1,
-         mime_decode/1,
-         mime_decode_to_string/1]).
+         encode_to_string/1]).
 
 decode(Base64url) ->
-    base64:decode(urldecode(Base64url)).
+    base64:decode(amend_equal(urldecode(Base64url))).
 
 decode_to_string(Base64url) ->
-    base64:decode_to_string(urldecode(Base64url)).
-
-mime_decode(Base64url) ->
-    base64:mime_decode(urldecode(Base64url)).
-
-mime_decode_to_string(Base64url) ->
-    base64:mime_decode_to_string(urldecode(Base64url)).
+    base64:decode_to_string(amend_equal(urldecode(Base64url))).
 
 encode(Data) ->
-    urlencode(base64:encode(Data)).
+    urlencode(strip_equal(base64:encode(Data))).
 
 encode_to_string(Data) ->
-    urlencode(base64:encode_to_string(Data)).
+    urlencode(strip_equal(base64:encode_to_string(Data))).
+
+-spec strip_equal(binary() | string()) -> binary()|string().
+strip_equal(Encoded) when is_list(Encoded) ->
+    hd(string:tokens(Encoded, "="));
+strip_equal(Encoded) when is_binary(Encoded) ->
+    LCS = binary:longest_common_suffix([Encoded, <<"===">>]),
+    binary:part(Encoded, 0, byte_size(Encoded)-LCS).
+
+%% @doc complements '=' if it doesn't have 4*n length
+-spec amend_equal(binary()|string()) -> binary()|string().
+amend_equal(Encoded) when is_list(Encoded) ->
+    Suffix = case length(Encoded) rem 4 of
+                 0 -> "";
+                 L -> [$=||_<-lists:seq(1,L)]
+             end,
+    lists:flatten([Encoded, Suffix]);
+amend_equal(Bin) when is_binary(Bin) ->
+    case byte_size(Bin) rem 4 of
+        0 -> Bin;
+        1 -> <<Bin/binary, "===">>;
+        2 -> <<Bin/binary, "==">>;
+        3 -> <<Bin/binary, "=">>
+    end.
 
 urlencode(Base64) when is_list(Base64) ->
     [urlencode_digit(D) || D <- Base64];
@@ -69,3 +86,21 @@ urlencode_digit(D)  -> D.
 urldecode_digit($_) -> $/;
 urldecode_digit($-) -> $+;
 urldecode_digit(D)  -> D.
+
+-ifdef(TEST).
+equal_strip_amend_test() ->
+    %% TODO: rewrite this with EQC
+    [begin
+         UUID = druuid:v4(),
+         Encoded = base64url:encode(UUID),
+         ?assertEqual(nomatch, binary:match(Encoded, [<<"=">>, <<"+">>, <<"/">>])),
+         ?assertEqual(UUID, base64url:decode(Encoded))
+     end || _<- lists:seq(1, 1024)],
+    [begin
+         UUID = druuid:v4(),
+         Encoded = base64url:encode_to_string(UUID),
+         %% ?assertEqual(nomatch, binary:match(Encoded, [<<"=">>, <<"+">>, <<"/">>])),
+         ?assertEqual(UUID, base64url:decode(Encoded))
+     end || _<- lists:seq(1, 1024)].
+
+-endif.

--- a/src/riak_cs_utils.erl
+++ b/src/riak_cs_utils.erl
@@ -51,7 +51,6 @@
          resolve_robj_siblings/1,
          riak_connection/0,
          riak_connection/1,
-         safe_base64_decode/1,
          safe_base64url_decode/1,
          safe_list_to_integer/1,
          set_object_acl/5,
@@ -500,15 +499,6 @@ active_to_bool({error, notfound}) ->
 -spec pid_to_binary(pid()) -> binary().
 pid_to_binary(Pid) ->
     list_to_binary(pid_to_list(Pid)).
-
--spec safe_base64_decode(binary() | string()) -> {ok, binary()} | bad.
-safe_base64_decode(Str) ->
-    try
-        X = base64:decode(Str),
-        {ok, X}
-    catch _:_ ->
-            bad
-    end.
 
 -spec safe_base64url_decode(binary() | string()) -> {ok, binary()} | bad.
 safe_base64url_decode(Str) ->


### PR DESCRIPTION
Multipart upload id in S3 does not includes equal '=' which made its
handling diverse among client libraries. Contrary to this, Riak CS
issues multipart upload ids that include '='. With this change
base64url module changes its behaviour, to automatically removing
trailing '=' at encoding time, and to automatically adding trailing
'=' at decoding time. This is harmless because in Base64 codes '=' is
just a filler.

This commit also removes several unused functions.

This addresses #1292 (RCS-349) and #1063 (RCS-350).
