### PR TITLE
Stop access_stats_test from being flappy

### DIFF
--- a/riak_test/src/rtcs.erl
+++ b/riak_test/src/rtcs.erl
@@ -1,6 +1,6 @@
-%% ---------------------------------------------------------------------
+%% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -16,9 +16,12 @@
 %% specific language governing permissions and limitations
 %% under the License.
 %%
-%% ---------------------------------------------------------------------
+%% -------------------------------------------------------------------
+
 -module(rtcs).
+
 -compile(export_all).
+
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 -include_lib("xmerl/include/xmerl.hrl").
@@ -312,10 +315,11 @@ sha(Bin) -> crypto:hash(sha, Bin).
 md5(Bin) -> crypto:hash(md5, Bin).
 
 datetime() ->
-    {{YYYY,MM,DD}, {H,M,S}} = calendar:universal_time(),
-    lists:flatten(io_lib:format("~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [YYYY, MM, DD, H, M, S])).
+    datetime(calendar:universal_time()).
 
-
+datetime({{YYYY,MM,DD}, {H,M,S}}) ->
+    lists:flatten(io_lib:format(
+        "~4..0B~2..0B~2..0BT~2..0B~2..0B~2..0BZ", [YYYY, MM, DD, H, M, S])).
 
 json_get(Key, Json) when is_binary(Key) ->
     json_get([Key], Json);

--- a/riak_test/tests/repl_v3_test.erl
+++ b/riak_test/tests/repl_v3_test.erl
@@ -1,11 +1,41 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2013-2016 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
 -module(repl_v3_test).
 
 -export([confirm/0]).
+
 -include_lib("eunit/include/eunit.hrl").
 
 -define(TEST_BUCKET, "riak-test-bucket").
 
 confirm() ->
+    case rt_config:get(build_type, oss) of
+        ee ->
+            confirm_ee();
+        _ ->
+            lager:info("~s test is only valid on riak_ee, skipping", [?MODULE]),
+            pass
+    end.
+
+confirm_ee() ->
     {UserConfig, {RiakNodes, _CSNodes, _Stanchion}} = rtcs:setup2x2(),
     lager:info("UserConfig = ~p", [UserConfig]),
     [A,B,C,D] = RiakNodes,


### PR DESCRIPTION
Previously, access_stats_test performed all of its operations very quickly, so it would intermittently request stats with the same begin and end time and get an empty result set back from CS.

Whether CS should return an empty result set in such a case is a different question, depending on whether a time specification represents an instant or an interval, but in either case that's not what this test is for.  Instead, it now simply spends enough time to make sure the begin and end times are different.

This PR inadvertently includes the changes in https://github.com/basho/riak_cs/pull/1308 so that PR should be merged before this one so they each reflect the appropriate change set.
