### PR TITLE
Bump node_package to 3.0.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.0"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.4"}}},
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.5"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "3.0.0"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.1"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
         {lager, ".*", {git, "git://github.com/basho/lager", {tag, "2.2.0"}}},
         {lager_syslog, ".*", {git, "git://github.com/basho/lager_syslog", {tag, "2.1.1"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.4"}}},
-        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.3"}}},
+        {node_package, ".*", {git, "git://github.com/basho/node_package", {tag, "2.0.5"}}},
         {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
         {webmachine, ".*", {git, "git://github.com/basho/webmachine", {tag, "1.10.8"}}},
         {riakc, ".*", {git, "git://github.com/basho/riak-erlang-client", {tag, "2.1.1"}}},


### PR DESCRIPTION
This PR incorporates the updates to node_package that are going into the new riak releases. See also basho/stanchion#109 JIRA RCS-357 basho/node_package#196 basho/node_package#200
