### PR TITLE
Return 400 Bad Request if multipart upload does not contain upload parts

### DIFF
--- a/src/riak_cs_wm_object_upload_part.erl
+++ b/src/riak_cs_wm_object_upload_part.erl
@@ -117,6 +117,11 @@ process_post(RD, Ctx=#context{local_context=LocalCtx, riak_client=RcPid}) ->
     case {parse_body(Body), catch base64url:decode(UploadId64)} of
         {bad, _} ->
             {{halt,477}, RD, Ctx};
+        %% RCS-156 (gh #1100) return a 400 Bad Request, Malformed XML error
+        %% when there is a multipart upload without any parts in the upload
+        %% complete message
+        {[], _UploadId} ->
+            riak_cs_s3_response:api_error(malformed_xml, RD, Ctx);
         {PartETags, UploadId} ->
             case riak_cs_mp_utils:complete_multipart_upload(
                    Bucket, list_to_binary(Key), UploadId, PartETags, User,


### PR DESCRIPTION
During a multipart upload, the "complete" message should contain a list of part ids and MD5 hashes. If it is empty, we should return a 400 Bad Request, Malformed XML message like S3.  The associated test for this test is [here](https://github.com/basho/s3-tests/blob/riakcs-2.1/s3tests/functional/test_s3.py#L4596-L4606). Addresses #1100
