### PR TITLE
Return 500 instead of 403 when Riak is unavailable [JIRA: RCS-359]

### DIFF
--- a/riak_test/tests/error_response_test.erl
+++ b/riak_test/tests/error_response_test.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/riak_test/tests/error_response_test.erl
+++ b/riak_test/tests/error_response_test.erl
@@ -42,9 +42,8 @@ confirm() ->
     erlcloud_s3:put_object(?BUCKET, ?KEY, SingleBlock, UserConfig),
 
     %% vefity response for timeout during getting a user.
-    %% FIXME: This should be http_error 503
     rt_intercept:add(ErrCSNode, {riak_cs_riak_client, [{{get_user, 2}, get_user_timeout}]}),
-    ?assertError({aws_error, {http_error, 403, [], _}},
+    ?assertError({aws_error, {http_error, 503, [], _}},
                  erlcloud_s3:get_object(?BUCKET, ?KEY, ErrConfig)),
     rt_intercept:clean(ErrCSNode, riak_cs_riak_client),
 
@@ -53,7 +52,6 @@ confirm() ->
     rt_intercept:add(ErrCSNode, {riak_cs_block_server, [{{get_block_local, 6}, get_block_local_timeout}]}),
     ?assertError({aws_error, {socket_error, retry_later}}, erlcloud_s3:get_object(?BUCKET, ?KEY, ErrConfig)),
     rt_intercept:clean(ErrCSNode, riak_cs_block_server),
-
 
     %% vefity response for timeout during get a bucket on stanchion.
     %% FIXME: This should be http_error 503

--- a/riak_test/tests/regression_tests.erl
+++ b/riak_test/tests/regression_tests.erl
@@ -29,10 +29,16 @@
 -export([confirm/0]).
 -include_lib("eunit/include/eunit.hrl").
 -include("riak_cs.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 -define(TEST_BUCKET_CS347, "test-bucket-cs347").
 
+-define(assert500(X),
+        ?assertError({aws_error, {http_error, 500, _, _}}, (X))).
+
 confirm() ->
+    %% Setting short timeouts to accelarate verify_cs756
+    rtcs:set_advanced_conf(cs, [{riak_cs, [{riakc_timeouts, 1000}]}]),
     {UserConfig, _} = SetupInfo = rtcs:setup(1),
 
     ok = verify_cs296(SetupInfo, "test-bucket-cs296"),
@@ -40,9 +46,11 @@ confirm() ->
     ok = verify_cs436(SetupInfo, "test-bucket-cs436"),
     ok = verify_cs512(UserConfig, "test-bucket-cs512"),
     ok = verify_cs770(SetupInfo, "test-bucket-cs770"),
-
     %% Append your next regression tests here
 
+    %% regression of CS#756 must be the last test as it stops all Riak
+    %% nodes.
+    ok = verify_cs756(SetupInfo, "test-bucket-cs756"),
     rtcs:pass().
 
 %% @doc Regression test for `riak_cs' <a href="https://github.com/basho/riak_cs/issues/296">
@@ -139,13 +147,17 @@ verify_cs436(_SetupInfo = {UserConfig, {_RiakNodes, _CSNodes, _Stanchion}}, Buck
 -define(KEY, "cs512-key").
 
 verify_cs512(UserConfig, BucketName) ->
-    %% {ok, UserConfig} = setup(),
     ?assertEqual(ok, erlcloud_s3:create_bucket(BucketName, UserConfig)),
     put_and_get(UserConfig, BucketName, <<"OLD">>),
     put_and_get(UserConfig, BucketName, <<"NEW">>),
-    delete(UserConfig, BucketName),
+    erlcloud_s3:delete_object(BucketName, ?KEY, UserConfig),
     assert_notfound(UserConfig,BucketName),
     ok.
+
+put_and_get(UserConfig, BucketName, Data) ->
+    erlcloud_s3:put_object(BucketName, ?KEY, Data, UserConfig),
+    Props = erlcloud_s3:get_object(BucketName, ?KEY, UserConfig),
+    ?assertEqual(proplists:get_value(content, Props), Data).
 
 verify_cs770({UserConfig, {RiakNodes, _, _}}, BucketName) ->
     %% put object and cancel it;
@@ -220,13 +232,33 @@ get_manifests(RiakNodes, BucketName, Key) ->
     [binary_to_term(V) || {_, V} <- riakc_obj:get_contents(Obj),
                           V =/= <<>>].
 
-put_and_get(UserConfig, BucketName, Data) ->
-    erlcloud_s3:put_object(BucketName, ?KEY, Data, UserConfig),
-    Props = erlcloud_s3:get_object(BucketName, ?KEY, UserConfig),
-    ?assertEqual(proplists:get_value(content, Props), Data).
+verify_cs756({UserConfig, {RiakNodes, _, _}}, BucketName) ->
+    %% Making sure API call from non-existent user all fails in 403, not 50x
+    %% This could be done with eqc
+    lager:info("CS756 regression"),
+    [rt:stop(RiakNode) || RiakNode <- RiakNodes],
+    [rt:wait_until_unpingable(RiakNode) || RiakNode <- RiakNodes],
 
-delete(UserConfig, BucketName) ->
-    erlcloud_s3:delete_object(BucketName, ?KEY, UserConfig).
+    %% test Object APIs before bucket creation
+    ?assert500(erlcloud_s3:put_object(BucketName, "mine", <<"deadbeef">>, UserConfig)),
+    ?assert500(erlcloud_s3:get_object(BucketName, "mine", UserConfig)),
+
+    %% test bucket creation fails
+    ?assert500(erlcloud_s3:create_bucket(BucketName, UserConfig)),
+    ?assert500(erlcloud_s3:delete_bucket("dummybucket", UserConfig)),
+
+    ?assert500(erlcloud_s3:put_object(BucketName, "mine", <<"deadbeef">>, UserConfig)),
+    ?assert500(erlcloud_s3:get_object(BucketName, "mine", UserConfig)),
+    ?assert500(erlcloud_s3:delete_object(BucketName, "mine", UserConfig)), 
+
+    %% try copy
+    ?assert500(erlcloud_s3:copy_object(BucketName, "destination",
+                                       BucketName, "mine", UserConfig)),
+
+    ?assert500(erlcloud_s3:delete_bucket("dummybucket", UserConfig)),
+    ?assert500(erlcloud_s3:delete_bucket(BucketName, UserConfig)),
+
+    ok.
 
 assert_notfound(UserConfig, BucketName) ->
     ?assertException(_,

--- a/riak_test/tests/regression_tests.erl
+++ b/riak_test/tests/regression_tests.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -233,7 +233,7 @@ get_manifests(RiakNodes, BucketName, Key) ->
                           V =/= <<>>].
 
 verify_cs756({UserConfig, {RiakNodes, _, _}}, BucketName) ->
-    %% Making sure API call from non-existent user all fails in 403, not 50x
+    %% Making sure API call to CS failed Riak KV underneath, all fails in 500
     %% This could be done with eqc
     lager:info("CS756 regression"),
     [rt:stop(RiakNode) || RiakNode <- RiakNodes],

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -91,7 +91,6 @@ fetch_and_cache_admin_creds(Key) ->
             {ok, Obj} ->
                 User = riak_cs_user:from_riakc_obj(Obj, false),
                 Secret = User?RCS_USER.key_secret,
-                _ = lager:debug("admin secret: ~s", [Secret]),
                 application:set_env(riak_cs, admin_secret, Secret);
             Error ->
                 _ = lager:error("Couldn't get admin user (~s) record: ~p",

--- a/src/riak_cs_app.erl
+++ b/src/riak_cs_app.erl
@@ -80,6 +80,7 @@ check_admin_creds() ->
 fetch_and_cache_admin_creds(Key) ->
     %% Not using as the master pool might not be initialized
     {ok, MasterPbc} = riak_connection(),
+    _ = lager:info("setting admin as ~s", [Key]),
     try
         %% Do we count this into stats?; This is a startup query and
         %% system latency is expected to be low. So get timeout can be
@@ -90,7 +91,7 @@ fetch_and_cache_admin_creds(Key) ->
             {ok, Obj} ->
                 User = riak_cs_user:from_riakc_obj(Obj, false),
                 Secret = User?RCS_USER.key_secret,
-                lager:info("setting admin secret as ~s", [Secret]),
+                _ = lager:debug("admin secret: ~s", [Secret]),
                 application:set_env(riak_cs, admin_secret, Secret);
             Error ->
                 _ = lager:error("Couldn't get admin user (~s) record: ~p",
@@ -192,6 +193,7 @@ check_bucket_props(Bucket, MasterPbc) ->
 
 riak_connection() ->
     {Host, Port} = riak_cs_config:riak_host_port(),
+    lager:debug("connecting to ~p", [{Host, Port}]),
     Timeout = case application:get_env(riak_cs, riakc_connect_timeout) of
                   {ok, ConfigValue} ->
                       ConfigValue;

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_cs_s3_response.erl
+++ b/src/riak_cs_s3_response.erl
@@ -111,6 +111,7 @@ error_message(unexpected_content) -> "This request does not support content";
 error_message(canned_acl_and_header_grant) -> "Specifying both Canned ACLs and Header Grants is not allowed";
 error_message(malformed_xml) -> "The XML you provided was not well-formed or did not validate against our published schema";
 error_message(remaining_multipart_upload) -> "Concurrent multipart upload initiation detected. Please stop it to delete bucket.";
+error_message(disconnected) -> "Please contact administrator.";
 error_message(not_implemented) -> "A request you provided implies functionality that is not implemented";
 error_message(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
@@ -161,6 +162,7 @@ error_code(canned_acl_and_header_grant) -> "InvalidRequest";
 error_code(malformed_acl_error) -> "MalformedACLError";
 error_code(malformed_xml) -> "MalformedXML";
 error_code(remaining_multipart_upload) -> "MultipartUploadRemaining";
+error_code(disconnected) -> "ServiceUnavailable";
 error_code(not_implemented) -> "NotImplemented";
 error_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),
@@ -218,6 +220,7 @@ status_code(canned_acl_and_header_grant)   -> 400;
 status_code(malformed_acl_error)           -> 400;
 status_code(malformed_xml)                 -> 400;
 status_code(remaining_multipart_upload)    -> 409;
+status_code(disconnected)                  -> 500;
 status_code(not_implemented)               -> 501;
 status_code(ErrorName) ->
     _ = lager:debug("Unknown error: ~p", [ErrorName]),

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -162,6 +162,7 @@ forbidden(RD, Ctx=#context{auth_module=AuthMod,
                            submodule=Mod,
                            riak_client=RcPid,
                            exports_fun=ExportsFun}) ->
+
     {AuthResult, AnonOk} =
         case AuthMod:identify(RD, Ctx) of
             failed ->
@@ -174,15 +175,20 @@ forbidden(RD, Ctx=#context{auth_module=AuthMod,
                                            <<"forbidden">>,
                                            [],
                                            [riak_cs_wm_utils:extract_name(UserKey)]),
-                UserLookupResult = maybe_create_user(
-                                     riak_cs_user:get_user(UserKey, RcPid),
-                                     UserKey,
-                                     Ctx#context.api,
-                                     Ctx#context.auth_module,
-                                     AuthData,
-                                     RcPid),
-                {authenticate(UserLookupResult, RD, Ctx, AuthData),
-                 resource_call(Mod, anon_ok, [], ExportsFun)}
+                case maybe_create_user(
+                       riak_cs_user:get_user(UserKey, RcPid),
+                       UserKey,
+                       Ctx#context.api,
+                       Ctx#context.auth_module,
+                       AuthData,
+                       RcPid) of
+                    {ok, {User, Obj}} = _LookupResult ->
+                        {authenticate(User, Obj, RD, Ctx, AuthData),
+                         resource_call(Mod, anon_ok, [], ExportsFun)};
+                    Error ->
+                        {Error,
+                         resource_call(Mod, anon_ok, [], ExportsFun)}
+                end
         end,
     post_authentication(AuthResult, RD, Ctx, AnonOk).
 
@@ -409,10 +415,9 @@ authorize(RD,Ctx=#context{submodule=Mod, exports_fun=ExportsFun}) ->
     end,
     R.
 
--type user_lookup_result() :: {ok, {rcs_user(), riakc_obj:riakc_obj()}} | {error, term()}.
--spec authenticate(user_lookup_result(), term(), term(), term()) ->
-                          {ok, rcs_user(), riakc_obj:riakc_obj()} | {error, term()}.
-authenticate({ok, {User, UserObj}}, RD, Ctx=#context{auth_module=AuthMod, submodule=Mod}, AuthData)
+-spec authenticate(rcs_user(), riakc_obj:riakc_obj(), term(), term(), term()) ->
+                          {ok, rcs_user(), riakc_obj:riakc_obj()} | {error, bad_auth}.
+authenticate(User, UserObj, RD, Ctx=#context{auth_module=AuthMod, submodule=Mod}, AuthData)
   when User?RCS_USER.status =:= enabled ->
     riak_cs_dtrace:dt_wm_entry({?MODULE, Mod}, <<"authenticate">>, [], [atom_to_binary(AuthMod, latin1)]),
     case AuthMod:authenticate(User, AuthData, RD, Ctx) of
@@ -426,12 +431,10 @@ authenticate({ok, {User, UserObj}}, RD, Ctx=#context{auth_module=AuthMod, submod
             riak_cs_dtrace:dt_wm_return({?MODULE, Mod}, <<"authenticate">>, [0], [atom_to_binary(AuthMod, latin1)]),
             {error, bad_auth}
     end;
-authenticate({ok, {User, _UserObj}}, _RD, _Ctx, _AuthData)
+authenticate(User, _UserObj, _RD, _Ctx, _AuthData)
   when User?RCS_USER.status =/= enabled ->
     %% {ok, _} -> %% disabled account, we are going to 403
-    {error, bad_auth};
-authenticate({error, _}=Error, _RD, _Ctx, _AuthData) ->
-    Error.
+    {error, bad_auth}.
 
 -spec exports_fun(orddict:orddict()) -> function().
 exports_fun(Exports) ->
@@ -494,15 +497,13 @@ post_authentication({error, {auth_not_supported, AuthType}}, RD,
     _ = lager:debug("auth_not_supported: ~s", [AuthType]),
     ResponseMod:api_error({auth_not_supported, AuthType}, RD, Ctx);
 post_authentication({error, notfound}, RD, Ctx, _, _) ->
-    %% This is rubbish. We need to differentiate between
-    %% no key_id being presented and the key_id lookup
-    %% failing in some better way.
-    _ = lager:debug("key_id not present or not found"),
-    riak_cs_wm_utils:deny_access(RD, Ctx);
-post_authentication({error, Reason}, RD, Ctx, _, _) ->
-    %% no matching keyid was found, or lookup failed
+    _ = lager:debug("User does not exist"),
+    riak_cs_wm_utils:deny_invalid_key(RD, Ctx);
+post_authentication({error, Reason}, RD,
+                    #context{response_module=ResponseMod} = Ctx, _, _) ->
+    %% Lookup failed, basically due to disconnected stuff
     _ = lager:debug("Authentication error: ~p", [Reason]),
-    riak_cs_wm_utils:deny_invalid_key(RD, Ctx).
+    ResponseMod:api_error(Reason, RD, Ctx).
 
 update_stats_inflow(_RD, undefined = _StatsPrefix) ->
     ok;

--- a/src/riak_cs_wm_common.erl
+++ b/src/riak_cs_wm_common.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_cs_wm_utils.erl
+++ b/src/riak_cs_wm_utils.erl
@@ -316,7 +316,7 @@ deny_access(RD, Ctx) ->
 
 
 
-%% @doc Prodice an invalid-access-keyid error message from a
+%% @doc Produce an invalid-access-keyid error message from a
 %% webmachine resource's `forbidden/2' function.
 deny_invalid_key(RD, Ctx=#context{response_module=ResponseMod}) ->
     ResponseMod:api_error(invalid_access_key_id, RD, Ctx).


### PR DESCRIPTION
This commit adds new response 500 from an atom 'disconnected', which
stems from Riak client error. The first call during request handling
is fetching user information of requester via access key ID. It fails
when Riak is unavailable by network partition or node being offline.
Riak CS was handling this as authentication error thus returned 403.

Regression tests are added in `regression_tests.erl` as a function,
stopping all Riak nodes and trying S3 API requests to CS.

Rebased #1277 to latest `2.1`
