### PR TITLE
skip repl_v3_test if not using an ee configuration for riak_test

### DIFF
--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -1,11 +1,41 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(repl_v3_test).
 
 -export([confirm/0]).
+
 -include_lib("eunit/include/eunit.hrl").
 
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
+    case rt_config:get(build_type, oss) of
+        ee ->
+            confirm_ee();
+        _ ->
+            lager:info("~s test is only valid on riak_ee, skipping", [?MODULE]),
+            pass
+    end.
+
+confirm_ee() ->
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup2x2(),
     lager:info("UserConfig = ~p", [UserConfig]),
     [A,B,C,D] = RiakNodes,


### PR DESCRIPTION
if the build_type from the configuration is not 'ee' the test immediately returns 'pass'
