### PR TITLE
Don't discard query string for usage queries

### DIFF
--- a/src/riak_cs_s3_rewrite.erl
+++ b/src/riak_cs_s3_rewrite.erl
@@ -110,10 +110,11 @@ rewrite_path(_Method, "/", _QS, undefined) ->
 rewrite_path(Method, Path, QS, undefined) ->
     {Bucket, UpdPath} = separate_bucket_from_path(Path),
     rewrite_path(Method, UpdPath, QS, mochiweb_util:unquote(Bucket));
+rewrite_path(_Method, Path = [47,117,115,97,103,101|_], QS=[_|_], "riak-cs") ->
+    %% [47,117,115,97,103,101] == "/usage"
+    "/riak-cs" ++ Path ++ "?" ++ QS;
 rewrite_path(_Method, Path, _QS, "riak-cs") ->
     "/riak-cs" ++ Path;
-rewrite_path(_Method, Path, _QS, "usage") ->
-    "/usage" ++ Path;
 rewrite_path(Method, "/", [], Bucket) when Method =/= 'GET' ->
     lists:flatten(["/buckets/", Bucket]);
 rewrite_path(Method, "/", QS, Bucket) ->


### PR DESCRIPTION
The riak_cs_wm_usage module expects parameters to be passed via query string.  Using s3curl a request would be made as such:

```
s3curl.pl --id admin -- -s -x localhost:8080 -v "http://s3.amazonaws.com/riak-cs/usage/T0FMWBBK6-P-LJFYHWBG?b&s=20160505T1200&e=20160505T180000Z"
```

Currently riak_cs_s3_rewrite:rewrite_path/4 discards the query string for all URIs starting with "/riak-cs", so no results are returned.  This PR would include the query string when the URI is "/riak-cs/usage"
