### PR TITLE
Fix for issue 1025 [RCS-358]

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -99,7 +99,7 @@ setup_clusters(Configs, JoinFun, NumNodes, Vsn) ->
             _SSLOpts ->
                 rtcs_admin:create_user_rpc(hd(_CSNodes), "admin-key", "admin-secret")
         end,
-                
+
     {AdminConfig, Nodes}.
 
 ssl_options(Config) ->

--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -103,9 +103,15 @@ setup_clusters(Configs, JoinFun, NumNodes, Vsn) ->
     {AdminConfig, Nodes}.
 
 ssl_options(Config) ->
-    RiakCS = proplists:get_value(cs, Config),
-    CSConfig = proplists:get_value(riak_cs, RiakCS),
-    proplists:get_value(ssl, CSConfig, []).
+    case proplists:get_value(cs, Config) of
+        undefined -> [];
+        RiakCS ->
+           case proplists:get_value(riak_cs, RiakCS) of
+               undefined -> [];
+               CSConfig ->
+                   proplists:get_value(ssl, CSConfig, [])
+           end
+    end.
 
 pass() ->
     teardown(),

--- a/riak_test/src/rtcs_admin.erl
+++ b/riak_test/src/rtcs_admin.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2015 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/riak_test/src/rtcs_admin.erl
+++ b/riak_test/src/rtcs_admin.erl
@@ -24,6 +24,7 @@
          create_user/2,
          create_user/3,
          create_user/4,
+         create_user_rpc/3,
          create_admin_user/1,
          update_user/5,
          get_user/4,
@@ -49,6 +50,15 @@ storage_stats_json_request(AdminConfig, UserConfig, Begin, End) ->
     lager:debug("Storage samples[json]: ~p", [Samples]),
     {struct, Slice} = latest(Samples, undefined),
     by_bucket_list(Slice, []).
+
+%% Kludge for SSL testing
+create_user_rpc(Node, Key, Secret) ->
+    User = "admin",
+    Email = "admin@me.com",
+
+    %% You know this is a kludge, user creation via RPC
+    _Res = rpc:call(Node, riak_cs_user, create_user, [User, Email, Key, Secret]),
+    aws_config(Key, Secret, rtcs_config:cs_port(1)).
 
 -spec create_admin_user(atom()) -> #aws_config{}.
 create_admin_user(Node) ->

--- a/riak_test/src/rtcs_object.erl
+++ b/riak_test/src/rtcs_object.erl
@@ -35,39 +35,41 @@ upload(UserConfig, {normal_partial, CL, Actual}, B, K) when is_list(K),
                                                             CL >= Actual ->
     %% Dumbest handmade S3 PUT Client
     %% Send partial payload to the socket and suddenly close
-    Host = io_lib:format("~s.s3.amazonaws.com", [B]),
-    Date = httpd_util:rfc1123_date(erlang:localtime()),
+    Binary = binary:copy(<<"*">>, Actual),
+
     %% Fake checksum, this request should fail if all payloads were sent
     MD5 = "1B2M2Y8AsgTpgAmY7PhCfg==",
-    ToSign = ["PUT", $\n, MD5, $\n, "application/octet-stream", $\n,
-              Date, $\n, [], $/, B, $/, K, []],
-    lager:debug("String to Sign: ~s", [ToSign]),
-    Sig = base64:encode_to_string(crypto:hmac(
-                                    sha,
-                                    UserConfig#aws_config.secret_access_key,
-                                    ToSign)),
-    Auth = io_lib:format("Authorization: AWS ~s:~s",
-                         [UserConfig#aws_config.access_key_id, Sig]),
-    {ok, Sock} = gen_tcp:connect("127.0.0.1", 15018, [{active, false}]),
-    FirstLine = io_lib:format("PUT /~s HTTP/1.1", [K]),
-    Binary = binary:copy(<<"*">>, Actual),
-    ReqHdr = [FirstLine, $\n, "Host: ", Host, $\n, Auth, $\n,
-              "Content-Length: ", integer_to_list(CL), $\n,
-              "Content-Md5: ", MD5, $\n,
-              "Content-Type: application/octet-stream", $\n,
-              "Date: ", Date, $\n],
+    ReqHdr = base_header(B, K, CL, MD5, UserConfig, ""),
     lager:info("~s", [iolist_to_binary(ReqHdr)]),
+
+    %% Hard coded Host only for riak_test
+    {ok, Sock} = gen_tcp:connect("127.0.0.1", 15018, [{active, false}]),
     case gen_tcp:send(Sock, [ReqHdr, $\n, Binary]) of
         ok ->
             %% Let caller handle the socket call, either close or continue
             {ok, Sock};
         Error ->
             Error
-    end.
+    end;
+upload(UserConfig, {https, Size}, B, K) ->
+    Binary = binary:copy(<<"*">>, Size),
+    MD5 = base64:encode(crypto:hash(md5, Binary)),
+    ReqHdr = base_header(B, K, Size, MD5, UserConfig, ""),
+    send_ssl_request([ReqHdr, $\n, Binary]).
 
 upload(UserConfig, normal_copy, B, DstK, SrcK) ->
     ?assertEqual([{copy_source_version_id, "false"}, {version_id, "null"}],
                  erlcloud_s3:copy_object(B, DstK, B, SrcK, UserConfig));
+
+upload(UserConfig, https_copy, B, DstK, SrcK) ->
+    MD5 = "",
+    CL = 0,
+    CopyHdr = ["x-amz-copy-source:/", B, "/", SrcK, $\n,
+               "x-amz-metadata-directive:COPY", $\n],
+    ReqHdr = base_header(B, DstK, CL, MD5, UserConfig, CopyHdr),
+
+    send_ssl_request([ReqHdr, CopyHdr, $\n]);
+
 upload(UserConfig, multipart_copy, B, DstK, SrcK) ->
     InitUploadRes = erlcloud_s3_multipart:initiate_upload(B, DstK, "text/plain", [], UserConfig),
     UploadId = erlcloud_s3_multipart:upload_id(InitUploadRes),
@@ -82,6 +84,43 @@ upload(UserConfig, multipart_copy, B, DstK, SrcK) ->
     EtagList = [ {1, Etag1}, {2, Etag2} ],
     ?assertEqual(ok, erlcloud_s3_multipart:complete_upload(
                        B, DstK, UploadId, EtagList, UserConfig)).
+
+send_ssl_request(Payload) ->
+    {ok, Sock} = ssl:connect("127.0.0.1", 15018, [{active, false}, binary]),
+    lager:info("sending HTTPS request: ~s", [Payload]),
+    ok = ssl:send(Sock, Payload),
+    {ok, Data} = ssl:recv(Sock, 0),
+    lager:debug("SSL recv: ~p", [Data]),
+    {ok, Packet, Rest} = erlang:decode_packet(http, Data, []),
+    lager:debug("~p / ~p", [Packet, Rest]),
+    ?assertEqual({http_response, {1, 1}, 200, "OK"}, Packet),
+    ssl:close(Sock),
+    ok.
+
+base_header(B, K, CL, MD5, UserConfig, MetaTags) ->
+    Host = io_lib:format("~s.s3.amazonaws.com", [B]),
+    Date = httpd_util:rfc1123_date(erlang:localtime()),
+    ToSign = ["PUT", $\n,
+              case CL of 0 -> ""; _ -> MD5 end, $\n,
+              "application/octet-stream", $\n,
+              Date, $\n, MetaTags, $/, B, $/, K, []],
+    lager:debug("String to Sign: ~s", [ToSign]),
+    Sig = base64:encode_to_string(crypto:hmac(
+                                    sha,
+                                    UserConfig#aws_config.secret_access_key,
+                                    ToSign)),
+    Auth = io_lib:format("Authorization: AWS ~s:~s",
+                         [UserConfig#aws_config.access_key_id, Sig]),
+    FirstLine = io_lib:format("PUT /~s HTTP/1.1", [K]),
+    [FirstLine, $\n, "Host: ", Host, $\n, Auth, $\n,
+     "Content-Length: ", integer_to_list(CL), $\n,
+     case CL of
+         0 -> "";
+         _ -> ["Content-Md5: ", MD5, $\n]
+     end,
+     "Content-Type: application/octet-stream", $\n,
+     "Date: ", Date, $\n].
+
 
 mb(MegaBytes) ->
     MegaBytes * 1024 * 1024.

--- a/riak_test/tests/https_tests.erl
+++ b/riak_test/tests/https_tests.erl
@@ -1,3 +1,23 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(https_tests).
 
 -export([confirm/0]).
@@ -6,6 +26,7 @@ confirm() ->
     {ok, _} = application:ensure_all_started(ssl),
     CSConfig = [{ssl, [{certfile, "./etc/cert.pem"}, {keyfile, "./etc/key.pem"}]}],
     {UserConfig, _} = rtcs:setup(1, [{cs, [{riak_cs, CSConfig}]}]),
+    % lager:info("UserConfig: ~p", [UserConfig]),
     ok = verify_cs1025(UserConfig),
     rtcs:pass().
 

--- a/riak_test/tests/https_tests.erl
+++ b/riak_test/tests/https_tests.erl
@@ -1,0 +1,21 @@
+-module(https_tests).
+
+-export([confirm/0]).
+
+confirm() ->
+    {ok, _} = application:ensure_all_started(ssl),
+    CSConfig = [{ssl, [{certfile, "./etc/cert.pem"}, {keyfile, "./etc/key.pem"}]}],
+    {UserConfig, _} = rtcs:setup(1, [{cs, [{riak_cs, CSConfig}]}]),
+    ok = verify_cs1025(UserConfig),
+    rtcs:pass().
+
+verify_cs1025(UserConfig) ->
+    B = <<"booper">>,
+    K = <<"drooper">>,
+    K2 = <<"super">>,
+    lager:debug("here0"),
+    rtcs_object:upload(UserConfig, {https, 0}, B, <<>>),
+    lager:debug("here"),
+    rtcs_object:upload(UserConfig, {https, 42}, B, K),
+    lager:debug("here2"),
+    rtcs_object:upload(UserConfig, https_copy, B, K2, K).

--- a/riak_test/tests/https_tests.erl
+++ b/riak_test/tests/https_tests.erl
@@ -13,9 +13,9 @@ verify_cs1025(UserConfig) ->
     B = <<"booper">>,
     K = <<"drooper">>,
     K2 = <<"super">>,
-    lager:debug("here0"),
+    lager:info("Creating a bucket ~s", [B]),
     rtcs_object:upload(UserConfig, {https, 0}, B, <<>>),
-    lager:debug("here"),
+    lager:info("Creating a source object to copy, ~s", [K]),
     rtcs_object:upload(UserConfig, {https, 42}, B, K),
-    lager:debug("here2"),
+    lager:info("Trying copy from ~s to ~s", [K, K2]),
     rtcs_object:upload(UserConfig, https_copy, B, K2, K).

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -1,6 +1,6 @@
 %% ---------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2014 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/riak_cs_copy_object.erl
+++ b/src/riak_cs_copy_object.erl
@@ -332,16 +332,17 @@ copy_range(RD, ?MANIFEST{content_length=Len}) ->
     end.
 
 
-%% @doc  nasty  hack,  do  not  use this  other  than  for  disconnect
+%% @doc nasty hack, do not use this other than for disconnect
 %% detection in copying objects.
--spec connection_checker(inet:socket()) -> fun(() -> boolean()).
+-type mochiweb_socket() :: inet:socket() | {ssl, ssl:sslsocket()}.
+-spec connection_checker(mochiweb_socket()) -> fun(() -> boolean()).
 connection_checker(Socket) ->
     fun() ->
-            case inet:peername(Socket) of
+            case mochiweb_socket:peername(Socket) of
                 {error,_E} ->
                     false;
                 {ok,_} ->
-                    case gen_tcp:recv(Socket, 0, 0) of
+                    case mochiweb_socket:recv(Socket, 0, 0) of
                         {error, timeout} ->
                             true;
                         {error, _E} ->


### PR DESCRIPTION
This merges branches bugfix/cs1025 with current 2.1 (for full-suite testing) and replaces the hard-coded host/port destinations for the ssl object copy test with values from the configuration.

It's smaller to merge back to 2.1 than back to bugfix/cs1025, so it supersedes https://github.com/basho/riak_cs/pull/1300
