### PR TITLE
Fixes issue 1288

### DIFF
--- a/riak_test/src/rtcs_dev.erl
+++ b/riak_test/src/rtcs_dev.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2013 Basho Technologies, Inc.
+%% Copyright (c) 2013-2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/riak_test/src/rtcs_dev.erl
+++ b/riak_test/src/rtcs_dev.erl
@@ -175,7 +175,7 @@ all_the_app_configs(DevPath) ->
     end.
 
 update_app_config(all, Config) ->
-    lager:info("rtdev:update_app_config(all, ~p)", [Config]),
+    lager:info("rtcs_dev:update_app_config(all, ~p)", [Config]),
     [ update_app_config(DevPath, Config) || DevPath <- devpaths()];
 update_app_config(Node, Config) when is_atom(Node) ->
     N = node_id(Node),
@@ -196,7 +196,7 @@ update_app_config(DevPath, Config) ->
     [update_app_config_file(AppConfig, Config) || AppConfig <- all_the_app_configs(DevPath)].
 
 update_app_config_file(ConfigFile, Config) ->
-    lager:info("rtdev:update_app_config_file(~s, ~p)", [ConfigFile, Config]),
+    lager:info("rtcs_dev:update_app_config_file(~s, ~p)", [ConfigFile, Config]),
 
     BaseConfig = case file:consult(ConfigFile) of
         {ok, [ValidConfig]} ->
@@ -466,7 +466,7 @@ check_node({_N, Version}) ->
     end.
 
 set_backend(Backend) ->
-    lager:info("rtdev:set_backend(~p)", [Backend]),
+    lager:info("rtcs_dev:set_backend(~p)", [Backend]),
     update_app_config(all, [{riak_kv, [{storage_backend, Backend}]}]),
     get_backends().
 

--- a/riak_test/tests/xml_response_test.erl
+++ b/riak_test/tests/xml_response_test.erl
@@ -24,8 +24,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
-
--include("deps/erlcloud/include/erlcloud_aws.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
 
 -define(test_bucket(Label), "test-bucket-" Label).
 -define(test_key(Label),    "test-key-" Label).
@@ -46,7 +45,7 @@ verify_multipart_upload_response() ->
     rtcs:set_conf({cs, current, 1}, [{root_host, Host}]),
     {AdminConfig, _} = rtcs:setup(1),
     % erlcloud requires that 's3_host' matches our 'root_host'
-    % TODO: read this from the conf file
+    % TODO: rtcs:setup should read this from the conf file
     Config = AdminConfig#aws_config{s3_host = Host},
 
     lager:info("creating bucket ~p", [Bucket]),
@@ -68,7 +67,7 @@ perform_multipart_upload(Bucket, Key, NumParts, PartSize, Config) ->
     lager:info("uploading parts of '~s/~s'", [Bucket, Key]),
     EtagList = upload_and_assert_parts(
         Bucket, Key, UploadId, NumParts, PartSize, Config),
-    lager:info("ETags of '~s/~s': ~p", [Bucket, Key, EtagList]),
+    % lager:info("ETags of '~s/~s': ~p", [Bucket, Key, EtagList]),
 
     lager:info("completing upload of '~s/~s'", [Bucket, Key]),
     complete_multipart_upload(Bucket, Key, UploadId, EtagList, Config).

--- a/riak_test/tests/xml_response_test.erl
+++ b/riak_test/tests/xml_response_test.erl
@@ -1,0 +1,183 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(xml_response_test).
+
+-export([confirm/0]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
+
+-define(test_bucket(Label), "test-bucket-" Label).
+-define(test_key(Label),    "test-key-" Label).
+-define(root_host_default,  "s3.amazonaws.com").
+-define(root_host_alt,      "foo.bar.example.com").
+
+confirm() ->
+    verify_multipart_upload_response().
+
+% TODO: get the default root host from the riak-cs.conf file?
+
+verify_multipart_upload_response() ->
+    {UserConfig, {_, [Node], _}} = rtcs:setup(1),
+    Bucket = ?test_bucket("vrhr"),
+    DefKey = ?test_key("vrhr-dflt"),
+    AltKey = ?test_key("vrhr-alt"),
+    NumParts = 3,
+    PartSize = (5 * 1024 * 1024),
+
+    lager:info("creating bucket ~p", [Bucket]),
+    ?assertEqual(ok, erlcloud_s3:create_bucket(Bucket, UserConfig)),
+
+    {ok, {_, DefRes}} = perform_multipart_upload(
+        Bucket, DefKey, NumParts, PartSize, UserConfig),
+    lager:info("Response Data of '~s/~s':\n~p\n", [Bucket, DefKey, DefRes]),
+
+    verify_multipart_upload_response(
+        DefRes, ?root_host_default, Bucket, DefKey),
+
+    rtcs_exec:stop_cs(1),
+    rt:wait_until_unpingable(Node),
+    rtcs:set_conf({cs, current, 1}, [{root_host, ?root_host_alt}]),
+    rtcs_exec:start_cs(1),
+    rt:wait_until_pingable(Node),
+
+    {ok, {_, AltRes}} = perform_multipart_upload(
+        Bucket, AltKey, NumParts, PartSize, UserConfig),
+    lager:info("Response Data of '~s/~s':\n~p\n", [Bucket, AltKey, AltRes]),
+
+    verify_multipart_upload_response(AltRes, ?root_host_alt, Bucket, AltKey),
+
+    rtcs:pass().
+
+perform_multipart_upload(Bucket, Key, NumParts, PartSize, Config) ->
+    lager:info("initiating multipart upload of '~s/~s'", [Bucket, Key]),
+    UploadId = erlcloud_s3_multipart:upload_id(
+        erlcloud_s3_multipart:initiate_upload(Bucket, Key, [], [], Config)),
+
+    lager:info("uploading parts of '~s/~s'", [Bucket, Key]),
+    EtagList = upload_and_assert_parts(
+        Bucket, Key, UploadId, NumParts, PartSize, Config),
+    lager:info("ETags of '~s/~s': ~p", [Bucket, Key, EtagList]),
+
+    lager:info("completing upload of '~s/~s'", [Bucket, Key]),
+    complete_multipart_upload(Bucket, Key, UploadId, EtagList, Config).
+
+verify_multipart_upload_response(ResponseBody, RootHost, Bucket, Key) ->
+    [#xmlText{value = ResBucket}] = get_response_value(
+        ResponseBody, 'CompleteMultipartUploadResult', 'Bucket'),
+    [#xmlText{value = ResKey}] = get_response_value(
+        ResponseBody, 'CompleteMultipartUploadResult', 'Key'),
+    [#xmlText{value = ResLocation}] = get_response_value(
+        ResponseBody, 'CompleteMultipartUploadResult', 'Location'),
+
+    ?assertEqual(ResBucket, Bucket),
+    ?assertEqual(ResKey, Key),
+    ?assertEqual(ResLocation, lists:flatten(
+        io_lib:format("http://~s.~s/~s", [Bucket, RootHost, Key]))).
+
+
+% verify_root_host_result(NodeId, User, Host) ->
+%     ?assertNotEqual(Host, get_response_value(User, Field)),
+%     reset_cs_root_host(NodeId, Host)
+%     ?assertEqual(Host, get_response_value(User, Field)),
+%
+% reset_cs_root_host(NodeId, Host) ->
+%     Node = rtcs:cs_node(NodeId),
+%     rtcs_exec:stop_cs(NodeId),
+%     rt:wait_until_unpingable(Node),
+%     rtcs:set_advanced_conf(Node, [{riak_cs, [{root_host, Host}]}]),
+%     rtcs_exec:start_cs(NodeId),
+%     rt:wait_until_pingable(Node),
+%     ok.
+
+get_response_value(
+        #xmlElement{name = TopLevel, content = Content}, TopLevel, Field) ->
+    get_response_value(Content, Field);
+get_response_value(ResponseBody, TopLevel, Field)
+        when erlang:is_tuple(ResponseBody)
+        andalso erlang:tuple_size(ResponseBody) > 0 ->
+    get_response_value(erlang:element(1, ResponseBody), TopLevel, Field).
+
+get_response_value([#xmlElement{name = Field, content = Value} | _], Field) ->
+    Value;
+get_response_value([_ | Content], Field) ->
+    get_response_value(Content, Field).
+
+%
+% Use erlcloud_s3:s3_request instead of erlcloud_s3_multipart:complete_upload
+% to be able to process the full result XML.
+%
+complete_multipart_upload(Bucket, Key, UploadId, EtagList, Config) ->
+    Response = erlcloud_s3:s3_request(
+        Config, post, Bucket,
+        [$/ | Key],                             % URL
+        [{"uploadId", UploadId}],               % sub-resources
+        [],                                     % params
+        etags_to_multipart_request(EtagList),   % POST data
+        []),                                    % headers
+    lager:info("Raw Response: ~p", [Response]),
+    case Response of
+        {_, []} ->
+            {ok, Response};
+        {Headers, BodyXML} ->
+            Body = xmerl_scan:string(BodyXML),
+            case erlang:element(1, Body) of
+                #xmlElement{name = 'Error'} ->
+                    {error, {msg, text, {Headers, Body}}};
+                _ ->
+                    {ok, {Headers, Body}}
+            end
+    end.
+
+etags_to_multipart_request(EtagList) ->
+    ReqData = [{'Part', [
+        {'PartNumber', [erlang:integer_to_list(N)]},
+        {'ETag', [T]}]} || {N, T} <- EtagList],
+    lager:info("Request Data: ~p", [ReqData]),
+    Request = {'CompleteMultipartUpload', ReqData},
+    erlang:list_to_binary(xmerl:export_simple([Request], xmerl_xml)).
+
+
+upload_and_assert_parts(Bucket, Key, UploadId, NumParts, PartSize, Config) ->
+    upload_and_assert_parts(
+        Bucket, Key, UploadId, NumParts, PartSize, Config, []).
+
+upload_and_assert_parts(_, _, _, 0, _, _, Result) ->
+    Result;
+upload_and_assert_parts(Bucket, Key, UploadId, PartNum, PartSize, Config, Result) ->
+    upload_and_assert_parts(
+        Bucket, Key, UploadId, (PartNum - 1), PartSize, Config,
+        [{PartNum, rtcs_multipart:upload_and_assert_part(
+            Bucket, Key, UploadId, PartNum,
+            generate_part_data(PartNum, PartSize), Config)} | Result]).
+
+%
+% assume PartNum is < 256 and PartSize is not negative
+%
+generate_part_data(PartNum, PartSize) ->
+    generate_part_data(PartNum, PartSize, <<>>).
+
+generate_part_data(_, 0, Result) ->
+    Result;
+generate_part_data(PartNum, Remain, Result) ->
+    generate_part_data(PartNum, (Remain - 1), <<Result/binary, PartNum>>).
+
+

--- a/src/riak_cs_config.erl
+++ b/src/riak_cs_config.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -66,7 +66,8 @@
          detailed_storage_calc/0,
          quota_modules/0,
          active_delete_threshold/0,
-         fast_user_get/0
+         fast_user_get/0,
+         root_host/0
         ]).
 
 %% Timeouts hitting Riak
@@ -427,6 +428,10 @@ active_delete_threshold() ->
 -spec fast_user_get() -> boolean().
 fast_user_get() ->
     get_env(riak_cs, fast_user_get, false).
+
+-spec root_host() -> string().
+root_host() ->
+    get_env(riak_cs, cs_root_host, ?ROOT_HOST).
 
 %% ===================================================================
 %% ALL Timeouts hitting Riak

--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -127,8 +127,7 @@ process_post(RD, Ctx=#context{local_context=LocalCtx, riak_client=RcPid}) ->
                     XmlDoc = {'CompleteMultipartUploadResult',
                               [{'xmlns', "http://s3.amazonaws.com/doc/2006-03-01/"}],
                               [
-                               %% TODO: use cs_root from app.config
-                               {'Location', [lists:append(["http://", binary_to_list(Bucket), ".s3.amazonaws.com/", Key])]},
+                               {'Location', [response_location(Bucket, Key)]},
                                {'Bucket', [Bucket]},
                                {'Key', [Key]},
                                {'ETag', [ETag]}
@@ -144,6 +143,10 @@ process_post(RD, Ctx=#context{local_context=LocalCtx, riak_client=RcPid}) ->
             end
     end.
 
+response_location(Bucket, Key) ->
+    lists:append(["http://",
+        binary:bin_to_list(Bucket), ".", riak_cs_config:root_host(), "/", Key]).
+    
 -spec valid_entity_length(#wm_reqdata{}, #context{}) -> {boolean(), #wm_reqdata{}, #context{}}.
 valid_entity_length(RD, Ctx) ->
     MaxLen = riak_cs_lfs_utils:max_content_len(),


### PR DESCRIPTION
This adds functionality to access the 'root_host' configuration parameter, and use that value in constructing replies containing a 'Location' element.

https://github.com/basho/riak_cs/issues/1288
RCS-318 (#1288)
